### PR TITLE
Add metadata to SM analysis entries

### DIFF
--- a/cpg_pipes/hb/batch.py
+++ b/cpg_pipes/hb/batch.py
@@ -24,6 +24,7 @@ class JobAttributes(TypedDict, total=False):
     sample: str
     dataset: str
     samples: list[str]
+    datasets: list[str]
     part: str
     label: str
     stage: str

--- a/cpg_pipes/pipeline/pipeline.py
+++ b/cpg_pipes/pipeline/pipeline.py
@@ -641,7 +641,8 @@ class Stage(Generic[TargetT], ABC):
                 if isinstance(val, dict):
                     for el in val.values():
                         _find_paths(el)
-    
+            
+            _find_paths(paths)
             reusable = all(exists(path) for path in paths)
         return reusable
 

--- a/cpg_pipes/pipeline/pipeline.py
+++ b/cpg_pipes/pipeline/pipeline.py
@@ -663,7 +663,7 @@ class Stage(Generic[TargetT], ABC):
         """
         seq_type = SequencingType.parse(get_config()['workflow']['sequencing_type'])
         job_attrs = dict(
-            seq_type=seq_type.value, 
+            seq_type=seq_type.value,
             stage=self.name,
         )
         if target:
@@ -809,13 +809,16 @@ class Pipeline:
             input_provider = CsvInputProvider(to_path(csv_path).open())
 
         if input_provider is not None:
+            seq_type = None
+            if val := get_config()['workflow'].get('sequencing_type'):
+                seq_type = SequencingType.parse(val)
             input_provider.populate_cohort(
                 cohort=self.cohort,
                 dataset_names=get_config()['workflow'].get('datasets'),
                 skip_samples=get_config()['workflow'].get('skip_samples'),
                 only_samples=get_config()['workflow'].get('only_samples'),
                 skip_datasets=get_config()['workflow'].get('skip_datasets'),
-                sequencing_type=get_config()['workflow'].get('sequencing_type'),
+                sequencing_type=seq_type,
             )
 
         self.hail_billing_project = get_billing_project(

--- a/cpg_pipes/pipeline/pipeline.py
+++ b/cpg_pipes/pipeline/pipeline.py
@@ -34,6 +34,7 @@ from ..providers.cpg.status import CpgStatusReporter
 from ..providers.inputs import InputProvider, CsvInputProvider
 from ..targets import Target, Dataset, Sample, Cohort
 from ..providers.status import StatusReporter
+from ..types import SequencingType
 from ..utils import exists
 
 logger = logging.getLogger(__file__)
@@ -69,6 +70,7 @@ class StageOutput:
         target: 'Target',
         data: StageOutputData | str | dict[str, str] | None = None,
         jobs: list[Job] | Job | None = None,
+        meta: dict | None = None,
         reusable: bool = False,
         skipped: bool = False,
         error_msg: str | None = None,
@@ -86,6 +88,7 @@ class StageOutput:
         self.stage = stage
         self.target = target
         self.jobs: list[Job] = [jobs] if isinstance(jobs, Job) else (jobs or [])
+        self.meta: dict = meta or {}
         self.reusable = reusable
         self.skipped = skipped
         self.error_msg = error_msg
@@ -98,6 +101,7 @@ class StageOutput:
             + (f' [reusable]' if self.reusable else '')
             + (f' [skipped]' if self.skipped else '')
             + (f' [error: {self.error_msg}]' if self.error_msg else '')
+            + f' meta={self.meta}'
             + f')'
         )
         return res
@@ -475,6 +479,7 @@ class Stage(Generic[TargetT], ABC):
         target: 'Target',
         data: StageOutputData | str | dict[str, str] | None = None,
         jobs: list[Job] | Job | None = None,
+        meta: dict | None = None,
         reusable: bool = False,
         skipped: bool = False,
         error_msg: str | None = None,
@@ -486,6 +491,7 @@ class Stage(Generic[TargetT], ABC):
             target=target,
             data=data,
             jobs=jobs,
+            meta=meta,
             reusable=reusable,
             skipped=skipped,
             error_msg=error_msg,
@@ -522,6 +528,8 @@ class Stage(Generic[TargetT], ABC):
             return None
 
         outputs.stage = self
+        outputs.meta |= self.get_job_attrs(target)
+
         for j in outputs.jobs:
             j.depends_on(*inputs.get_jobs(target))
 
@@ -537,6 +545,7 @@ class Stage(Generic[TargetT], ABC):
                 target=target,
                 jobs=outputs.jobs,
                 prev_jobs=inputs.get_jobs(target),
+                meta=outputs.meta,
             )
         return outputs
 
@@ -620,12 +629,19 @@ class Stage(Generic[TargetT], ABC):
                 # Do not check the files' existence, assume they don't exist:
                 reusable = False
         else:
-            # Checking that expected output exists:
-            paths: list[Path]
-            if isinstance(expected_out, dict):
-                paths = [v for k, v in expected_out.items()]
-            else:
-                paths = [expected_out]
+            # Checking that all paths in the expected output exists:
+            paths: list[Path] = []
+
+            def _find_paths(val):
+                if isinstance(val, Path):
+                    paths.append(val)
+                if isinstance(val, list):
+                    for el in val:
+                        _find_paths(el)
+                if isinstance(val, dict):
+                    for el in val.values():
+                        _find_paths(el)
+    
             reusable = all(exists(path) for path in paths)
         return reusable
 
@@ -645,7 +661,11 @@ class Stage(Generic[TargetT], ABC):
         """
         Create Hail Batch Job attributes dictionary
         """
-        job_attrs = dict(stage=self.name)
+        seq_type = SequencingType.parse(get_config()['workflow']['sequencing_type'])
+        job_attrs = dict(
+            seq_type=seq_type.value, 
+            stage=self.name,
+        )
         if target:
             job_attrs |= target.get_job_attrs()
         return job_attrs

--- a/cpg_pipes/pipeline/stage_subclasses.py
+++ b/cpg_pipes/pipeline/stage_subclasses.py
@@ -58,6 +58,15 @@ class SampleStage(Stage[Sample], ABC):
                 logger.info(f'{self.name}: #{sample_i + 1}/{sample}')
                 action = self._get_action(sample)
                 action_by_sid[sample.id] = action
+                if action == Action.REUSE:
+                    if self.analysis_type and self.status_reporter:
+                        self.status_reporter.create_analysis(
+                            output=str(self.expected_outputs(sample)),
+                            analysis_type=self.analysis_type,
+                            analysis_status='completed',
+                            target=sample,
+                            meta=sample.get_job_attrs(),
+                        )
 
             if len(set(action_by_sid.values())) == 1:
                 action = list(action_by_sid.values())[0]

--- a/cpg_pipes/providers/cpg/inputs.py
+++ b/cpg_pipes/providers/cpg/inputs.py
@@ -41,7 +41,7 @@ class CpgInputProvider(InputProvider):
         only_samples: list[str] | None = None,
         skip_datasets: list[str] | None = None,
         ped_files: list[Path] | None = None,
-        sequencing_type: str | None = None,
+        sequencing_type: SequencingType | None = None,
     ) -> Cohort:
         """
         Overriding the superclass method.

