### PR TITLE
GatherBatchEvidence: add ref panel samples to PED

### DIFF
--- a/configs/gatk-sv.toml
+++ b/configs/gatk-sv.toml
@@ -61,6 +61,7 @@ protein_coding_gtf = "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resourc
 
 [references.broad.sv.ref_panel]
 prefix = 'sv-resources/ref-panel'
+ped_file = 'ped_1kgp_all.ped'
 qc_definitions = "1KG/v2/single_sample.qc_definitions.tsv"
 contig_ploidy_model_tar = "1KG/v2/gcnv/ref_panel_1kg_v2-contig-ploidy-model.tar.gz"
 model_tar_tmpl = "1KG/v2/gcnv/model_files/ref_panel_1kg_v2-gcnv-model-shard-{shard}.tar.gz"

--- a/configs/gatk-sv.toml
+++ b/configs/gatk-sv.toml
@@ -61,7 +61,8 @@ protein_coding_gtf = "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resourc
 
 [references.broad.sv.ref_panel]
 prefix = 'sv-resources/ref-panel'
-ped_file = 'ped_1kgp_all.ped'
+ped_file = '1KG/v1/ped/1kg_ref_panel_v1.ped'
+ref_panel_bincov_matrix = '1KG/v1/merged_evidence/ref_panel_1kg_v1.bincov.bed.gz'
 qc_definitions = "1KG/v2/single_sample.qc_definitions.tsv"
 contig_ploidy_model_tar = "1KG/v2/gcnv/ref_panel_1kg_v2-contig-ploidy-model.tar.gz"
 model_tar_tmpl = "1KG/v2/gcnv/model_files/ref_panel_1kg_v2-gcnv-model-shard-{shard}.tar.gz"

--- a/gatk_sv/gatk_sv.py
+++ b/gatk_sv/gatk_sv.py
@@ -384,16 +384,18 @@ class GatherBatchEvidence(DatasetStage):
         """Add jobs to Batch"""
         sids = dataset.get_sample_ids()
 
+        # PED file must include reference panel samples as well, so concatenating
+        # the `dataset` PED file with the reference panel PED file:
         combined_ped_path = (
-            self.tmp_prefix()
+            self.tmp_prefix
             / 'ped_with_ref_panel'
-            / f'{self.alignment_inputs_hash()}.ped'
+            / f'{dataset.alignment_inputs_hash()}.ped'
         )
         with combined_ped_path.open('w') as out:
             with dataset.write_ped_file().open() as f:
                 out.write(f.read())
-            with get_config()['sv_ref_panel']['ped_file'].open() as f:
-                # doesn't have any header, so can safely concatenate:
+            # THe ref panel PED doesn't have any header, so can safely concatenate:
+            with reference_path('broad/sv/ref_panel/ped_file').open() as f:
                 out.write(f.read())
 
         input_by_sid = inputs.as_dict_by_target(stage=GatherSampleEvidence)

--- a/gatk_sv/gatk_sv.py
+++ b/gatk_sv/gatk_sv.py
@@ -47,41 +47,6 @@ def get_images(keys: list[str]) -> dict[str, str]:
     return {k: image_path(k) for k in get_config()['images'].keys() if k in keys}
 
 
