### PR TITLE
Wrappers for bioinformatics data types

### DIFF
--- a/cpg_pipes/providers/cpg/inputs.py
+++ b/cpg_pipes/providers/cpg/inputs.py
@@ -4,6 +4,8 @@ InputProvider implementation that pulls data from the sample-metadata database.
 
 import logging
 import traceback
+from collections import defaultdict
+from itertools import groupby
 
 from sample_metadata import ApiException
 
@@ -22,9 +24,9 @@ class SmdbInputProvider(InputProvider):
     """
 
     def __init__(
-        self, 
-        db: SMDB, 
-        check_files: bool = False, 
+        self,
+        db: SMDB,
+        check_files: bool = False,
         smdb_errors_are_fatal: bool = True,
     ):
         super().__init__(check_files=check_files)
@@ -122,7 +124,7 @@ class SmdbInputProvider(InputProvider):
         """
         assert cohort.get_sample_ids()
         try:
-            seq_infos: list[dict] = self.db.seqapi.get_sequences_by_sample_ids(
+            found_seqs: list[dict] = self.db.seqapi.get_sequences_by_sample_ids(
                 cohort.get_sample_ids()
             )
         except ApiException:
@@ -135,25 +137,40 @@ class SmdbInputProvider(InputProvider):
                     'However, here is the error: '
                 )
                 traceback.print_exc()
-                seq_infos = []
-        seq_by_sid = {seq['sample_id']: seq for seq in seq_infos}
-        seq_info_by_sid = {
-            sample.id: seq_by_sid.get(sample.id) for sample in cohort.get_samples()
-        }
-        sids_with_missing_seq = [k for k, v in seq_info_by_sid.items() if v is None]
-        if sids_with_missing_seq:
-            msg = f'No sequencing data for samples: {", ".join(sids_with_missing_seq)}'
+                found_seqs = []
+        found_seqs_by_sid = defaultdict(list)
+        for found_seq in found_seqs:
+            found_seqs_by_sid[found_seq['sample_id']].append(found_seq)
+        
+        # Checking missing sequences
+        if sample_wo_seq := [
+            s for s in cohort.get_samples() if s.id not in found_seqs_by_sid
+        ]:
+            msg = f'No sequencing data found for samples:\n'
+            for ds, samples in groupby(sample_wo_seq, key=lambda s: s.dataset.name):
+                msg += (
+                    f'\t{ds}, {len(list(samples))} samples: '
+                    f'{", ".join([s.id for s in samples])}\n'
+                )
             if self.smdb_errors_are_fatal:
                 raise InputProviderError(msg)
             else:
-                logger.warning(
-                    f'{msg}. Continuing without sequencing data because lenient=true'
-                )
+                msg += '\nContinuing without sequencing data because lenient=true'
+                logger.warning(msg)
+
         for sample in cohort.get_samples():
