### PR TITLE
Fix `command()`: `retry_gs_cp` requires `define_retry_function`

### DIFF
--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -303,7 +303,7 @@ def picard_collect_metrics(
     cp $BATCH_TMPDIR/prefix.quality_yield_metrics {j.out_quality_yield_metrics}
     """
 
-    j.command(command(cmd))
+    j.command(command(cmd, define_retry_function=True))
     b.write_output(
         j.out_alignment_summary_metrics, str(out_alignment_summary_metrics_path)
     )
@@ -381,7 +381,7 @@ def picard_hs_metrics(
       OUTPUT={j.out_hs_metrics}
     """
 
-    j.command(command(cmd))
+    j.command(command(cmd, define_retry_function=True))
     b.write_output(j.out_hs_metrics, str(out_picard_hs_metrics_path))
     return j
 
@@ -435,6 +435,6 @@ def picard_wgs_metrics(
       READ_LENGTH={read_length}
     """
 
-    j.command(command(cmd))
+    j.command(command(cmd, define_retry_function=True))
     b.write_output(j.out_csv, str(out_picard_wgs_metrics_path))
     return j

--- a/cpg_workflows/jobs/samtools.py
+++ b/cpg_workflows/jobs/samtools.py
@@ -45,6 +45,6 @@ def samtools_stats(
     $CRAM > {j.output_stats}
     """
 
-    j.command(command(cmd))
+    j.command(command(cmd, define_retry_function=True))
     b.write_output(j.output_stats, str(out_samtools_stats_path))
     return j

--- a/cpg_workflows/jobs/verifybamid.py
+++ b/cpg_workflows/jobs/verifybamid.py
@@ -70,6 +70,11 @@ def verifybamid(
     cp OUTPUT.selfSM {j.out_selfsm}
     """
 
-    j.command(command(cmd, define_retry_function=True))
+    j.command(
+        command(
+            cmd,
+            define_retry_function=True,
+        )
+    )
     b.write_output(j.out_selfsm, str(out_verify_bamid_path))
     return j

--- a/cpg_workflows/jobs/verifybamid.py
+++ b/cpg_workflows/jobs/verifybamid.py
@@ -70,6 +70,6 @@ def verifybamid(
     cp OUTPUT.selfSM {j.out_selfsm}
     """
 
-    j.command(command(cmd))
+    j.command(command(cmd, define_retry_function=True))
     b.write_output(j.out_selfsm, str(out_verify_bamid_path))
     return j


### PR DESCRIPTION
Follow up fix for https://github.com/populationgenomics/production-pipelines/pull/165