-def get_gcnv_models() -> dict[str, str | list[str]]:
-    """
-    Dict of WDL inputs with gCNV models
-    """
-    res: dict[str, str | list[str]] = {
-        'ref_panel_samples': get_config()['sv_ref_panel']['ref_panel_samples'],
-        'contig_ploidy_model_tar': str(
-            reference_path('broad/sv/ref_panel/contig_ploidy_model_tar')
-        ),
-        'gcnv_model_tars': [
-            str(reference_path('broad/sv/ref_panel/model_tar_tmpl')).format(shard=i)
-            for i in range(get_config()['sv_ref_panel']['model_tar_cnt'])
-        ],
-        'ref_panel_PE_files': [
-            str(reference_path('broad/sv/ref_panel/ref_panel_PE_file_tmpl')).format(
-                sample=s
-            )
-            for s in get_config()['sv_ref_panel']['ref_panel_samples']
-        ],
-        'ref_panel_SR_files': [
-            str(reference_path('broad/sv/ref_panel/ref_panel_SR_file_tmpl')).format(
-                sample=s
-            )
-            for s in get_config()['sv_ref_panel']['ref_panel_samples']
-        ],
-        'ref_panel_SD_files': [
-            str(reference_path('broad/sv/ref_panel/ref_panel_SD_file_tmpl')).format(
-                sample=s
-            )
-            for s in get_config()['sv_ref_panel']['ref_panel_samples']
-        ],
-    }
-    return res
-
-
 def get_references(keys: list[str | dict[str, str]]) -> dict[str, str | list[str]]:
     """
     Dict of WDL inputs with reference file paths.
@@ -432,7 +397,40 @@ class GatherBatchEvidence(DatasetStage):
         input_dict |= {
             'ref_dict': str(reference_path(f'broad/ref_fasta').with_suffix('.dict')),
         }
-        input_dict |= get_gcnv_models()
+
+        # reference panel gCNV models
+        input_dict |= {
+            'ref_panel_samples': get_config()['sv_ref_panel']['ref_panel_samples'],
+            'ref_panel_bincov_matrix': str(
+                reference_path('broad/sv/ref_panel/ref_panel_bincov_matrix')
+            ),
+            'contig_ploidy_model_tar': str(
+                reference_path('broad/sv/ref_panel/contig_ploidy_model_tar')
+            ),
+            'gcnv_model_tars': [
+                str(reference_path('broad/sv/ref_panel/model_tar_tmpl')).format(shard=i)
+                for i in range(get_config()['sv_ref_panel']['model_tar_cnt'])
+            ],
+            'ref_panel_PE_files': [
+                str(reference_path('broad/sv/ref_panel/ref_panel_PE_file_tmpl')).format(
+                    sample=s
+                )
+                for s in get_config()['sv_ref_panel']['ref_panel_samples']
+            ],
+            'ref_panel_SR_files': [
+                str(reference_path('broad/sv/ref_panel/ref_panel_SR_file_tmpl')).format(
+                    sample=s
+                )
+                for s in get_config()['sv_ref_panel']['ref_panel_samples']
+            ],
+            'ref_panel_SD_files': [
+                str(reference_path('broad/sv/ref_panel/ref_panel_SD_file_tmpl')).format(
+                    sample=s
+                )
+                for s in get_config()['sv_ref_panel']['ref_panel_samples']
+            ],
+        }
+
         input_dict |= get_images(
             [
                 'sv_base_mini_docker',

--- a/gatk_sv/sync_references.sh
+++ b/gatk_sv/sync_references.sh
@@ -5,3 +5,7 @@ Sync the Broad reference resources into the corresponding CPG bucket.
 gsutil rsync -r \
   gs://gatk-sv-resources-public/hg38/v0/sv-resources \
   gs://cpg-reference/hg38/v0/sv-resources
+
+gsutil cp \
+  gs://broad-dsde-methods-eph/ped_1kgp_all.ped \
+  gs://cpg-reference/hg38/v0/sv-resources/ref-panel/


### PR DESCRIPTION
Attempt to fix https://batch.hail.populationgenomics.org.au/batches/376707

GatherBatchEvidence [calls SubsetPedFile](https://github.com/broadinstitute/gatk-sv/blob/64638188a18476f4dbc19c0f8b91f5faa1de3d1e/wdl/GatherBatchEvidence.wdl#L214-L222) which subsets `ref_panel_samples` from `ped_file`, so that means that the `ped_file` is expected to contain ref panel samples as well. Copying the ref panel (=1KG) PED file from `gs://broad-dsde-methods-eph/ped_1kgp_all.ped` (got pointer from https://github.com/broadinstitute/gatk-sv/blob/57f5b05c3837bf9241564722386b6e8ed6c7f160/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl) and making sure we are concatenating both our dataset's PED file and the ref panel PED file.

Testing: https://batch.hail.populationgenomics.org.au/batches/376985