### PR TITLE
Add slack messaging to status reporter

### DIFF
--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -220,10 +220,15 @@ def pipeline_click_options(function: Callable) -> Callable:
             'If not provided, a temp folder will be created',
         ),
         click.option(
+            '--slack-channel',
+            'slack_channel',
+            help='Slack channel to send status reports with CPG status reporter.',
+        ),
+        click.option(
             '--skip-samples-stages',
             'skip_samples_stages',
             type=dict,
-            help='Map of stages to lists of samples, to skip for specific stages.',
+            help='Maps stage IDs to lists of samples, to skip for specific stages.',
         ),
     ]
 

--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -225,6 +225,13 @@ def pipeline_click_options(function: Callable) -> Callable:
             help='Slack channel to send status reports with CPG status reporter.',
         ),
         click.option(
+            '--smdb-errors-are-fatal/--no-smdb-errors-are-fatal',
+            'smdb_errors_are_fatal',
+            default=True,
+            help='When the sample-metadata database API returns an error from the '
+                 'database, only show the error and continue, instead of crashing',
+        ),
+        click.option(
             '--skip-samples-stages',
             'skip_samples_stages',
             type=dict,

--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -225,13 +225,6 @@ def pipeline_click_options(function: Callable) -> Callable:
             help='Slack channel to send status reports with CPG status reporter.',
         ),
         click.option(
-            '--smdb-errors-are-fatal/--no-smdb-errors-are-fatal',
-            'smdb_errors_are_fatal',
-            default=True,
-            help='When the sample-metadata database API returns an error from the '
-                 'database, only show the error and continue, instead of crashing',
-        ),
-        click.option(
             '--skip-samples-stages',
             'skip_samples_stages',
             type=dict,

--- a/cpg_pipes/pipeline/create_pipeline.py
+++ b/cpg_pipes/pipeline/create_pipeline.py
@@ -69,6 +69,7 @@ def create_pipeline(
     local_dir: Path | None = None,
     skip_samples_stages: dict[str, list[str]] | None = None,
     slack_channel: str | None = None,
+    crash_on_db_errors: bool = True,
 ) -> 'Pipeline':
     """
     Create a Pipeline instance. All options correspond to command line parameters
@@ -87,7 +88,7 @@ def create_pipeline(
         if status_reporter_type == StatusReporterType.CPG:
             status_reporter = CpgStatusReporter(smdb, slack_channel=slack_channel)
         if input_provider_type == InputProviderType.SMDB:
-            input_provider = SmdbInputProvider(smdb)
+            input_provider = SmdbInputProvider(smdb, crash_on_erorrs=crash_on_db_errors)
 
     if input_provider_type == InputProviderType.CSV:
         if not input_csv:

--- a/cpg_pipes/pipeline/create_pipeline.py
+++ b/cpg_pipes/pipeline/create_pipeline.py
@@ -68,6 +68,7 @@ def create_pipeline(
     force_samples: list[str] | None = None,
     local_dir: Path | None = None,
     skip_samples_stages: dict[str, list[str]] | None = None,
+    slack_channel: str | None = None,
 ) -> 'Pipeline':
     """
     Create a Pipeline instance. All options correspond to command line parameters
@@ -84,7 +85,7 @@ def create_pipeline(
         sm_proj = Dataset(analysis_dataset, namespace=namespace).stack
         smdb = SMDB(sm_proj)
         if status_reporter_type == StatusReporterType.CPG:
-            status_reporter = CpgStatusReporter(smdb)
+            status_reporter = CpgStatusReporter(smdb, slack_channel=slack_channel)
         if input_provider_type == InputProviderType.SMDB:
             input_provider = SmdbInputProvider(smdb)
 

--- a/cpg_pipes/pipeline/create_pipeline.py
+++ b/cpg_pipes/pipeline/create_pipeline.py
@@ -69,7 +69,6 @@ def create_pipeline(
     local_dir: Path | None = None,
     skip_samples_stages: dict[str, list[str]] | None = None,
     slack_channel: str | None = None,
-    crash_on_db_errors: bool = True,
 ) -> 'Pipeline':
     """
     Create a Pipeline instance. All options correspond to command line parameters
@@ -88,7 +87,7 @@ def create_pipeline(
         if status_reporter_type == StatusReporterType.CPG:
             status_reporter = CpgStatusReporter(smdb, slack_channel=slack_channel)
         if input_provider_type == InputProviderType.SMDB:
-            input_provider = SmdbInputProvider(smdb, crash_on_erorrs=crash_on_db_errors)
+            input_provider = SmdbInputProvider(smdb)
 
     if input_provider_type == InputProviderType.CSV:
         if not input_csv:

--- a/cpg_pipes/providers/cpg/inputs.py
+++ b/cpg_pipes/providers/cpg/inputs.py
@@ -3,9 +3,6 @@ InputProvider implementation that pulls data from the sample-metadata database.
 """
 
 import logging
-import traceback
-
-from sample_metadata import ApiException
 
 from .smdb import SMDB, SmSequence
 from ..inputs import InputProvider, InputProviderError
@@ -21,15 +18,9 @@ class SmdbInputProvider(InputProvider):
     InputProvider implementation that pulls data from the sample-metadata database.
     """
 
-    def __init__(
-        self, 
-        db: SMDB, 
-        check_files: bool = False, 
-        crash_on_erorrs: bool = True,
-    ):
+    def __init__(self, db: SMDB, check_files: bool = False):
         super().__init__(check_files=check_files)
         self.db = db
-        self.crash_on_erorrs = crash_on_erorrs
 
     def populate_cohort(
         self,
@@ -120,40 +111,15 @@ class SmdbInputProvider(InputProvider):
         """
         Populate sequencing inputs for samples.
         """
-        assert cohort.get_sample_ids()
-        try:
-            seq_infos: list[dict] = self.db.seqapi.get_sequences_by_sample_ids(
-                cohort.get_sample_ids()
-            )
-        except ApiException:
-            if self.crash_on_erorrs:
-                raise
-            else:
-                logger.error(
-                    'Getting sequencing data from SMDB resulted in an error. '
-                    'Continuing without sequencing data because of flag override. '
-                    'However, here is the error: '
-                )
-                traceback.print_exc()
-                seq_infos = []
+        seq_infos: list[dict] = self.db.seqapi.get_sequences_by_sample_ids(
+            cohort.get_sample_ids()
+        )
         seq_by_sid = {seq['sample_id']: seq for seq in seq_infos}
-        seq_info_by_sid = {
-            sample.id: seq_by_sid.get(sample.id) for sample in cohort.get_samples()
-        }
-        sids_with_missing_seq = [k for k, v in seq_info_by_sid.items() if v is None]
-        if sids_with_missing_seq:
-            msg = f'No sequencing data for samples: {", ".join(sids_with_missing_seq)}'
-            if self.crash_on_erorrs:
-                raise InputProviderError(msg)
-            else:
-                logger.warning(
-                    f'{msg}. Continuing without sequencing data because lenient=true'
-                )
         for sample in cohort.get_samples():
-            if seq_info := seq_by_sid.get(sample.id):
-                seq = SmSequence.parse(seq_info, self.check_files)
-                sample.alignment_input = seq.alignment_input
-                sample.sequencing_type = seq.sequencing_type
+            seq_info = seq_by_sid[sample.id]
+            seq = SmSequence.parse(seq_info, self.check_files)
+            sample.alignment_input = seq.alignment_input
+            sample.sequencing_type = seq.sequencing_type
 
     def populate_analysis(self, cohort: Cohort) -> None:
         """

--- a/cpg_pipes/providers/cpg/inputs.py
+++ b/cpg_pipes/providers/cpg/inputs.py
@@ -3,6 +3,9 @@ InputProvider implementation that pulls data from the sample-metadata database.
 """
 
 import logging
+import traceback
+
+from sample_metadata import ApiException
 
 from .smdb import SMDB, SmSequence
 from ..inputs import InputProvider, InputProviderError
@@ -18,9 +21,15 @@ class SmdbInputProvider(InputProvider):
     InputProvider implementation that pulls data from the sample-metadata database.
     """
 
-    def __init__(self, db: SMDB, check_files: bool = False):
+    def __init__(
+        self, 
+        db: SMDB, 
+        check_files: bool = False, 
+        crash_on_erorrs: bool = True,
+    ):
         super().__init__(check_files=check_files)
         self.db = db
+        self.crash_on_erorrs = crash_on_erorrs
 
     def populate_cohort(
         self,
@@ -111,15 +120,40 @@ class SmdbInputProvider(InputProvider):
         """
         Populate sequencing inputs for samples.
         """
-        seq_infos: list[dict] = self.db.seqapi.get_sequences_by_sample_ids(
-            cohort.get_sample_ids()
-        )
+        assert cohort.get_sample_ids()
+        try:
+            seq_infos: list[dict] = self.db.seqapi.get_sequences_by_sample_ids(
+                cohort.get_sample_ids()
+            )
+        except ApiException:
+            if self.crash_on_erorrs:
+                raise
+            else:
+                logger.error(
+                    'Getting sequencing data from SMDB resulted in an error. '
+                    'Continuing without sequencing data because of flag override. '
+                    'However, here is the error: '
+                )
+                traceback.print_exc()
+                seq_infos = []
         seq_by_sid = {seq['sample_id']: seq for seq in seq_infos}
+        seq_info_by_sid = {
+            sample.id: seq_by_sid.get(sample.id) for sample in cohort.get_samples()
+        }
+        sids_with_missing_seq = [k for k, v in seq_info_by_sid.items() if v is None]
+        if sids_with_missing_seq:
+            msg = f'No sequencing data for samples: {", ".join(sids_with_missing_seq)}'
+            if self.crash_on_erorrs:
+                raise InputProviderError(msg)
+            else:
+                logger.warning(
+                    f'{msg}. Continuing without sequencing data because lenient=true'
+                )
         for sample in cohort.get_samples():
-            seq_info = seq_by_sid[sample.id]
-            seq = SmSequence.parse(seq_info, self.check_files)
-            sample.alignment_input = seq.alignment_input
-            sample.sequencing_type = seq.sequencing_type
+            if seq_info := seq_by_sid.get(sample.id):
+                seq = SmSequence.parse(seq_info, self.check_files)
+                sample.alignment_input = seq.alignment_input
+                sample.sequencing_type = seq.sequencing_type
 
     def populate_analysis(self, cohort: Cohort) -> None:
         """

--- a/cpg_pipes/providers/status.py
+++ b/cpg_pipes/providers/status.py
@@ -46,6 +46,10 @@ class StatusReporter(ABC):
     Status reporter
     """
 
+    def __init__(self):
+        self.slack_channel = None
+        self.slack_token = None
+
     @abstractmethod
     def add_updaters_jobs(
         self,
@@ -58,4 +62,40 @@ class StatusReporter(ABC):
     ):
         """
         Add Hail Batch jobs that update the analysis status.
+        """
+
+    def slack_env(self, j: Job):
+        """
+        Add environment variables that configure Slack reporter.
+        """
+        if self.slack_channel and self.slack_token:
+            j.env('SLACK_CHANNEL', self.slack_channel)
+            j.env('SLACK_TOKEN', self.slack_token)
+
+    def slack_message_cmd(
+        self,
+        text: str | None = None,
+        data: dict[str, str] | None = None,
+    ) -> str:
+        """
+        Add command to the job that sends Slack message.
+        Message can be a dictionary (`data`), which will be correspondingly formatted;
+        or text (`text`). Either can use Slack mrkdwn for formatting:
+        https://api.slack.com/reference/surfaces/formatting
+        """
+        if not self.slack_channel or not self.slack_token:
+            return ''
+        msg = ''
+        if data:
+            msg += '\\n'.join(f'{k}: {v}' for k, v in data.items())
+        if text:
+            msg += f'\\n{text}'
+        if not msg:
+            return ''
+        return f"""
+        curl -X POST \
+        -H "Authorization: Bearer $SLACK_TOKEN" \
+        -H "Content-type: application/json" \
+        -d '{{"channel": "'$SLACK_CHANNEL'", "text": "{msg}"}}' \
+        https://slack.com/api/chat.postMessage
         """

--- a/cpg_pipes/providers/status.py
+++ b/cpg_pipes/providers/status.py
@@ -78,10 +78,10 @@ class StatusReporter(ABC):
         data: dict[str, str] | None = None,
     ) -> str:
         """
-        Add command to the job that sends Slack message.
-        Message can be a dictionary (`data`), which will be correspondingly formatted;
-        or text (`text`). Either can use Slack mrkdwn for formatting:
-        https://api.slack.com/reference/surfaces/formatting
+        Make a bash command that prepares and sends a Slack message.
+        Message can be constructed from a dict `data`, or can be passed directly 
+        as text (`text`). In either case, strings can use Slack `mrkdwn` 
+        for formatting: https://api.slack.com/reference/surfaces/formatting
         """
         if not self.slack_channel or not self.slack_token:
             return ''


### PR DESCRIPTION
Activated through `--slack-channel=` or `CPG_SLACK_CHANNEL`. Token is provided through `CPG_SLACK_TOKEN`, or `slack-seqr-loader-token` secret in `cpg-common`.

Example of usage to send a link to an analysis HTML report for a dataset:

```python
status_reporter.slack_env(job)
text = f'*[{dataset.name}]* <{html_url}|analysis report>'
job.command(dedent(status_reporter.slack_message_cmd(text=text)))
```