### PR TITLE
Update DRAGMAP image to use 1.3.0

### DIFF
--- a/cpg_pipes/providers/images.py
+++ b/cpg_pipes/providers/images.py
@@ -5,12 +5,12 @@ import os
 
 
 AVAILABLE = {
-    'gatk': 'gatk:4.2.3.0',
+    'gatk': 'gatk:4.2.6.1',
     'bcftools': 'bcftools:1.10.2--h4f4756c_2',
     'sm-api': 'sm-api:4.0.0',
     'bwa': 'bwa:v0',
     'bwamem2': 'bwamem2:v0',
-    'dragmap': 'dragmap:1.2.1',
+    'dragmap': 'dragmap:1.3.0',
     'samtools': 'picard_samtools:v0',
     'picard': 'picard_samtools:v0',
     'picard_samtools': 'picard_samtools:v0',

--- a/dockers/dragmap/Dockerfile
+++ b/dockers/dragmap/Dockerfile
@@ -1,56 +1,30 @@
-# Using rocky as temp replacement for CentOS
-FROM rockylinux:8.5 
+FROM debian:buster-slim
 
-ARG DRAGMAP_VERSION=1.3.0
+ENV VERSION 1.3.0
 
 ENV MAMBA_ROOT_PREFIX /root/micromamba
 ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
 
-ENV TERM=xterm-256color \
-    HAS_GTEST=0 \
-    BOOST_LIBRARYDIR=/usr/lib64/boost169 \
-    BOOST_INCLUDEDIR=/usr/include/boost169 \
-    DRAGMAP_URL=https://github.com/Illumina/DRAGMAP/archive/refs/tags/${DRAGMAP_VERSION}.tar.gz
-
-WORKDIR /usr/gitc
-
-# Install dependencies
-RUN set -eux; \
-    yum upgrade -y && \
-    yum install -y epel-release && \
-    yum install -y boost169-devel \
-        bzip2 \
-        bzip2-devel \
-        curl-devel \
-        gcc \
-        gcc-c++ \
-        java-1.8.0-openjdk \
-        make \
-        ncurses-devel \
-        openssl-devel \
-        wget \
-        xz-devel \
-        zlib-devel \
+RUN apt-get update && apt-get install -y \
+    git wget bash bzip2 zip \
+    build-essential libboost-all-dev \
     && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c bioconda -c conda-forge \
     bazam biobambam samtools google-cloud-sdk \
     && \
-    rm -r /root/micromamba/pkgs \
-    && \
-    # Install DRAGMAP
-    wget ${DRAGMAP_URL} && \
-    tar -xf ${DRAGMAP_VERSION}.tar.gz && \
-    rm ${DRAGMAP_VERSION}.tar.gz && \
-    \
-    cd DRAGMAP-${DRAGMAP_VERSION} && \
-    make && \
+    rm -r /root/micromamba/pkgs
+
+RUN apt update && apt install -y build-essential curl libboost-all-dev && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/* && \
+    git clone --depth 1 --branch $VERSION https://github.com/Illumina/DRAGMAP && \
+    cd DRAGMAP && \
+    HAS_GTEST=0 make -j 8 && \
+    mkdir ${MAMBA_ROOT_PREFIX}/bin && \
     mv build/release/dragen-os ${MAMBA_ROOT_PREFIX}/bin/ && \
-    \
     cd .. && \
-    rm -r DRAGMAP-${DRAGMAP_VERSION} \
-    && \
-# Clean up cached files
-    yum clean all; \
-    rm -rf /var/cache/yum;
+    rm -r /DRAGMAP

--- a/dockers/dragmap/Dockerfile
+++ b/dockers/dragmap/Dockerfile
@@ -1,13 +1,56 @@
-FROM debian:buster-slim
+# Using rocky as temp replacement for CentOS
+FROM rockylinux:8.5 
+
+ARG DRAGMAP_VERSION=1.3.0
 
 ENV MAMBA_ROOT_PREFIX /root/micromamba
 ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
 
-RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
-    rm -r /var/lib/apt/lists/* && \
-    rm -r /var/cache/apt/* && \
+ENV TERM=xterm-256color \
+    HAS_GTEST=0 \
+    BOOST_LIBRARYDIR=/usr/lib64/boost169 \
+    BOOST_INCLUDEDIR=/usr/include/boost169 \
+    DRAGMAP_URL=https://github.com/Illumina/DRAGMAP/archive/refs/tags/${DRAGMAP_VERSION}.tar.gz
+
+WORKDIR /usr/gitc
+
+# Install dependencies
+RUN set -eux; \
+    yum upgrade -y && \
+    yum install -y epel-release && \
+    yum install -y boost169-devel \
+        bzip2 \
+        bzip2-devel \
+        curl-devel \
+        gcc \
+        gcc-c++ \
+        java-1.8.0-openjdk \
+        make \
+        ncurses-devel \
+        openssl-devel \
+        wget \
+        xz-devel \
+        zlib-devel \
+    && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c bioconda -c conda-forge \
-    bazam dragmap biobambam samtools google-cloud-sdk && \
-    rm -r /root/micromamba/pkgs
+    bazam biobambam samtools google-cloud-sdk \
+    && \
+    rm -r /root/micromamba/pkgs \
+    && \
+    # Install DRAGMAP
+    wget ${DRAGMAP_URL} && \
+    tar -xf ${DRAGMAP_VERSION}.tar.gz && \
+    rm ${DRAGMAP_VERSION}.tar.gz && \
+    \
+    cd DRAGMAP-${DRAGMAP_VERSION} && \
+    make && \
+    mv build/release/dragen-os ${MAMBA_ROOT_PREFIX}/bin/ && \
+    \
+    cd .. && \
+    rm -r DRAGMAP-${DRAGMAP_VERSION} \
+    && \
+# Clean up cached files
+    yum clean all; \
+    rm -rf /var/cache/yum;

--- a/dockers/dragmap/README
+++ b/dockers/dragmap/README
@@ -1,1 +1,1 @@
-gcloud builds submit --timeout=8h --tag=australia-southeast1-docker.pkg.dev/cpg-common/images/dragmap:1.2.1
+gcloud builds submit --timeout=8h --tag=australia-southeast1-docker.pkg.dev/cpg-common/images/dragmap:1.3.0


### PR DESCRIPTION
Until 1.3.0 bioconda build is broken https://github.com/bioconda/bioconda-recipes/pull/34744, working around conda DRAGMAP. Combining WARP image https://github.com/broadinstitute/warp/blob/master/dockers/broad/dragmap/Dockerfile and our micromamba image to get DRAGMAP installed from source, and all other tools from bioconda.