### PR TITLE
Pass CRAI path to CRAM QC functions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.1.0
+  VERSION: 1.1.1
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/somalier.py
+++ b/cpg_workflows/jobs/somalier.py
@@ -330,6 +330,10 @@ def extract(
 
     j.image(image_path('somalier'))
     if isinstance(gvcf_or_cram_path, CramPath):
+        if not gvcf_or_cram_path.index_path:
+            raise ValueError(
+                f'CRAM for somalier is required to have CRAI index ({gvcf_or_cram_path})'
+            )
         storage_gb = None  # avoid extra disk by default
         if get_config()['workflow']['sequencing_type'] == 'genome':
             storage_gb = 100

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -131,6 +131,7 @@ class CramQC(SampleStage):
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
         cram_path = inputs.as_path(sample, Align, 'cram')
+        crai_path = inputs.as_path(sample, Align, 'crai')
 
         jobs = []
         for qc in qc_functions():
@@ -141,7 +142,7 @@ class CramQC(SampleStage):
             if qc.func:
                 j = qc.func(  # type: ignore
                     self.b,
-                    CramPath(cram_path),
+                    CramPath(cram_path, crai_path),
                     job_attrs=self.get_job_attrs(sample),
                     overwrite=not get_config()['workflow'].get('check_intermediates'),
                     **out_path_kwargs,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'cpg-utils',
-        'hail',
+        'hail>=0.2.104',
         'networkx',
         'sample-metadata>=5.0.1',
         'analysis-runner',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.1.0',
+    version='1.1.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The problem is two-fold:
1. After abstracting out CRAM QC as a separate stage, I forgot to make sure CRAI index is passed along with CRAM to `somalier extract`.
2. Hail before 0.2.104 wasn't strict about problematic strings passed to `read_input_group`, e.g. `None` for CRAI in this case. Now it's explicitly failing. So pinning `hail` version to catch such errors.

Fixes:
```
Traceback (most recent call last):
  File "/production-pipelines/./main.py", line 55, in <module>
    main()
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/production-pipelines/./main.py", line 51, in main
    run_workflow(stages=WORKFLOWS[workflow])
  File "/production-pipelines/cpg_workflows/workflow.py", line 706, in run_workflow
    get_workflow().run(stages=stages, wait=wait)
  File "/production-pipelines/cpg_workflows/workflow.py", line 788, in run
    self.set_stages(_stages)
  File "/production-pipelines/cpg_workflows/workflow.py", line 938, in set_stages
    stg.output_by_target = stg.queue_for_cohort(get_cohort())
  File "/production-pipelines/cpg_workflows/workflow.py", line 1021, in queue_for_cohort
    output_by_target[sample.target_id] = self._queue_jobs_with_checks(
  File "/production-pipelines/cpg_workflows/workflow.py", line 429, in _queue_jobs_with_checks
    outputs = self.queue_jobs(target, inputs)
  File "/production-pipelines/cpg_workflows/stages/cram_qc.py", line 142, in queue_jobs
    j = qc.func(  # type: ignore
  File "/production-pipelines/cpg_workflows/jobs/somalier.py", line 337, in extract
    input_file = b.read_input_group(
  File "/usr/local/lib/python3.10/dist-packages/hailtop/batch/batch.py", line 429, in read_input_group
    new_resources = {name: self._new_input_resource_file(file, value=f'{root}/{os.path.basename(file.rstrip("/"))}')
  File "/usr/local/lib/python3.10/dist-packages/hailtop/batch/batch.py", line 429, in <dictcomp>
    new_resources = {name: self._new_input_resource_file(file, value=f'{root}/{os.path.basename(file.rstrip("/"))}')
  File "/usr/local/lib/python3.10/dist-packages/hailtop/batch/batch.py", line 303, in _new_input_resource_file
    self._backend.validate_file_scheme(input_path)
  File "/usr/local/lib/python3.10/dist-packages/hailtop/batch/backend.py", line 739, in validate_file_scheme
    raise ValueError(
ValueError: Local filepath detected: 'None'. ServiceBackend does not support the use of local filepaths. Please specify a remote URI instead (e.g. gs://bucket/folder).
```
[E.g.](https://batch.hail.populationgenomics.org.au/batches/378645/jobs/1)