### PR TITLE
Calculate storage for joint calling from number of samples

### DIFF
--- a/jobs/genotype.py
+++ b/jobs/genotype.py
@@ -84,10 +84,10 @@ def haplotype_caller(
         if intervals is None:
             intervals_j, intervals = get_intervals(
                 b=b,
-                source_intervals_path=get_config()['workflow'].get('intervals_path'),
                 scatter_count=scatter_count,
+                source_intervals_path=get_config()['workflow'].get('intervals_path'),
                 job_attrs=job_attrs,
-                output_prefix=tmp_prefix / 'intervals',
+                output_prefix=tmp_prefix / f'intervals_{scatter_count}',
             )
             if intervals_j:
                 jobs.append(intervals_j)

--- a/jobs/vep.py
+++ b/jobs/vep.py
@@ -30,9 +30,9 @@ def vep_jobs(
     b: Batch,
     vcf_path: Path,
     tmp_prefix: Path,
+    gvcf_count: int,
     out_path: Path | None = None,
     overwrite: bool = False,
-    scatter_count: int = 50,
     job_attrs: dict | None = None,
 ) -> list[Job]:
     """
@@ -51,14 +51,19 @@ def vep_jobs(
         **{'vcf.gz': str(vcf_path), 'vcf.gz.tbi': str(vcf_path) + '.tbi'}
     )
 
-    scatter_count = max(scatter_count, 2)
+    scatter_count = 50
+    if gvcf_count > 300:
+        scatter_count = 100
+    if gvcf_count > 1000:
+        scatter_count = 200
+
     parts_bucket = tmp_prefix / 'vep' / 'parts'
     part_files = []
 
     intervals_j, intervals = get_intervals(
         b=b,
         scatter_count=scatter_count,
-        output_prefix=tmp_prefix,
+        output_prefix=tmp_prefix / f'intervals_{scatter_count}',
     )
     if intervals_j:
         jobs.append(intervals_j)
@@ -92,6 +97,7 @@ def vep_jobs(
         if vep_one_job:
             jobs.append(vep_one_job)
 
+    gather_j: Job | None = None
     if to_hail_table:
         gather_j = gather_vep_json_to_ht(
             b=b,

--- a/stages/vep.py
+++ b/stages/vep.py
@@ -39,12 +39,6 @@ class Vep(CohortStage):
         """
         Submit jobs.
         """
-        if get_config()['workflow']['sequencing_type'] == 'genome':
-            scatter_count = max(2, len(cohort.get_samples()) // 10)
-        else:
-            assert get_config()['workflow']['sequencing_type'] == 'exome'
-            scatter_count = max(2, len(cohort.get_samples()) // 50)
-
         jobs = vep.vep_jobs(
             self.b,
             vcf_path=inputs.as_path(cohort, stage=Vqsr, id='siteonly'),
@@ -52,6 +46,6 @@ class Vep(CohortStage):
             tmp_prefix=to_path(self.expected_outputs(cohort)['prefix']),
             overwrite=not get_config()['workflow'].get('check_intermediates'),
             job_attrs=self.get_job_attrs(),
-            scatter_count=scatter_count,
+            gvcf_count=len(cohort.get_samples()),
         )
         return self.make_outputs(cohort, self.expected_outputs(cohort), jobs)

--- a/test/test_workflow_dry.py
+++ b/test/test_workflow_dry.py
@@ -117,4 +117,4 @@ def test_workflow_dry(mocker: MockFixture, tmpdir: str):
         get_batch().job_by_tool['picard CollectVariantCallingMetrics']['job_n']
         == len(cohort.get_samples()) + 1
     )
-    assert get_batch().job_by_tool['gatk GenomicsDBImport']['job_n'] == 2
+    assert get_batch().job_by_tool['gatk GenomicsDBImport']['job_n'] == 50


### PR DESCRIPTION
Implement a function to set storage for joint-calling jobs, to fit a pVCF. The constants are chosen a bit randomly, based on observations, so the function might need more refinement. But it serves the purpose to start with: increase storage with the number of samples, but sublinearly.