### PR TITLE
Pass job attributes everywhere in seqr-loader workflow

### DIFF
--- a/jobs/joint_genotyping.py
+++ b/jobs/joint_genotyping.py
@@ -175,6 +175,7 @@ def make_joint_genotyping_jobs(
             out_vcf_path=out_vcf_path,
             site_only=False,
             gvcf_count=len(gvcf_by_sid),
+            job_attrs=job_attrs,
         )
         if gather_j:
             gather_j.name = f'Joint genotyping: {gather_j.name}'
@@ -360,6 +361,7 @@ def _add_joint_genotyper_job(
             }
         )
     job_name = f'Joint genotyping: {tool.name}'
+    job_attrs = (job_attrs or {}) | {'tool': f'gatk {tool.name}'}
     j = b.new_job(job_name, job_attrs)
     j.image(image_path('gatk'))
     res = STANDARD.request_resources(ncpu=4)
@@ -507,6 +509,7 @@ def _add_make_sitesonly_job(
         )
 
     job_name = 'Joint genotyping: MakeSitesOnlyVcf'
+    job_attrs = (job_attrs or {}) | {'tool': 'gatk MakeSitesOnlyVcf'}
     j = b.new_job(job_name, job_attrs)
     j.image(image_path('gatk'))
     j.memory('8G')

--- a/jobs/picard.py
+++ b/jobs/picard.py
@@ -78,7 +78,7 @@ def get_intervals(
 
     j = b.new_job(
         f'Make {scatter_count} intervals for {sequencing_type}',
-        attributes=(job_attrs or {}) | dict(tool='picard_IntervalListTools'),
+        attributes=(job_attrs or {}) | dict(tool='picard IntervalListTools'),
     )
     j.image(image_path('picard'))
     STANDARD.set_resources(j, storage_gb=16, mem_gb=2)

--- a/jobs/vep.py
+++ b/jobs/vep.py
@@ -44,7 +44,7 @@ def vep_jobs(
         assert str(out_path).endswith('.vcf.gz'), out_path
 
     if out_path and can_reuse(out_path, overwrite):
-        return [b.new_job('VEP [reuse]', job_attrs)]
+        return []
 
     jobs: list[Job] = []
     vcf = b.read_input_group(
@@ -63,6 +63,7 @@ def vep_jobs(
     intervals_j, intervals = get_intervals(
         b=b,
         scatter_count=scatter_count,
+        job_attrs=job_attrs,
         output_prefix=tmp_prefix / f'intervals_{scatter_count}',
     )
     if intervals_j:
@@ -128,7 +129,7 @@ def gather_vep_json_to_ht(
     Parse results from VEP with annotations formatted in JSON,
     and write into a Hail Table using a Batch job.
     """
-    j = b.new_job('VEP json to Hail table', job_attrs)
+    j = b.new_job('VEP json to Hail table', (job_attrs or {}) | dict(tool='hail query'))
     j.image(image_path('hail'))
     cmd = query_command(
         vep_module,
@@ -156,7 +157,7 @@ def vep_one(
     if out_path and can_reuse(out_path, overwrite):
         return None
 
-    j = b.new_job('VEP', job_attrs)
+    j = b.new_job('VEP', (job_attrs or {}) | dict(tool='vep'))
     j.image(image_path('vep'))
     STANDARD.set_resources(j, storage_gb=50, mem_gb=50, ncpu=16)
 

--- a/jobs/vqsr.py
+++ b/jobs/vqsr.py
@@ -246,6 +246,7 @@ def make_vqsr_jobs(
             b,
             tranches=snps_tranches,
             disk_size=small_disk,
+            job_attrs=job_attrs,
         ).out_tranches
 
         assert isinstance(snp_gathered_tranches, hb.ResourceFile)

--- a/stages/seqr_loader.py
+++ b/stages/seqr_loader.py
@@ -82,7 +82,7 @@ class AnnotateCohort(CohortStage):
                 'query_modules',
             ],
         )
-        j.attributes = self.get_job_attrs(cohort) | {'tool': 'hail dataproc'}
+        j.attributes = self.get_job_attrs(cohort) | {'tool': 'hailctl dataproc'}
 
         return self.make_outputs(
             cohort,
@@ -152,7 +152,7 @@ class AnnotateDataset(DatasetStage):
                 'query_modules',
             ],
         )
-        j.attributes = self.get_job_attrs(dataset) | {'tool': 'hail dataproc'}
+        j.attributes = self.get_job_attrs(dataset) | {'tool': 'hailctl dataproc'}
 
         return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=[j])
 
@@ -234,6 +234,6 @@ class MtToEs(DatasetStage):
             pyfiles=['seqr-loading-pipelines/hail_scripts'],
         )
         j._preemptible = False
-        j.attributes = self.get_job_attrs(dataset) | {'tool': 'hail dataproc'}
+        j.attributes = (j.attributes or {}) | {'tool': 'hailctl dataproc'}
         jobs = [j]
         return self.make_outputs(dataset, data=index_name, jobs=jobs)


### PR DESCRIPTION
Making submission statistics nice and clean, and facilitating dry tests.