-            if seq_info := seq_by_sid.get(sample.id):
-                seq = SmSequence.parse(seq_info, self.check_files)
-                sample.alignment_input = seq.alignment_input
-                sample.sequencing_type = seq.sequencing_type
+            for d in found_seqs_by_sid.get(sample.id, []):
+                seq = SmSequence.parse(d, self.check_files)
+                if seq.alignment_input:
+                    if seq.sequencing_type in sample.alignment_input_by_seq_type:
+                        raise InputProviderError(
+                            f'{sample}: found more than 1 alignment input with '
+                            f'sequencing type: {seq.sequencing_type.value}. Check your '
+                            f'input provider to make sure there is only one data source '
+                            f'of sequencing type per sample.'
+                        )
+                    sample.alignment_input_by_seq_type[seq.sequencing_type] = \
+                        seq.alignment_input
 
     def populate_analysis(self, cohort: Cohort) -> None:
         """

--- a/cpg_pipes/types.py
+++ b/cpg_pipes/types.py
@@ -1,0 +1,188 @@
+"""
+Basic bioinformatics status types.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Union
+
+from . import Path, to_path
+from . import utils
+from hailtop.batch import ResourceGroup, ResourceFile, Batch
+
+logger = logging.getLogger(__file__)
+
+
+class CramPath:
+    """
+    Represents alignment data on a bucket within the pipeline.
+    Includes a path to a CRAM or a BAM file along with a corresponding index,
+    and a corresponding fingerprint path.
+    """
+
+    def __init__(self, path: str | Path, index_path: Path | str | None = None):
+        self.path = to_path(path)
+        self.is_bam = self.path.suffix == '.bam'
+        self.ext = 'cram' if not self.is_bam else 'bam'
+        self.index_ext = 'crai' if not self.is_bam else 'bai'
+        self._index_path = index_path
+        self.somalier_path = to_path(f'{self.path}.somalier')
+
+    def __str__(self) -> str:
+        return str(self.path)
+
+    def __repr__(self) -> str:
+        return f'CRAM({self.path})'
+
+    def exists(self) -> bool:
+        """
+        CRAM file exists.
+        """
+        return self.path.exists()
+
+    @property
+    def index_path(self) -> Path:
+        """
+        Path to the corresponding index
+        """
+        return (
+            to_path(self._index_path)
+            if self._index_path
+            else to_path(f'{self.path}.{self.index_ext}')
+        )
+
+    def resource_group(self, b: Batch) -> ResourceGroup:
+        """
+        Create a Hail Batch resource group
+        """
+        return b.read_input_group(
+            **{
+                self.ext: str(self.path),
+                f'{self.ext}.{self.index_ext}': str(self.index_path),
+            }
+        )
+
+
+class GvcfPath:
+    """
+    Represents GVCF data on a bucket within the pipeline.
+    Includes a path to a GVCF file along with a corresponding TBI index,
+    and a corresponding fingerprint path.
+    """
+
+    def __init__(self, path: Path | str):
+        self.path = to_path(path)
+        self.somalier_path = to_path(f'{self.path}.somalier')
+
+    def __str__(self) -> str:
+        return str(self.path)
+
+    def __repr__(self) -> str:
+        return f'GVCF({self.path})'
+
+    def exists(self) -> bool:
+        """
+        GVCF file exists.
+        """
+        return self.path.exists()
+
+    @property
+    def tbi_path(self) -> Path:
+        """
+        Path to the corresponding index
+        """
+        return to_path(f'{self.path}.tbi')
+
+    def resource_group(self, b: Batch) -> ResourceGroup:
+        """
+        Create a Hail Batch resource group
+        """
+        return b.read_input_group(
+            **{
+                'g.vcf.gz': str(self.path),
+                'g.vcf.gz.tbi': str(self.tbi_path),
+            }
+        )
+
+
+FastqPath = Union[str, Path, ResourceFile]
+
+
+@dataclass
+class FastqPair:
+    """
+    Pair of FASTQ files
+    """
+
+    r1: FastqPath
+    r2: FastqPath
+
+    def __getitem__(self, i):
+        assert i == 0 or i == 1, i
+        return [self.r1, self.r2][i]
+
+    def as_resources(self, b) -> 'FastqPair':
+        """
+        Makes a pair of ResourceFile objects for r1 and r2.
+        """
+        r1 = (
+            self.r1 if isinstance(self.r1, ResourceFile) else b.read_input(str(self.r1))
+        )
+        r2 = (
+            self.r2 if isinstance(self.r2, ResourceFile) else b.read_input(str(self.r2))
+        )
+        return FastqPair(r1, r2)
+
+    def __str__(self):
+        return f'{self.r1}|{self.r2}'
+
+
+FastqPairs = List[FastqPair]
+
+
+# Alignment input can be a CRAM file on a bucket, or a list of Fastq pairs on a bucket.
+AlignmentInput = Union[FastqPairs, CramPath]
+
+
+def alignment_input_exists(v: AlignmentInput) -> bool:
+    """
+    Check if all files in alignment inputs exist.
+    """
+    if isinstance(v, CramPath):
+        return utils.exists(v.path)
+    else:
+        return all(utils.exists(pair.r1) and utils.exists(pair.r2) for pair in v)
+    
+
+class SequencingType(Enum):
+    """
+    Type (scope) of a sequencing experiment.
+    """
+
+    GENOME = 'genome'
+    EXOME = 'exome'
+    SINGLE_CELL = 'single_cell'
+
+    @staticmethod
+    def parse(str_val: str) -> 'SequencingType':
+        """
+        Parse a string into a SequencingType object.
+        """
+        str_to_val: dict[str, SequencingType] = {} 
+        for val, str_vals in {
+            SequencingType.GENOME: ['wgs', 'genome'],
+            SequencingType.EXOME: ['exome', 'wts', 'wes'],
+            SequencingType.SINGLE_CELL: ['single_cell', 'single_cell_rna'],
+        }.items():
+            for str_v in str_vals:
+                str_v = str_v.lower()
+                assert str_v not in str_to_val, (str_v, str_to_val)
+                str_to_val[str_v] = val
+        str_val = str_val.lower()
+        if str_val not in str_to_val:
+            raise ValueError(
+                f'Unrecognised sequence type {str_val}. '
+                f'Available: {list(str_to_val.keys())}'
+            )
+        return str_to_val[str_val]

