### PR TITLE
Use cpg-utils for CPG storage provider

### DIFF
--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -12,7 +12,7 @@ from ..providers import (
     StatusReporterType,
     InputProviderType,
 )
-from ..providers.storage import Namespace, Cloud
+from ..providers.storage import Namespace
 
 
 def choice_from_enum(cls: Type[Enum]) -> click.Choice:
@@ -141,14 +141,6 @@ def pipeline_click_options(function: Callable) -> Callable:
             'and output files',
         ),
         click.option(
-            '--cloud',
-            'cloud',
-            type=choice_from_enum(Cloud),
-            callback=val_to_enum(Cloud),
-            default=Cloud.GS.value,
-            help='Cloud storage provider',
-        ),
-        click.option(
             '--status-reporter',
             'status_reporter_type',
             type=choice_from_enum(StatusReporterType),
@@ -200,7 +192,7 @@ def pipeline_click_options(function: Callable) -> Callable:
             'check_inputs',
             default=False,
             is_flag=True,
-            help='Chech input file existence (e.g. FASTQ files). If they are missing '
+            help='Check input file existence (e.g. FASTQ files). If they are missing '
             'the --skip-samples-with-missing-input option controls whether such '
             'should be ignored, or raise an error.',
         ),
@@ -230,7 +222,7 @@ def pipeline_click_options(function: Callable) -> Callable:
             '--skip-samples-stages',
             'skip_samples_stages',
             type=dict,
-            help='Maps stage IDs to lists of samples, to skip for specific stages.',
+            help='Map of stages to lists of samples, to skip for specific stages.',
         ),
     ]
 

--- a/cpg_pipes/pipeline/create_pipeline.py
+++ b/cpg_pipes/pipeline/create_pipeline.py
@@ -58,6 +58,8 @@ def create_pipeline(
     Create a Pipeline instance. All options correspond to command line parameters
     described in `pipeline_click_options` in the `cli_opts` module
     """
+    refs = CpgRefData()
+
     if storage_policy_type == StoragePolicyType.CPG:
         storage_provider = CpgStorageProvider()
     else:
@@ -91,6 +93,7 @@ def create_pipeline(
         description=description,
         analysis_dataset_name=analysis_dataset,
         storage_provider=storage_provider,
+        refs=refs,
         status_reporter=status_reporter,
         input_provider=input_provider,
         datasets=datasets,

--- a/cpg_pipes/pipeline/create_pipeline.py
+++ b/cpg_pipes/pipeline/create_pipeline.py
@@ -13,12 +13,10 @@ from ..providers import (
     StatusReporterType,
     InputProviderType,
 )
-from ..providers.storage import Namespace, Cloud
-from ..providers.cpg import (
-    CpgStorageProvider,
-    CpgStatusReporter,
-    SmdbInputProvider,
-)
+from ..providers.storage import Namespace
+from ..providers.cpg.inputs import SmdbInputProvider
+from ..providers.cpg.storage import CpgStorageProvider
+from ..providers.cpg.status import CpgStatusReporter
 from ..providers.cpg.smdb import SMDB
 from ..providers.inputs import InputProvider, CsvInputProvider
 from ..providers.status import StatusReporter
@@ -27,26 +25,12 @@ from ..targets import Dataset
 logger = logging.getLogger(__file__)
 
 
-def init_storage_provider(
-    storage_policy_type: StoragePolicyType = None,
-    cloud: Cloud = Cloud.GS,
-):
-    """
-    Create storage provider based on enum options
-    """
-    if storage_policy_type == StoragePolicyType.CPG:
-        return CpgStorageProvider(cloud)
-    else:
-        raise PipelineError(f'Unsupported storage policy {storage_policy_type}')
-
-
 def create_pipeline(
     analysis_dataset: str,
     name: str,
     namespace: Namespace,
     description: str | None = None,
     storage_policy_type: StoragePolicyType = StoragePolicyType.CPG,
-    cloud: Cloud = Cloud.GS,
     status_reporter_type: StatusReporterType = None,
     input_provider_type: InputProviderType = InputProviderType.SMDB,
     input_csv: str | None = None,
@@ -74,7 +58,10 @@ def create_pipeline(
     Create a Pipeline instance. All options correspond to command line parameters
     described in `pipeline_click_options` in the `cli_opts` module
     """
-    storage_provider = init_storage_provider(storage_policy_type, cloud)
+    if storage_policy_type == StoragePolicyType.CPG:
+        storage_provider = CpgStorageProvider()
+    else:
+        raise PipelineError(f'Unsupported storage policy {storage_policy_type}')
 
     status_reporter: StatusReporter | None = None
     input_provider: InputProvider | None = None
@@ -82,7 +69,7 @@ def create_pipeline(
         input_provider_type == InputProviderType.SMDB
         or status_reporter_type == StatusReporterType.CPG
     ):
-        sm_proj = Dataset(analysis_dataset, namespace=namespace).stack
+        sm_proj = Dataset(analysis_dataset, namespace=namespace).name
         smdb = SMDB(sm_proj)
         if status_reporter_type == StatusReporterType.CPG:
             status_reporter = CpgStatusReporter(smdb)

--- a/cpg_pipes/pipeline/pipeline.py
+++ b/cpg_pipes/pipeline/pipeline.py
@@ -32,7 +32,7 @@ from ..providers.inputs import InputProvider
 from ..providers.storage import StorageProvider
 from ..targets import Target, Dataset, Sample, Cohort
 from ..providers.status import StatusReporter
-from ..refdata import RefData
+from ..providers.refdata import RefData
 from ..utils import exists
 
 logger = logging.getLogger(__file__)
@@ -772,6 +772,7 @@ class Pipeline:
         name: str,
         analysis_dataset_name: str,
         storage_provider: StorageProvider,
+        refs: RefData,
         description: str | None = None,
         stages: list[StageDecorator] | None = None,
         input_provider: InputProvider | None = None,
@@ -809,17 +810,18 @@ class Pipeline:
                 only_samples=only_samples,
                 skip_datasets=skip_datasets,
             )
