### PR TITLE
Use extras to install cpg_utils[workflows]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cpg-utils[workflows]
+cpg-utils
 analysis-runner
 cpg-gnomad
 pandas


### PR DESCRIPTION
`cpg_utils` uses extras to installs the `workflows` module: https://github.com/populationgenomics/cpg-utils/blob/main/setup.py#L23-L33 - the reason for that is that we want to avoid circular dependencies, with `cpg_utils.workflows` depending on `sample_metadata`, and `sample_metadata` depending on `cpg_utils`. So adjusting `requirements.txt` here accordingly.