--- a/cpg_pipes/types.py
+++ b/cpg_pipes/types.py
@@ -3,18 +3,78 @@ Wrappers for bioinformatics file types (CRAM, GVCF, FASTQ, etc).
 """
 
 import logging
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Union
 
+from hailtop.batch import ResourceGroup, ResourceFile, Batch
+
 from . import Path, to_path
 from . import utils
-from hailtop.batch import ResourceGroup, ResourceFile, Batch
 
 logger = logging.getLogger(__file__)
 
 
-class CramPath:
+class SequencingType(Enum):
+    """
+    Type (scope) of a sequencing experiment.
+    """
+
+    GENOME = 'genome'
+    EXOME = 'exome'
+    SINGLE_CELL = 'single_cell'
+    MTSEQ = 'mtseq'
+    ONT = 'ont'
+
+    @staticmethod
+    def parse(str_val: str) -> 'SequencingType':
+        """
+        Parse a string into a SequencingType object.
+        
+        >>> SequencingType.parse('genome')
+        SequencingType.GENOME
+        >>> SequencingType.parse('wes')
+        SequencingType.EXOME
+        """
+        str_to_val: dict[str, SequencingType] = {} 
+        for val, str_vals in {
+            SequencingType.GENOME: ['genome', 'wgs'],
+            SequencingType.EXOME: ['exome', 'wts', 'wes'],
+            SequencingType.SINGLE_CELL: ['single_cell', 'single_cell_rna'],
+            SequencingType.MTSEQ: ['mtseq']
+        }.items():
+            for str_v in str_vals:
+                str_v = str_v.lower()
+                assert str_v not in str_to_val, (str_v, str_to_val)
+                str_to_val[str_v] = val
+        str_val = str_val.lower()
+        if str_val not in str_to_val:
+            raise ValueError(
+                f'Unrecognised sequence type {str_val}. '
+                f'Available: {list(str_to_val.keys())}'
+            )
+        return str_to_val[str_val]
+
+
+class AlignmentInput(ABC):
+    """
+    Data that works as input for alignment or realignment.
+    """
+    @abstractmethod
+    def exists(self) -> bool:
+        """
+        Check if all files exist.
+        """
+
+    @abstractmethod
+    def path_glob(self) -> str:
+        """
+        Compact representation of file paths. 
+        """
+
+
+class CramPath(AlignmentInput):
     """
     Represents alignment data on a bucket within the pipeline.
     Includes a path to a CRAM or a BAM file along with a corresponding index,
@@ -62,6 +122,13 @@ class CramPath:
                 f'{self.ext}.{self.index_ext}': str(self.index_path),
             }
         )
+    
+    def path_glob(self) -> str:
+        """
+        Compact representation of file paths. 
+        For a CRAM, it's just the CRAM file path.
+        """
+        return str(self.path)
 
 
 class GvcfPath:
@@ -126,99 +193,51 @@ class FastqPair:
         """
         Makes a pair of ResourceFile objects for r1 and r2.
         """
-        r1 = (
-            self.r1 if isinstance(self.r1, ResourceFile) else b.read_input(str(self.r1))
-        )
-        r2 = (
-            self.r2 if isinstance(self.r2, ResourceFile) else b.read_input(str(self.r2))
-        )
-        return FastqPair(r1, r2)
+        return FastqPair(*[
+            self[i] 
+            if isinstance(self[i], ResourceFile) 
+            else b.read_input(str(self[i]))
+            for i in [0, 1]
+        ])
 
     def __str__(self):
         return f'{self.r1}|{self.r2}'
 
 
-FastqPairs = List[FastqPair]
-
-
-class SequencingType(Enum):
+class FastqPairs(list[FastqPair], AlignmentInput):
     """
-    Type (scope) of a sequencing experiment.
+    Multiple FASTQ file pairs belonging to the same sample 
+    (e.g. multuple lanes or top-ups).
     """
