### PR TITLE
Use https for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "seqr-loading-pipelines"]
 	path = seqr-loading-pipelines
-	url = git@github.com:populationgenomics/seqr-loading-pipelines.git
+	url = https://github.com/populationgenomics/seqr-loading-pipelines.git


### PR DESCRIPTION
For SSH, a key is required, so trying a web URL instead.

Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1665361390281969