### PR TITLE
Click config file: check potential typos

### DIFF
--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -253,7 +253,10 @@ def pipeline_click_options(function: Callable) -> Callable:
         'config',
         type=click.Path(exists=True, dir_okay=False, readable=True),
         help='Read configuration from a YAML FILE.',
-        callback=get_config_callback(getattr(function, '__click_params__', []))
+        callback=get_config_callback(getattr(function, '__click_params__', [])),
+        expose_value=False,  # don't poss parameter to `main()`
+        is_eager=True,  # process before other options, to make sure we don't fail 
+                        # is required command line options are missing
     )(function)
 
 

--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -16,6 +16,9 @@ from ..providers.storage import Namespace
 
 logger = logging.getLogger(__file__)
 
+# Whether to fail if a configuration file has unknown parameters.
+CONFIG_FILE_STRICT = True
+
 
 def choice_from_enum(cls: Type[Enum]) -> click.Choice:
     """
@@ -274,11 +277,15 @@ def get_config_callback(defined_options: list[click.Option]):
         defined_opts = [_opt.name for _opt in defined_options]
         unused_defaults = [k for k in d.keys() if k not in defined_opts]
         if unused_defaults:
-            logger.warning(
+            msg = (
                 f'Found unknown option(s) in the config {yaml_path}: '
                 f'{unused_defaults}'
             )
-        
+            if CONFIG_FILE_STRICT:
+                raise click.BadOptionUsage(param, msg, ctx)
+            else:
+                logger.warning(msg)
+
         ctx.default_map = ctx.default_map or {}
         ctx.default_map.update(d)
     return config_callback

--- a/cpg_pipes/pipeline/cli_opts.py
+++ b/cpg_pipes/pipeline/cli_opts.py
@@ -1,10 +1,10 @@
 """
 Common pipeline command line options for Click.
 """
+import logging
 from enum import Enum
 from typing import Callable, Type, TypeVar
 import click
-import click_config_file
 import yaml  # type: ignore
 
 from ..providers import (
@@ -13,6 +13,8 @@ from ..providers import (
     InputProviderType,
 )
 from ..providers.storage import Namespace
+
+logger = logging.getLogger(__file__)
 
 
 def choice_from_enum(cls: Type[Enum]) -> click.Choice:
@@ -63,6 +65,7 @@ def pipeline_click_options(function: Callable) -> Callable:
         def main(custom_argument: str):
             pipeline = create_pipeline(**kwargs, config=dict(myarg=custom_argument))
     """
+
     options = [
         click.option(
             '-n',
@@ -237,15 +240,45 @@ def pipeline_click_options(function: Callable) -> Callable:
     # application which is bottom to top.
     for opt in options[::-1]:
         function = opt(function)
-
-    # Adding ability to load options from a yaml file
-    # using https://pypi.org/project/click-config-file
-    def yaml_provider(fp, _):
-        """Load options from YAML"""
-        with open(fp) as f:
-            return yaml.load(f, Loader=yaml.SafeLoader)
-
-    return click_config_file.configuration_option(
-        provider=yaml_provider,
-        implicit=False,
+    
+    # Adding a special option to read defaults from a user-provided configuration file. 
+    # Adding it last, so we are able to compare parameters in the file with the "normal" 
+    # options that would be populated in function.__click_params__ by click at this 
+    # point.
+    return click.option(
+        '--config',
+        'config',
+        type=click.Path(exists=True, dir_okay=False, readable=True),
+        help='Read configuration from a YAML FILE.',
+        callback=get_config_callback(getattr(function, '__click_params__', []))
     )(function)
+
+
+def get_config_callback(defined_options: list[click.Option]):
+    """
+    Create callback for the --config option. We want to be able to check what params 
+    are defined by "normal" click options to compare them with the params in the 
+    config file, so for this reason we parametrise the callback with `defined_options`
+    by wrapping it with another function `get_config_callback`.
+    """
+    def config_callback(ctx, param, yaml_path):
+        """Read default option values from a YAML config file"""
+        try:
+            with open(yaml_path) as f:
+                d = yaml.load(f, Loader=yaml.SafeLoader)
+        except Exception as e:
+            raise click.BadOptionUsage(
+                param, f'Error reading configuration file: {e}', ctx
+            )
+        
+        defined_opts = [_opt.name for _opt in defined_options]
+        unused_defaults = [k for k in d.keys() if k not in defined_opts]
+        if unused_defaults:
+            logger.warning(
+                f'Found unknown option(s) in the config {yaml_path}: '
+                f'{unused_defaults}'
+            )
+        
+        ctx.default_map = ctx.default_map or {}
+        ctx.default_map.update(d)
+    return config_callback

--- a/pipelines/configs/prophecy-test.yml
+++ b/pipelines/configs/prophecy-test.yml
@@ -3,4 +3,4 @@ analysis_dataset: prophecy
 datasets: [prophecy]
 keep_scratch: true
 skip_samples_with_missing_input: true
-only-samples: [CPG214858, CPG215046, CPG214668]
+only_samples: [CPG214858, CPG215046, CPG214668]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
     ],
     install_requires=[
         'click',
-        'click-config-file',
         'pandas',
         'hail>=0.2.91',
         'cpg-gnomad',  # github.com/populationgenomics/gnomad_methods


### PR DESCRIPTION
When a config file contains parameters that are not defined by normal `click.option()` decorators, `click-config-file` would just silently ignores that. Even though it's sometimes a useful behaviour when you want to reuse the same config for different pipelines, we still want to catch potential typos in a config, e.g. like the one fixed in this commit: `only_samples` vs. `only-samples`. 

So I'm dropping the `click-config-file` dependency, and instead adding a custom callback that prints a warning if a config option doesn't match defined click decorators.

UPDATE: it's easy to overlook the warning, so changed the default behaviour to failure for now.