+        self.refs = refs
+
         self.force_samples = force_samples
 
         self.name = name
         self.version = version or time.strftime('%Y%m%d-%H%M%S')
         self.namespace = namespace
-        self.refs = RefData(self.storage_provider.get_ref_base())
         self.hail_billing_project = get_billing_project(
             self.cohort.analysis_dataset.stack
         )
         self.tmp_bucket = to_path(
-            self.cohort.analysis_dataset.get_tmp_bucket(
+            self.cohort.analysis_dataset.storage_tmp_path(
                 version=(name + (f'/{version}' if version else ''))
             )
         )

--- a/cpg_pipes/providers/storage.py
+++ b/cpg_pipes/providers/storage.py
@@ -1,7 +1,6 @@
 """
 Abstract storage provider.
 """
-import os
 import pathlib
 from enum import Enum
 from abc import ABC, abstractmethod
@@ -28,86 +27,36 @@ class Namespace(Enum):
     TEST = 'test'
 
 
-class Cloud(Enum):
-    """
-    Cloud storage provider and corresponding protocol prefix.
-    """
-
-    GS = 'gs'
-
-
 class StorageProvider(ABC):
     """
     Abstract class for implementing storage path policy.
-    Onty get_base() method is required, however other methods are available to 
+    Onty path() method is required, however other methods are available to 
     override as well.
     """
 
-    def __init__(
-        self, 
-        cloud: Cloud, 
-    ):
-        self.cloud = cloud
+    def __init__(self):
+        pass
 
     @abstractmethod
-    def get_base(
+    def path(
         self,
         dataset: str,
         namespace: Namespace,
-        suffix: str | None = None,
+        category: str | None = None,
         version: str | None = None,
         sample: str = None,
     ) -> Path:
         """
-        Base path for primary results.
-        @param dataset: dataset/stack name
+        Path prefix for primary results.
+        @param dataset: dataset name
         @param namespace: namespace (test or main)
-        @param suffix: (optional) suffix to append to the bucket name
+        @param category: (optional) category to append to the bucket name
         @param version: (optional) pipeline version
         @param sample: (optional) sample name
         """
 
-    def get_tmp_base(
-        self,
-        dataset: str,
-        namespace: Namespace,
-        version: str | None = None,
-        sample: str = None,
-    ) -> Path:
-        """
-        Base path for temporary files.
-        """
-        return self.get_base(
-            dataset=dataset,
-            namespace=namespace,
-            version=version,
-            sample=sample,
-            suffix='tmp',
-        )
-
-    def get_web_base(
-        self,
-        dataset: str,
-        namespace: Namespace,
-        version: str | None = None,
-        sample: str = None,
-    ) -> Path:
-        """
-        Path base corresponding to the HTTP server. Used to expose files in web:
-        `get_web_url()` with same parameters should return a HTTP URL matching this 
-        object. Inspired by the CPG storage policy: 
-        https://github.com/populationgenomics/team-docs/blob/main/storage_policies/README.md#web-gscpg-dataset-maintest-web
-        """
-        return self.get_base(
-            dataset=dataset,
-            namespace=namespace,
-            version=version,
-            sample=sample,
-            suffix='web',
-        )
-
     @abstractmethod
-    def get_web_url(
+    def web_url(
         self,
         dataset: str,
         namespace: Namespace,
@@ -115,11 +64,6 @@ class StorageProvider(ABC):
         sample: str = None,
     ) -> str | None:
         """
-        URL corresponding to the WEB bucket.
-        """
-
-    @abstractmethod
-    def get_ref_base(self) -> Path:
-        """
-        Prefix for reference data.
+        URL corresponding to path(category='web', ...), assuming other parameters
+        are the same.
         """

--- a/cpg_pipes/targets.py
+++ b/cpg_pipes/targets.py
@@ -325,7 +325,7 @@ class Dataset(Target):
     @property
     def storage_provider(self) -> StorageProvider:
         """
-        Storage provider object resonsible for dataset file paths.
+        Storage provider object responsible for dataset file paths.
         """
         if not self._storage_provider:
             raise ValueError(

--- a/cpg_pipes/targets.py
+++ b/cpg_pipes/targets.py
@@ -325,7 +325,7 @@ class Dataset(Target):
     @property
     def storage_provider(self) -> StorageProvider:
         """
-        Storage provider required to get bucket paths for the dataset.
+        Storage provider object resonsible for dataset file paths.
         """
         if not self._storage_provider:
             raise ValueError(
@@ -334,38 +334,47 @@ class Dataset(Target):
             )
         return self._storage_provider
 
-    def get_bucket(self, **kwargs) -> Path:
+    def path(self, **kwargs) -> Path:
         """
-        The primary dataset bucket (-main or -test).
+        The primary storage path.
         """
-        return self.storage_provider.get_base(
+        return self.storage_provider.path(
             dataset=self.stack,
             namespace=self.namespace,
             **kwargs,
         )
 
-    def get_tmp_bucket(self, **kwargs) -> Path:
+    def storage_tmp_path(self, **kwargs) -> Path:
         """
-        The tmp bucket (-main-tmp or -test-tmp)
+        Storage path for temporary files.
         """
-        return self.storage_provider.get_tmp_base(
-            dataset=self.stack, namespace=self.namespace, **kwargs
+        return self.storage_provider.path(
+            dataset=self.stack, 
+            namespace=self.namespace,
+            category='tmp',
+            **kwargs,
         )
 
-    def get_web_bucket(self, **kwargs) -> Path:
+    def web_path(self, **kwargs) -> Path:
         """
-        Get web bucket (-main-web or -test-web)
+        Path for files served by an HTTP server Matches corresponding URLs returns by
+        self.web_url() URLs.
         """
-        return self.storage_provider.get_web_base(
-            dataset=self.stack, namespace=self.namespace, **kwargs
+        return self.storage_provider.path(
+            dataset=self.stack, 
+            namespace=self.namespace,
+            category='web',
+            **kwargs
         )
 
-    def get_web_url(self, **kwargs) -> str | None:
+    def web_url(self, **kwargs) -> str | None:
         """
-        Get web base URL.
+        URLs matching self.storage_web_path() files serverd by an HTTP server. 
         """
-        return self.storage_provider.get_web_url(
-            dataset=self.stack, namespace=self.namespace, **kwargs
+        return self.storage_provider.web_url(
+            dataset=self.stack, 
+            namespace=self.namespace, 
+            **kwargs
         )
 
     def add_sample(
@@ -420,7 +429,7 @@ class Dataset(Target):
         """
         return f'{self.name}: '
 
-    def make_ped_file(self) -> Path:
+    def make_ped_file(self, tmp_bucket: Path | None = None) -> Path:
         """
         Create a PED file for all samples
         """
@@ -430,7 +439,7 @@ class Dataset(Target):
                 datas.append(sample.pedigree.get_ped_dict())
         df = pd.DataFrame(datas)
 
-        ped_path = self.get_tmp_bucket() / f'{self.name}.ped'
+        ped_path = (tmp_bucket or self.storage_tmp_path()) / f'{self.name}.ped'
         with ped_path.open('w') as fp:
             df.to_csv(fp, sep='\t', index=False)
 
@@ -566,13 +575,13 @@ class Sample(Target):
         """
         Path to a CRAM file. Not checking its existence here.
         """
-        return CramPath(self.dataset.get_bucket() / 'cram' / f'{self.id}.cram')
+        return CramPath(self.dataset.path() / 'cram' / f'{self.id}.cram')
 
     def get_gvcf_path(self) -> GvcfPath:
         """
         Path to a GVCF file. Not checking its existence here.
         """
-        return GvcfPath(self.dataset.get_bucket() / 'gvcf' / f'{self.id}.g.vcf.gz')
+        return GvcfPath(self.dataset.path() / 'gvcf' / f'{self.id}.g.vcf.gz')
 
     @property
     def target_id(self) -> str:


### PR DESCRIPTION
Updating CpgStorageProvider to use `cpg_utils.hail_batch.dataset_path()`.

Not sure if it makes sense to merge it here, or work directly on moving this into cpg-utils. Happy to discuss more.

There are multiple stacked PR (https://github.com/populationgenomics/production-pipelines/pull/46, https://github.com/populationgenomics/production-pipelines/pull/47, https://github.com/populationgenomics/production-pipelines/pull/48). It would be ideal to quickly merge everything one after another, to avoid running into merge problems with so many branches depending on each other. I'm also okay to close them all, and move the codebase into cpg_utils.