### PR TITLE
Use labelled pool, update batch job attrs/stats

### DIFF
--- a/cpg_pipes/hb/resources.py
+++ b/cpg_pipes/hb/resources.py
@@ -291,20 +291,8 @@ class JobResource:
         """
 
         j.storage(f'{self.get_storage_gb()}G')
-        
-        if j['use_private_pool']:
-            # Force setting j._machine_type send the job to the private pool:
-            # https://github.com/populationgenomics/hail/blob/ad1fc0e2a30f67855aee84ae9adabc3f3135bd47/batch/batch/inst_coll_config.py#L324-L344
-            if self.get_ncpu() == self.machine_type.max_ncpu:
-                # Taking entire machine
-                j._machine_type = self.machine_type.gcp_name()
-            else:
-                # Private pools don't support binning, so replacing with a smaller machine
-                ncpu = max(2, self.get_ncpu())
-                j._machine_type = gcp_machine_name(self.machine_type.name, ncpu)
-        else:
-            j.cpu(self.get_ncpu())
-            j.memory(f'{self.get_mem_gb()}G')
-    
+        j.cpu(self.get_ncpu())
+        j.memory(f'{self.get_mem_gb()}G')
+
         # Returning self to allow command chaining.
         return self

--- a/cpg_pipes/jobs/joint_genotyping.py
+++ b/cpg_pipes/jobs/joint_genotyping.py
@@ -58,7 +58,8 @@ def make_joint_genotyping_jobs(
     Outputs a multi-sample VCF under `output_vcf_path`.
     """
     if utils.can_reuse([out_vcf_path, out_siteonly_vcf_path], overwrite):
-        return [b.new_job('Joint genotyping [reuse]', job_attrs)]
+        job_attrs['reuse'] = True
+        return [b.new_job('Joint genotyping', job_attrs)]
 
     if len(gvcf_by_sid) == 0:
         raise ValueError(


### PR DESCRIPTION
* `--hail-pool-label` replaces `--use-private-pool` and has a str value now to provide pool label (e.g. `seqr`, `large-cohorts`)
* Unrelated change, but it would be so painful to separate it. I slightly refactored job attributes which are used to print Batch jobs pre-submit stats, e.g.:

```
Will submit 612 jobs
Split by stage:
  Align: 612 jobs for 51 samples
Split by label:
  Align: 612 jobs for 51 samples
Split by tool:
  DRAGMAP: 510 jobs for 51 samples
  samtools_merge: 51 jobs for 51 samples
  picard_MarkDuplicates: 51 jobs for 51 samples
```