-
-    GENOME = 'genome'
-    EXOME = 'exome'
-    SINGLE_CELL = 'single_cell'
-    MTSEQ = 'mtseq'
-
-    @staticmethod
-    def parse(str_val: str) -> 'SequencingType':
-        """
-        Parse a string into a SequencingType object.
-        """
-        str_to_val: dict[str, SequencingType] = {} 
-        for val, str_vals in {
-            SequencingType.GENOME: ['genome', 'wgs'],
-            SequencingType.EXOME: ['exome', 'wts', 'wes'],
-            SequencingType.SINGLE_CELL: ['single_cell', 'single_cell_rna'],
-            SequencingType.MTSEQ: ['mtseq']
-        }.items():
-            for str_v in str_vals:
-                str_v = str_v.lower()
-                assert str_v not in str_to_val, (str_v, str_to_val)
-                str_to_val[str_v] = val
-        str_val = str_val.lower()
-        if str_val not in str_to_val:
-            raise ValueError(
-                f'Unrecognised sequence type {str_val}. '
-                f'Available: {list(str_to_val.keys())}'
-            )
-        return str_to_val[str_val]
-
-
-class AlignmentInput:
-    """
-    Alignment input can be an indexed CRAM file, or a list of FASTQ file pairs.
-    """
-    def __init__(
-        self, 
-        data: Union[CramPath, FastqPairs],
-        sequencing_type: SequencingType,
-    ):
-        self.data = data
-        self.is_cram_or_bam = isinstance(data, CramPath)
-        self.sequencing_type = sequencing_type
-        
-    def __str__(self):
-        return f'{self.sequencing_type.value}:{str(self.data)}'
-
     def exists(self) -> bool:
         """
-        Check if all files in alignment inputs exist.
+        Check if each FASTQ file in each pair exist.
         """
-        if isinstance(self.data, CramPath):
-            return utils.exists(self.data.path)
-        else:
-            return all(
-                utils.exists(pair.r1) and utils.exists(pair.r2) 
-                for pair in self.data
-            )
+        return all(
+            utils.exists(pair.r1) and utils.exists(pair.r2) 
+            for pair in self
+        )
 
-    def compact_file_paths(self) -> str:
+    def path_glob(self) -> str:
         """
         Compact representation of file paths. 
-        For CRAM, it's simply path to CRAM. 
         For FASTQ pairs, it's glob string to find all FASTQ files.
+
+        >>> FastqPairs([
+        >>>     FastqPair('gs://sample_R1.fq.gz', 'gs://sample_R2.fq.gz'),
+        >>> ]).path_glob()
+        'gs://sample_R{2,1}.fq.gz'
+        >>> FastqPairs([
+        >>>     FastqPair('gs://sample_L1_R1.fq.gz', 'gs://sample_L1_R2.fq.gz'), 
+        >>>     FastqPair('gs://sample_L2_R1.fq.gz', 'gs://sample_L2_R2.fq.gz'),
+        >>> ]).path_glob()
+        'gs://sample_L{2,1}_R{2,1}.fq.gz'
         """
-        if isinstance(self.data, CramPath):
-            result = str(self.data.path)
-        else:
-            all_fastq_paths = []
-            for pair in self.data:
-                all_fastq_paths.extend([pair.r1, pair.r2])
-            # Triple { intentional: they are resolved to single {
-            result = ''.join([
-                f'{{{",".join(set(chars))}}}' if len(set(chars)) > 1 else chars[0] 
-                for chars in zip(*map(str, all_fastq_paths))
-            ])
-        return f'{self.sequencing_type.value}:{result}'
+        all_fastq_paths = []
+        for pair in self:
+            all_fastq_paths.extend([pair.r1, pair.r2])
+        # Triple braces are intentional: they are resolved to single ones.
+        return ''.join([
+            f'{{{",".join(set(chars))}}}' if len(set(chars)) > 1 else chars[0] 
+            for chars in zip(*map(str, all_fastq_paths))
+        ])

--- a/cpg_pipes/types.py
+++ b/cpg_pipes/types.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Union
+from typing import Union
 
 from hailtop.batch import ResourceGroup, ResourceFile, Batch
 
@@ -207,7 +207,7 @@ class FastqPair:
 class FastqPairs(list[FastqPair], AlignmentInput):
     """
     Multiple FASTQ file pairs belonging to the same sample 
-    (e.g. multuple lanes or top-ups).
+    (e.g. multiple lanes or top-ups).
     """
     def exists(self) -> bool:
         """


### PR DESCRIPTION
Add classes for basic bioinformatics data types used in the pipelines, to help validating inputs for Hail Batch bioinformatics jobs. 
* CramPath
* GvcfPath
* FastqPath/FastqPair/FastqPairs
* AlignmentInput
* Also adds an enum SequencingType, matching the one of sample-metadata (see this PR against `initial` https://github.com/populationgenomics/production-pipelines/pull/57 for more context)