--- a/cpg_pipes/providers/cpg/smdb.py
+++ b/cpg_pipes/providers/cpg/smdb.py
@@ -232,6 +232,7 @@ class SMDB:
         status: str | AnalysisStatus,
         sample_ids: list[str],
         project_name: str | None = None,
+        meta: dict | None = None,
     ) -> int | None:
         """
         Tries to create an Analysis entry, returns its id if successful.
@@ -248,6 +249,7 @@ class SMDB:
             status=models.AnalysisStatus(status),
             output=str(output),
             sample_ids=list(sample_ids),
+            meta=meta or {},
         )
         try:
             aid = self.aapi.create_new_analysis(project=project_name, analysis_model=am)

--- a/cpg_pipes/providers/cpg/status.py
+++ b/cpg_pipes/providers/cpg/status.py
@@ -80,14 +80,13 @@ class CpgStatusReporter(StatusReporter):
             return []
         # Interacting with the sample metadata server:
         # 1. Create a "queued" analysis
-        aid = self.create_analysis(
+        if (aid := self.create_analysis(
             output=str(output),
             analysis_type=analysis_type,
             analysis_status='queued',
             target=target,
             meta=meta,
-        )
-        if aid is None:
+        )) is None:
             raise StatusReporterError(
                 'SmdbStatusReporter error: failed to create analysis'
             )
@@ -121,14 +120,14 @@ class CpgStatusReporter(StatusReporter):
         analysis_status: str,
         target: Target,
         meta: dict | None = None,        
-    ) -> int:
+    ) -> int | None:
         """Record analysis entry"""
         return self.smdb.create_analysis(
             output=output,
             type_=analysis_type,
             status=analysis_status,
             sample_ids=target.get_sample_ids(),
-            meta=meta | dict(
+            meta=(meta or {}) | dict(
                 sample_num=len(target.get_samples()),
                 samples=target.get_sample_ids(),
             ),

--- a/cpg_pipes/providers/cpg/status.py
+++ b/cpg_pipes/providers/cpg/status.py
@@ -75,7 +75,7 @@ class CpgStatusReporter(StatusReporter):
                 'Cannot use hail.batch.Resource objects with status reporter. '
                 'Only supported single Path objects'
             )
-
+        
         if not jobs:
             return []
         # Interacting with the sample metadata server:
@@ -105,7 +105,7 @@ class CpgStatusReporter(StatusReporter):
             status=AnalysisStatus.COMPLETED,
             analysis_type=analysis_type,
             job_attrs=target.get_job_attrs(),
-            output=str(output),
+            output=output if isinstance(output, Path) else None,
         )
 
         if prev_jobs:
@@ -127,10 +127,7 @@ class CpgStatusReporter(StatusReporter):
             type_=analysis_type,
             status=analysis_status,
             sample_ids=target.get_sample_ids(),
-            meta=(meta or {}) | dict(
-                sample_num=len(target.get_samples()),
-                samples=target.get_sample_ids(),
-            ),
+            meta=meta,
         )
 
     @staticmethod
@@ -140,7 +137,7 @@ class CpgStatusReporter(StatusReporter):
         status: AnalysisStatus,
         analysis_type: str,
         job_attrs: dict | None = None,
-        output: str | None = None,
+        output: Path | None = None,
     ) -> Job:
         """
         Create a Hail Batch job that updates status of analysis. For status=COMPLETED,
