### PR TITLE
GATK-SV: GatherSampleEvidence and EvidenceQC fixes

### DIFF
--- a/configs/acute-care-test.toml
+++ b/configs/acute-care-test.toml
@@ -17,3 +17,6 @@ only_samples = [
 
 [hail]
 billing_project = 'acute-care'
+
+[references.broad]
+bwa_ref_fasta = 'Homo_sapiens_assembly38.fasta'

--- a/configs/gatk-sv.toml
+++ b/configs/gatk-sv.toml
@@ -63,9 +63,10 @@ protein_coding_gtf = "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resourc
 prefix = 'sv-resources/ref-panel'
 qc_definitions = "1KG/v2/single_sample.qc_definitions.tsv"
 contig_ploidy_model_tar = "1KG/v2/gcnv/ref_panel_1kg_v2-contig-ploidy-model.tar.gz"
-ref_panel_PE_file_tmpl = "1KG/v2/{sample}.disc.txt.gz"
-ref_panel_SE_file_tmpl = "1KG/v2/{sample}.split.txt.gz"
 model_tar_tmpl = "1KG/v2/gcnv/model_files/ref_panel_1kg_v2-gcnv-model-shard-{shard}.tar.gz"
+ref_panel_PE_file_tmpl = "tws_SVEvidence/pe/{sample}.pe.txt.gz"
+ref_panel_SR_file_tmpl = "tws_SVEvidence/sr/{sample}.sr.txt.gz"
+ref_panel_SD_file_tmpl = "tws_SVEvidence/sd/{sample}.sd.txt.gz"
 
 [sv_ref_panel]
 ref_panel_samples = ["HG00096", "HG00129", "HG00140", "HG00150", "HG00187", "HG00239", "HG00277", "HG00288", "HG00337", "HG00349", "HG00375", "HG00410", "HG00457", "HG00557", "HG00599", "HG00625", "HG00701", "HG00740", "HG00844", "HG01060", "HG01085", "HG01112", "HG01275", "HG01325", "HG01344", "HG01356", "HG01384", "HG01393", "HG01396", "HG01474", "HG01507", "HG01572", "HG01607", "HG01709", "HG01747", "HG01790", "HG01794", "HG01799", "HG01861", "HG01874", "HG01880", "HG01885", "HG01958", "HG01982", "HG02002", "HG02010", "HG02019", "HG02020", "HG02069", "HG02085", "HG02186", "HG02221", "HG02235", "HG02272", "HG02275", "HG02299", "HG02332", "HG02367", "HG02374", "HG02489", "HG02490", "HG02491", "HG02586", "HG02588", "HG02611", "HG02620", "HG02642", "HG02648", "HG02658", "HG02855", "HG02953", "HG03007", "HG03009", "HG03085", "HG03099", "HG03100", "HG03111", "HG03369", "HG03370", "HG03436", "HG03449", "HG03472", "HG03476", "HG03556", "HG03604", "HG03649", "HG03684", "HG03694", "HG03709", "HG03722", "HG03727", "HG03744", "HG03756", "HG03789", "HG03850", "HG03864", "HG03872", "HG03888", "HG04118", "HG04158", "HG04161", "HG04183", "NA06984", "NA10847", "NA11894", "NA12340", "NA12489", "NA12872", "NA18499", "NA18507", "NA18530", "NA18539", "NA18549", "NA18553", "NA18560", "NA18638", "NA18923", "NA18941", "NA18945", "NA18956", "NA18995", "NA19001", "NA19035", "NA19062", "NA19102", "NA19143", "NA19184", "NA19350", "NA19351", "NA19377", "NA19443", "NA19449", "NA19661", "NA19678", "NA19679", "NA19684", "NA19746", "NA19795", "NA19818", "NA19913", "NA20126", "NA20320", "NA20321", "NA20346", "NA20509", "NA20510", "NA20522", "NA20752", "NA20764", "NA20802", "NA20845", "NA20869", "NA20895", "NA21102", "NA21122", "NA21133"]

--- a/gatk_sv/README.md
+++ b/gatk_sv/README.md
@@ -5,7 +5,7 @@ and importing results to Seqr, using the [cpg_utils/workflows library](https://g
 
 ## Usage
 
-To run the workflow, run the `gatk_sv.py` script, and pass the following TOML configs directly as command line arguments. Replace `acute-care-test.toml` with another config if you want to process a different dataset.
+To launch the workflow, run the `gatk_sv.py` script, and pass the following TOML configs directly as command line arguments. Replace `acute-care-test.toml` with another config if you want to process a different dataset.
 
 ```bash
 python gatk_sv.py \

--- a/gatk_sv/README.md
+++ b/gatk_sv/README.md
@@ -1,11 +1,11 @@
 # GATK-SV
 
 Hail Batch driver for running the Broad's [GATK-SV workflow](https://github.com/broadinstitute/gatk-sv),
-and importing results to Seqr.
+and importing results to Seqr, using the [cpg_utils/workflows library](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/workflows/README.md).
 
 ## Usage
 
-To use, run the `gatk_sv.py` script, and pass the following TOML configs directly as command line arguments. Replace `acute-care-test.toml` with another config if you want to process a different dataset.
+To run the workflow, run the `gatk_sv.py` script, and pass the following TOML configs directly as command line arguments. Replace `acute-care-test.toml` with another config if you want to process a different dataset.
 
 ```bash
 python gatk_sv.py \


### PR DESCRIPTION
- EvidenceQC requires evidence files to be named with a specific ending,
- Using the WDL repo SHA with disabled localizaion,
- Adding SD files as outputs of GatherSampleEvidence,
- Use ref_panels with SD files,
- Enable Scramble,
- Pass CRAM fasta for CRAM->BAM to work properly,
- Pass saved outputs instead of resource files.

Also, add link to the cpg_utils/workflows docs to the README.