### PR TITLE
Path scheme for unittests

### DIFF
--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -27,7 +27,6 @@ def _set_config(results_prefix: Path, extra_conf: dict | None = None):
         d,
         {
             'workflow': {
-                'local_dir': str(results_prefix),
                 'dataset_gcp_project': 'thousand-genomes',
                 'dataset': 'thousand-genomes',
                 'access_level': 'test',
@@ -37,6 +36,14 @@ def _set_config(results_prefix: Path, extra_conf: dict | None = None):
                 'reference_prefix': str(
                     to_path(__file__).parent / 'data' / 'large_cohort' / 'reference'
                 ),
+            },
+            'path_schemes': {
+                'local': {
+                    'default': f'{results_prefix}',
+                    'tmp': f'{results_prefix}/tmp',
+                    'analysis': f'{results_prefix}/analysis',
+                    'web': f'{results_prefix}/web',
+                }
             },
             'large_cohort': {
                 'sample_qc_cutoffs': {
@@ -87,6 +94,12 @@ def test_large_cohort(mocker: MockFixture):
         s.gvcf = GvcfPath(gvcf_path)
 
     mocker.patch('cpg_utils.workflows.inputs.create_cohort', lambda: cohort)
+
+    def mock_write(self, path: str, *args, **kwargs):
+        to_path(path).parent.mkdir(parents=True, exist_ok=True)
+
+    mocker.patch('hail.table.write', mock_write)
+    mocker.patch('hail.matrixtable.write', mock_write)
 
     from large_cohort import (
         combiner,

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -27,12 +27,12 @@ def _set_config(results_prefix: Path, extra_conf: dict | None = None):
         d,
         {
             'workflow': {
+                'path_scheme': 'local',
                 'dataset_gcp_project': 'thousand-genomes',
                 'dataset': 'thousand-genomes',
                 'access_level': 'test',
                 'sequencing_type': 'genome',
                 'check_intermediates': True,
-                'path_scheme': 'local',
                 'reference_prefix': str(
                     to_path(__file__).parent / 'data' / 'large_cohort' / 'reference'
                 ),
@@ -94,12 +94,6 @@ def test_large_cohort(mocker: MockFixture):
         s.gvcf = GvcfPath(gvcf_path)
 
     mocker.patch('cpg_utils.workflows.inputs.create_cohort', lambda: cohort)
-
-    def mock_write(self, path: str, *args, **kwargs):
-        to_path(path).parent.mkdir(parents=True, exist_ok=True)
-
-    mocker.patch('hail.table.write', mock_write)
-    mocker.patch('hail.matrixtable.write', mock_write)
 
     from large_cohort import (
         combiner,

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -30,13 +30,17 @@ def _set_config(results_prefix: Path, extra_conf: dict | None = None):
                 'dataset': 'test-analysis-dataset',
                 'access_level': 'test',
                 'sequencing_type': 'genome',
-                'driver_image': '<stub>',
                 'skip_stages': ['Align'],
                 'check_inputs': False,
                 'check_intermediates': False,
                 'check_expected_outputs': False,
                 'path_scheme': 'local',
                 'status_reporter': None,
+            },
+            'path_schemes': {
+                'local': {
+                    'default': f'{results_prefix}',
+                }
             },
             'hail': {
                 'billing_project': 'test-analysis-dataset',


### PR DESCRIPTION
Following on https://github.com/populationgenomics/cpg-utils/pull/117, updating the unittests config to use "local" path scheme, and mocking writes to make sure all local path directories are created.