@@ -162,7 +159,7 @@ class CpgStatusReporter(StatusReporter):
         if output:
             calc_size_cmd = f"""
         from cloudpathlib import CloudPath
-        meta['size'] = CloudPath({output}).stat().st_size
+        meta['size'] = CloudPath('{str(output)}').stat().st_size
         """
         cmd = dedent(
             f"""\

--- a/cpg_pipes/providers/cpg/status.py
+++ b/cpg_pipes/providers/cpg/status.py
@@ -66,19 +66,9 @@ class CpgStatusReporter(StatusReporter):
         """
         Create "queued" analysis and insert "in_progress" and "completed" updater jobs.
         """
-        if isinstance(output, dict):
-            raise StatusReporterError(
-                'SmdbStatusReporter only supports a single Path as output data.'
-            )
-        if isinstance(output, Resource):
-            raise StatusReporterError(
-                'Cannot use hail.batch.Resource objects with status reporter. '
-                'Only supported single Path objects'
-            )
-        
         if not jobs:
             return []
-        # Interacting with the sample metadata server:
+        
         # 1. Create a "queued" analysis
         if (aid := self.create_analysis(
             output=str(output),
@@ -105,7 +95,7 @@ class CpgStatusReporter(StatusReporter):
             status=AnalysisStatus.COMPLETED,
             analysis_type=analysis_type,
             job_attrs=target.get_job_attrs(),
-            output=output if isinstance(output, Path) else None,
+            output_path=output if isinstance(output, Path) else None,
         )
 
         if prev_jobs:
@@ -137,7 +127,7 @@ class CpgStatusReporter(StatusReporter):
         status: AnalysisStatus,
         analysis_type: str,
         job_attrs: dict | None = None,
-        output: Path | None = None,
+        output_path: Path | None = None,
     ) -> Job:
         """
         Create a Hail Batch job that updates status of analysis. For status=COMPLETED,
@@ -156,10 +146,10 @@ class CpgStatusReporter(StatusReporter):
         j.image(image_path('sm-api'))
 
         calc_size_cmd = None
-        if output:
+        if output_path:
             calc_size_cmd = f"""
         from cloudpathlib import CloudPath
-        meta['size'] = CloudPath('{str(output)}').stat().st_size
+        meta['size'] = CloudPath('{str(output_path)}').stat().st_size
         """
         cmd = dedent(
             f"""\

--- a/cpg_pipes/providers/inputs.py
+++ b/cpg_pipes/providers/inputs.py
@@ -39,7 +39,7 @@ class InputProvider(ABC):
         only_samples: list[str] | None = None,
         skip_datasets: list[str] | None = None,
         ped_files: list[Path] | None = None,
-        sequencing_type: str | None = None,
+        sequencing_type: SequencingType | None = None,
     ) -> Cohort:
         """
         Add datasets in the cohort. There exists only one cohort for
@@ -81,7 +81,8 @@ class InputProvider(ABC):
             raise InputProviderError(msg)
         
         self.populate_alignment_inputs(cohort)
-        self.filter_sequencing_type(cohort, SequencingType.parse(sequencing_type))
+        if sequencing_type:
+            self.filter_sequencing_type(cohort, sequencing_type)
         self.populate_analysis(cohort)
         self.populate_participants(cohort)
         self.populate_pedigree(cohort)

--- a/cpg_pipes/providers/status.py
+++ b/cpg_pipes/providers/status.py
@@ -59,10 +59,22 @@ class StatusReporter(ABC):
         target: Target,
         jobs: list[Job] | None = None,
         prev_jobs: list[Job] | None = None,
+        meta: dict | None = None,
     ) -> list[Job]:
         """
         Add Hail Batch jobs that update the analysis status.
         """
+
+    @abstractmethod
+    def create_analysis(
+        self,
+        output: str,
+        analysis_type: str,
+        analysis_status: str,
+        target: Target,
+        meta: dict | None = None,        
+    ) -> int:
+        """Record analysis entry"""
 
     def slack_env(self, j: Job):
         """

--- a/cpg_pipes/providers/status.py
+++ b/cpg_pipes/providers/status.py
@@ -73,7 +73,7 @@ class StatusReporter(ABC):
         analysis_status: str,
         target: Target,
         meta: dict | None = None,        
-    ) -> int:
+    ) -> int | None:
         """Record analysis entry"""
 
     def slack_env(self, j: Job):

--- a/cpg_pipes/stages/fastqc.py
+++ b/cpg_pipes/stages/fastqc.py
@@ -45,7 +45,7 @@ class FastQC(SampleStage):
         if isinstance(alignment_input, CramPath) and alignment_input.is_bam:
             logger.info(
                 f'FastQC input {sample} has CRAM inputs {alignment_input} '
-                f'for type {seq_type.value}, skipping FASTQC'
+                f'for type {seq_type}, skipping FASTQC'
             )
             return self.make_outputs(sample, skipped=True)
 

--- a/cpg_pipes/targets.py
+++ b/cpg_pipes/targets.py
@@ -209,7 +209,10 @@ class Cohort(Target):
         """
         Attributes for Hail Batch job.
         """
-        return {'samples': self.get_sample_ids()}
+        return {
+            'samples': self.get_sample_ids(),
+            'datasets': [d.name for d in self.get_datasets()], 
+        }
 
     def get_job_prefix(self) -> str:
         """
@@ -401,7 +404,11 @@ class Dataset(Target):
         """
         Attributes for Hail Batch job.
         """
-        return {'dataset': self.name, 'samples': self.get_sample_ids()}
+        return {
+            'dataset': self.name, 
+            'datasets': [self.name], 
+            'samples': self.get_sample_ids(),
+        }
 
     def get_job_prefix(self) -> str:
         """
@@ -588,7 +595,12 @@ class Sample(Target):
         """
         Attributes for Hail Batch job.
         """
-        return {'dataset': self.dataset.name, 'sample': self.id}
+        return {
+            'dataset': self.dataset.name, 
+            'datasets': [self.dataset.name], 
+            'sample': self.id,
+            'samples': [self.id],
+        }
 
     def get_job_prefix(self) -> str:
         """

--- a/cpg_pipes/targets.py
+++ b/cpg_pipes/targets.py
@@ -406,7 +406,6 @@ class Dataset(Target):
         """
         return {
             'dataset': self.name, 
-            'datasets': [self.name], 
             'samples': self.get_sample_ids(),
         }
 
@@ -597,9 +596,7 @@ class Sample(Target):
         """
         return {
             'dataset': self.dataset.name, 
-            'datasets': [self.dataset.name], 
             'sample': self.id,
-            'samples': [self.id],
         }
 
     def get_job_prefix(self) -> str:

--- a/cpg_pipes/types.py
+++ b/cpg_pipes/types.py
@@ -28,7 +28,7 @@ class SequencingType(Enum):
     ONT = 'ont'
 
     @staticmethod
-    def parse(str_val: str | None) -> Optional['SequencingType']:
+    def parse(str_val: str) -> 'SequencingType':
         """
         Parse a string into a SequencingType object.
         
@@ -37,8 +37,6 @@ class SequencingType(Enum):
         >>> SequencingType.parse('wes')
         SequencingType.EXOME
         """
-        if str_val is None:
-            return None
         str_to_val: dict[str, SequencingType] = {} 
         for val, str_vals in {
             SequencingType.GENOME: ['genome', 'wgs'],

--- a/scripts/populate_sm_analysis.py
+++ b/scripts/populate_sm_analysis.py
@@ -27,7 +27,7 @@ input_provider.populate_cohort(
     skip_samples=get_config()['workflow'].get('skip_samples'),
     only_samples=get_config()['workflow'].get('only_samples'),
     skip_datasets=get_config()['workflow'].get('skip_datasets'),
-    only_seq_type=seq_type,
+    sequencing_type=seq_type,
 )
 
 status = CpgStatusReporter(smdb)

--- a/scripts/populate_sm_analysis.py
+++ b/scripts/populate_sm_analysis.py
@@ -1,0 +1,70 @@
+"""
+Script to just populate analysis entries with status=completed in the 
+sample-metadata DB.
+"""
+
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import Namespace
+
+from cpg_pipes.providers.cpg.inputs import CpgInputProvider
+from cpg_pipes.providers.cpg.smdb import SMDB
+from cpg_pipes.providers.cpg.status import CpgStatusReporter
+from cpg_pipes.targets import Cohort
+from cpg_pipes.types import SequencingType
+from cpg_pipes.utils import exists
+
+access_level = get_config()['workflow']['access_level']
+cohort = Cohort(
+    analysis_dataset_name=get_config()['workflow']['dataset'],
+    namespace=Namespace.from_access_level(access_level),
+)
+smdb = SMDB(cohort.analysis_dataset.name)
+input_provider = CpgInputProvider(smdb)
+seq_type = SequencingType.parse(get_config()['workflow']['sequencing_type'])
+input_provider.populate_cohort(
+    cohort=cohort,
+    dataset_names=get_config()['workflow'].get('datasets'),
+    skip_samples=get_config()['workflow'].get('skip_samples'),
+    only_samples=get_config()['workflow'].get('only_samples'),
+    skip_datasets=get_config()['workflow'].get('skip_datasets'),
+    only_seq_type=seq_type,
+)
+
+status = CpgStatusReporter(smdb)
+
+for sample in cohort.get_samples():
+    if (path := sample.get_cram_path().path).exist():
+        status.create_analysis(
+            str(path),
+            analysis_type='cram',
+            analysis_status='completed',
+            target=sample,
+            meta=sample.get_job_attrs() | dict(
+                size=path.stat().st_size,
+                sequencing_type=seq_type.value,
+            ),
+        )
+    if (path := sample.get_gvcf_path().path).exist():
+        status.create_analysis(
+            str(path),
+            analysis_type='gvcf',
+            analysis_status='completed',
+            target=sample,
+            meta=sample.get_job_attrs() | dict(
+                size=path.stat().st_size,
+                sequencing_type=seq_type.value,
+            ),
+        )
+
+h = cohort.alignment_inputs_hash()
+path = cohort.analysis_dataset.path() / 'mt' / f'{h}.mt'
+if exists(path):
+    status.create_analysis(
+        str(path),
+        analysis_type='joint-calling',
+        analysis_status='completed',
+        target=cohort,
+        meta=cohort.get_job_attrs() | dict(
+            sequencing_type=seq_type.value,
+        ),
+    )

--- a/scripts/populate_sm_analysis.py
+++ b/scripts/populate_sm_analysis.py
@@ -1,6 +1,7 @@
 """
 Script to just populate analysis entries with status=completed in the 
-sample-metadata DB.
+sample-metadata DB. For back-populating old data; for new data, it should be
+populated automatically with `workflow/status_provider="smdb"` set in config.
 """
 
 from cpg_utils.config import get_config


### PR DESCRIPTION
* Support passing metadata to DB analysis entries. Metadata added into status=queued entries is the same as Hail job attributes, so just reusing that data for both purposes.
* Metadata added: sequencing_type, sample/dataset ids, sample/dataset numbers, file size.
* File size is added dynamically in status=completed updater jobs. 
* Populate type=es-index analysis.
* To support the latter, allow bare strings in `expected_output()` (file existence would be checked only for Path instances).
* Add script to post-populate analysis entries for existing files.
* Also automatically add status=completed entries when "reuse" jobs are added.