### PR TITLE
Messaging to slack: second attempt

### DIFF
--- a/cpg_pipes/dataproc_scripts/seqr/mt_to_es.py
+++ b/cpg_pipes/dataproc_scripts/seqr/mt_to_es.py
@@ -59,6 +59,7 @@ def main(
         secret_name=get_config()['elasticsearch']['password_secret_id'],
         fail_gracefully=False,
     )
+    assert password
 
     es = HailElasticsearchClient(
         host=host,

--- a/cpg_pipes/dataproc_scripts/seqr/mt_to_es.py
+++ b/cpg_pipes/dataproc_scripts/seqr/mt_to_es.py
@@ -11,11 +11,11 @@ import logging
 import math
 import click
 import hail as hl
-from cpg_utils.cloud import read_secret
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import genome_build
-from google.cloud import secretmanager
 from hail_scripts.elasticsearch.hail_elasticsearch_client import HailElasticsearchClient
+
+from cpg_pipes.utils import read_secret
 
 logger = logging.getLogger(__file__)
 

--- a/cpg_pipes/dataproc_scripts/seqr/mt_to_es.py
+++ b/cpg_pipes/dataproc_scripts/seqr/mt_to_es.py
@@ -6,16 +6,14 @@ Hail script to submit on a dataproc cluster.
 Loads the matrix table into an ElasticSearch index.
 """
 
-import os
 import logging
 import math
 import click
 import hail as hl
+from cpg_utils.cloud import read_secret
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import genome_build
 from hail_scripts.elasticsearch.hail_elasticsearch_client import HailElasticsearchClient
-
-from cpg_pipes.utils import read_secret
 
 logger = logging.getLogger(__file__)
 
@@ -59,6 +57,7 @@ def main(
     password = read_secret(
         project_id=get_config()['elasticsearch']['password_project_id'],
         secret_name=get_config()['elasticsearch']['password_secret_id'],
+        fail_gracefully=False,
     )
 
     es = HailElasticsearchClient(

--- a/cpg_pipes/jobs/multiqc.py
+++ b/cpg_pipes/jobs/multiqc.py
@@ -16,6 +16,7 @@ from cpg_pipes import Path
 from cpg_pipes.hb.command import wrap_command
 from cpg_pipes.hb.resources import STANDARD
 from cpg_pipes.providers.status import StatusReporter
+from cpg_pipes.slack import slack_message_cmd
 
 logger = logging.getLogger(__file__)
 
@@ -98,9 +99,10 @@ def multiqc(
         cmd += '\n' + f'echo "HTML URL: {out_html_url}"'
 
     if out_html_url and status_reporter:
-        status_reporter.slack_env(j)
-        text = f'*[{dataset_name}]* <{out_html_url}|MultiQC report>'
-        cmd += '\n' + status_reporter.slack_message_cmd(text=text)
+        slack_message_cmd(
+            j, 
+            text=f'*[{dataset_name}]* <{out_html_url}|MultiQC report>'
+        )
 
     j.command(wrap_command(cmd, setup_gcp=True))
     b.write_output(j.html, str(out_html_path))

--- a/cpg_pipes/jobs/scripts/check_pedigree.py
+++ b/cpg_pipes/jobs/scripts/check_pedigree.py
@@ -56,8 +56,8 @@ def main(
         pedlog=pedlog,
     )
 
-    slack_token = os.environ.get('SLACK_TOKEN')
     slack_channel = os.environ.get('SLACK_CHANNEL')
+    slack_token = os.environ.get('SLACK_TOKEN')
     if slack_token and slack_channel:
         from slack_sdk.errors import SlackApiError
         from slack_sdk import WebClient

--- a/cpg_pipes/providers/cpg/status.py
+++ b/cpg_pipes/providers/cpg/status.py
@@ -2,11 +2,9 @@
 CPG implementation of status reporter.
 """
 
-import os
 from textwrap import dedent
 
 from cpg_utils.hail_batch import image_path
-from google.cloud import secretmanager
 from hailtop.batch.job import Job
 from hailtop.batch import Batch, Resource
 
@@ -24,34 +22,12 @@ from .smdb import SMDB, SmdbError
 class CpgStatusReporter(StatusReporter):
     """
     Job status reporter. Works through creating and updating sample-metadata
-    database Analysis entries. It is also able to send notifications to Slack.
-    To enable that, create a channel, set `CPG_SLACK_CHANNEL` and `CPG_SLACK_TOKEN` 
-    environment  variables, and add "Seqr Loader" app into a channel with:
-
-    /invite @Seqr Loader
+    database Analysis entries.
     """
 
-    def __init__(
-        self, 
-        smdb: SMDB, 
-        slack_channel: str | None = None,
-    ):
+    def __init__(self, smdb: SMDB):
         super().__init__()
         self.smdb = smdb
-        self.slack_channel = slack_channel or os.environ.get('CPG_SLACK_CHANNEL')
-        self.slack_token = os.environ.get('CPG_SLACK_TOKEN')
-        if self.slack_channel and not self.slack_token:
-            project_id = 'seqr-308602'
-            secret_name = 'slack-seqr-loader-token'
-            slack_token_secret = (
-                f'projects/{project_id}/secrets/{secret_name}/versions/latest'
-            )
-            secret_manager = secretmanager.SecretManagerServiceClient()
-            # noinspection PyTypeChecker
-            response = secret_manager.access_secret_version(
-                request={'name': slack_token_secret}
-            )
-            self.slack_token = response.payload.data.decode('UTF-8')
 
     def add_updaters_jobs(
         self,

--- a/cpg_pipes/providers/status.py
+++ b/cpg_pipes/providers/status.py
@@ -46,10 +46,6 @@ class StatusReporter(ABC):
     Status reporter
     """
 
-    def __init__(self):
-        self.slack_channel = None
-        self.slack_token = None
-
     @abstractmethod
     def add_updaters_jobs(
         self,
@@ -75,39 +71,3 @@ class StatusReporter(ABC):
         meta: dict | None = None,        
     ) -> int | None:
         """Record analysis entry"""
-
-    def slack_env(self, j: Job):
-        """
-        Add environment variables that configure Slack reporter.
-        """
-        if self.slack_channel and self.slack_token:
-            j.env('SLACK_CHANNEL', self.slack_channel)
-            j.env('SLACK_TOKEN', self.slack_token)
-
-    def slack_message_cmd(
-        self,
-        text: str | None = None,
-        data: dict[str, str] | None = None,
-    ) -> str:
-        """
-        Make a bash command that prepares and sends a Slack message.
-        Message can be constructed from a dict `data`, or can be passed directly 
-        as text (`text`). In either case, strings can use Slack `mrkdwn` 
-        for formatting: https://api.slack.com/reference/surfaces/formatting
-        """
-        if not self.slack_channel or not self.slack_token:
-            return ''
-        msg = ''
-        if data:
-            msg += '\\n'.join(f'{k}: {v}' for k, v in data.items())
-        if text:
-            msg += f'\\n{text}'
-        if not msg:
-            return ''
-        return f"""
-        curl -X POST \
-        -H "Authorization: Bearer $SLACK_TOKEN" \
-        -H "Content-type: application/json" \
-        -d '{{"channel": "'$SLACK_CHANNEL'", "text": "{msg}"}}' \
-        https://slack.com/api/chat.postMessage
-        """

--- a/cpg_pipes/slack.py
+++ b/cpg_pipes/slack.py
@@ -9,12 +9,12 @@ configuration values are set.
 """
 
 from textwrap import dedent
-from hailtop.batch.job import Job
 
+from cpg_utils.cloud import read_secret
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import copy_common_env
 
-from cpg_pipes.utils import read_secret
+from hailtop.batch.job import Job
 
 
 def get_token() -> str:
@@ -31,6 +31,7 @@ def get_token() -> str:
     token = read_secret(
         project_id=token_project_id,
         secret_name=token_secret_id,
+        fail_gracefully=False,
     )
     assert token
     return token

--- a/cpg_pipes/slack.py
+++ b/cpg_pipes/slack.py
@@ -1,0 +1,80 @@
+"""
+Sending notifications to Slack. To enable, create a channel, add "Seqr Loader" app 
+into a channel with:
+
+/invite @Seqr Loader
+
+Make sure `slack/channel`, `slack/token_secret_id`, and `slack/token_project_id` 
+configuration values are set.
+"""
+
+from textwrap import dedent
+from hailtop.batch.job import Job
+
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import copy_common_env
+
+from cpg_pipes.utils import read_secret
+
+
+def get_token() -> str:
+    """
+    Returns Slack token.
+    """
+    token_secret_id = get_config()['slack'].get('token_secret_id')
+    token_project_id = get_config()['slack'].get('token_project_id')
+    if not token_secret_id or not token_project_id:
+        raise ValueError(
+            '`slack.token_secret_id` and `slack.token_project_id` '
+            'must be set in config to retrieve Slack token'
+        )
+    token = read_secret(
+        project_id=token_project_id,
+        secret_name=token_secret_id,
+    )
+    assert token
+    return token
+
+
+def slack_env(j: Job):
+    """
+    Add environment variables that configure Slack reporter.
+    """
+    if not (channel := get_config().get('slack', {}).get('channel')):
+        return None
+    copy_common_env(j)
+    j.env('SLACK_CHANNEL', channel)
+    j.env('SLACK_TOKEN', get_token())
+
+
+def slack_message_cmd(
+    j: Job,
+    text: str | None = None,
+    data: dict[str, str] | None = None,
+):
+    """
+    Make a bash command that prepares and sends a Slack message.
+    Message can be constructed from a dict `data`, or can be passed directly 
+    as text (`text`). In either case, strings can use Slack `mrkdwn` 
+    for formatting: https://api.slack.com/reference/surfaces/formatting
+    
+    Assumes `workflow/slack_channel` configuration parameter is set, as well as 
+    CPG_SLACK_TOKEN environment variable.
+    """
+    if not (channel := get_config()['slack'].get('channel')):
+        return ''
+    msg = ''
+    if data:
+        msg += '\\n'.join(f'{k}: {v}' for k, v in data.items())
+    if text:
+        msg += f'\\n{text}'
+    if not msg:
+        return ''
+    slack_env(j)
+    j.command(dedent(f"""
+    curl -X POST \
+    -H "Authorization: Bearer {get_token()}" \
+    -H "Content-type: application/json" \
+    -d '{{"channel": "'{channel}'", "text": "{msg}"}}' \
+    https://slack.com/api/chat.postMessage
+    """))

--- a/cpg_pipes/utils.py
+++ b/cpg_pipes/utils.py
@@ -97,18 +97,3 @@ def can_reuse(
 
     logger.debug(f'Reusing existing {path}. Use --overwrite to overwrite')
     return True
-
-
-def read_secret(project_id: str, secret_name: str) -> str:
-    """
-    Reads the latest version of a GCP Secret Manager secret.
-
-    Unlike cpg_utils.cloud.read_secret, crashes if the secret can not be read.
-    """
-
-    secret_manager = secretmanager.SecretManagerServiceClient()
-    secret_path = secret_manager.secret_version_path(project_id, secret_name, 'latest')
-
-    # noinspection PyTypeChecker
-    response = secret_manager.access_secret_version(request={'name': secret_path})
-    return response.payload.data.decode('UTF-8')

--- a/cpg_pipes/utils.py
+++ b/cpg_pipes/utils.py
@@ -100,9 +100,11 @@ def can_reuse(
 
 
 def read_secret(project_id: str, secret_name: str) -> str:
-    """Reads the latest version of a GCP Secret Manager secret.
+    """
+    Reads the latest version of a GCP Secret Manager secret.
 
-    Unlike cpg_utils.cloud, raises an exception if the secret can not be read"""
+    Unlike cpg_utils.cloud.read_secret, crashes if the secret can not be read.
+    """
 
     secret_manager = secretmanager.SecretManagerServiceClient()
     secret_path = secret_manager.secret_version_path(project_id, secret_name, 'latest')

--- a/pipelines/configs/seqr.toml
+++ b/pipelines/configs/seqr.toml
@@ -1,29 +1,30 @@
 [workflow]
 access_level = 'full'
 dataset = 'seqr'
-datasets = [
-    'acute-care', 
-    'perth-neuro', 
-    'ravenscroft-rdstudy', 
-    'circa', 
-    'heartkids',
-    'ohmr3-mendelian', 
-    'ohmr4-epilepsy',
-    'rdnow',
-    'mito-disease',
-    'ravenscroft-arch',
-    'hereditary-neuro',
-]
+datasets = ['perth-neuro']
+#datasets = [
+#    'acute-care', 
+#    'perth-neuro', 
+#    'ravenscroft-rdstudy', 
+#    'circa', 
+#    'heartkids',
+#    'ohmr3-mendelian', 
+#    'ohmr4-epilepsy',
+#    'rdnow',
+#    'mito-disease',
+#    'ravenscroft-arch',
+#    'hereditary-neuro',
+#]
+only_samples = ['CPG13409']
 skip_samples = [
   'CPG11783',   # acute-care, no FASTQ data
   'CPG13326',   # perth-neuro, no FASTQ data: https://github.com/populationgenomics/seqr-private/issues/2
 #  'CPG200014',  # heartkids, https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1654038000773069
 ]
 check_inputs = true
-skip_samples_with_missing_input = false
+skip_samples_with_missing_input = true
 keep_scratch = true
-#status_reporter = 'smdb'
-#slack_channel: 'seqr-loader'
+status_reporter = 'smdb'
 #skip_samples_stages:
 #  VerifyBamId: [CPG13409]  # https://batch.hail.populationgenomics.org.au/batches/56236/jobs/372
 sequencing_type = 'genome'
@@ -37,3 +38,8 @@ password_project_id = 'seqr-308602'
 pool_label = 'seqr'
 billing_project = 'seqr'
 bucket = 'gs://cpg-seqr-hail'
+
+[slack]
+channel = 'seqr-loader-test'
+token_secret_id = 'slack-seqr-loader-token'
+token_project_id = 'seqr-308602'

--- a/pipelines/configs/seqr.toml
+++ b/pipelines/configs/seqr.toml
@@ -1,28 +1,25 @@
 [workflow]
 access_level = 'full'
 dataset = 'seqr'
-datasets = ['perth-neuro']
-#datasets = [
-#    'acute-care', 
-#    'perth-neuro', 
-#    'ravenscroft-rdstudy', 
-#    'circa', 
-#    'heartkids',
-#    'ohmr3-mendelian', 
-#    'ohmr4-epilepsy',
-#    'rdnow',
-#    'mito-disease',
-#    'ravenscroft-arch',
-#    'hereditary-neuro',
-#]
-only_samples = ['CPG13409']
+datasets = [
+    'acute-care', 
+    'perth-neuro', 
+    'ravenscroft-rdstudy', 
+    'circa', 
+    'heartkids',
+    'ohmr3-mendelian', 
+    'ohmr4-epilepsy',
+    'rdnow',
+    'mito-disease',
+    'ravenscroft-arch',
+    'hereditary-neuro',
+]
 skip_samples = [
   'CPG11783',   # acute-care, no FASTQ data
   'CPG13326',   # perth-neuro, no FASTQ data: https://github.com/populationgenomics/seqr-private/issues/2
-#  'CPG200014',  # heartkids, https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1654038000773069
 ]
 check_inputs = true
-skip_samples_with_missing_input = true
+skip_samples_with_missing_input = false
 keep_scratch = true
 status_reporter = 'smdb'
 #skip_samples_stages:


### PR DESCRIPTION
Decoupling slack messaging from status reporter. Configuring through the global config.

Expects `slack` section like this:

```
[slack]
channel = 'seqr-loader-test'
token_secret_id = 'slack-seqr-loader-token'
token_project_id = 'seqr-308602'
```

If `channel` is specified, would check the secret provided for a token. 

Adds `slack_message_cmd(j, text)` function that adds a command to a job that sends `text` to the requested channel.
