### PR TITLE
corrects docker image name

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      IMAGE_NAME: australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-workflows
+      IMAGE_NAME: australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows
     steps:
     - uses: actions/checkout@main
 


### PR DESCRIPTION
Image name format to use underscores instead of a hyphen