### PR TITLE
Improve dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ For example, out "Align" stage that runs BWA might look like as following:
 ```python
 from cpg_utils import Path
 from cpg_workflows.workflow import stage, SampleStage, Sample, StageInput, StageOutput
-
+from cpg_workflows.batch import get_batch
 
 @stage
 class Align(SampleStage):
@@ -501,9 +501,9 @@ class Align(SampleStage):
         return sample.make_cram_path().path
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
-        j = self.b.new_job('BWA', self.get_job_attrs(sample))
+        j = get_batch().new_job('BWA', self.get_job_attrs(sample))
         j.command(f'bwa ... > {j.output}')
-        self.b.write_output(j.output, str(self.expected_outputs(sample)))
+        get_batch().write_output(j.output, str(self.expected_outputs(sample)))
         # Construct StageOutput object, where we pass a path to the results, 
         return self.make_outputs(sample, self.expected_outputs(sample), [j])
 ```

--- a/configs/defaults/workflows.toml
+++ b/configs/defaults/workflows.toml
@@ -39,7 +39,7 @@ web_url_template = 'https://{namespace}-web.populationgenomics.org.au/{dataset}'
 
 # Map of stages to lists of samples, to skip for specific stages
 #[workflow.skip_samples_stages]
-#VerifyBamId = ['CPG13409']
+#CramQC = ['CPG13409']
 
 # Name of the workflow (to prefix output paths)
 #name =
@@ -77,6 +77,11 @@ check_expected_outputs = true
 
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
+
+# Only print the final merged config and a list of stages to be submitted.
+# Will skip any communication with Metamist, Hail Batch, and Cloud Storage, so 
+# the code can be run without permissions.
+#dry_run = true
 
 [images]
 # Docker image URLs. Can be absolute or relative to `workflow.image_registry_prefix`.
@@ -198,7 +203,4 @@ HG001_NA12878 = 'HG001'
 SYNDIP = 'syndip'
 
 [hail]
-#billing_project =
-#pool_label = 'seqr'
 delete_scratch_on_exit = false
-dry_run = false

--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -55,7 +55,14 @@ class Batch(hb.Batch):
     created jobs, in order to print statistics before submitting the Batch.
     """
 
-    def __init__(self, name, backend, *args, pool_label=None, **kwargs):
+    def __init__(
+        self,
+        name,
+        backend,
+        *args,
+        pool_label=None,
+        **kwargs,
+    ):
         super().__init__(name, backend, *args, **kwargs)
         # Job stats registry:
         self.job_by_label = dict()

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -86,7 +86,7 @@ def make_joint_genotyping_jobs(
     df = pd.DataFrame(
         [{'id': sid, 'path': str(path)} for sid, path in gvcf_by_sid.items()]
     )
-    if not get_config()['hail'].get('dry_run', False):
+    if not get_config()['workflow'].get('dry_run', False):
         with sample_map_bucket_path.open('w') as fp:
             df.to_csv(fp, index=False, header=False, sep='\t')
 

--- a/cpg_workflows/jobs/multiqc.py
+++ b/cpg_workflows/jobs/multiqc.py
@@ -62,7 +62,7 @@ def multiqc(
     STANDARD.set_resources(mqc_j, ncpu=16)
 
     file_list_path = tmp_prefix / 'multiqc-file-list.txt'
-    if not get_config()['hail'].get('dry_run', False):
+    if not get_config()['workflow'].get('dry_run', False):
         with file_list_path.open('w') as f:
             f.writelines([f'{p}\n' for p in paths])
     file_list = b.read_input(str(file_list_path))
@@ -74,7 +74,7 @@ def multiqc(
 
     if sample_id_map:
         sample_map_path = tmp_prefix / 'rename-sample-map.tsv'
-        if not get_config()['hail'].get('dry_run', False):
+        if not get_config()['workflow'].get('dry_run', False):
             _write_sample_id_map(sample_id_map, sample_map_path)
         sample_map_file = b.read_input(str(sample_map_path))
     else:

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -97,7 +97,7 @@ def annotate_dataset_jobs(
     that will be loaded into Seqr).
     """
     sample_ids_list_path = tmp_prefix / 'sample-list.txt'
-    if not get_config()['hail'].get('dry_run', False):
+    if not get_config()['workflow'].get('dry_run', False):
         with sample_ids_list_path.open('w') as f:
             f.write(','.join(sample_ids))
 

--- a/cpg_workflows/jobs/somalier.py
+++ b/cpg_workflows/jobs/somalier.py
@@ -94,7 +94,7 @@ def _make_sample_map(dataset: Dataset):
     df = pd.DataFrame(
         [{'id': s.id, 'pid': s.participant_id} for s in dataset.get_samples()]
     )
-    if not get_config()['hail'].get('dry_run', False):
+    if not get_config()['workflow'].get('dry_run', False):
         with sample_map_fpath.open('w') as fp:
             df.to_csv(fp, sep='\t', index=False, header=False)
     return sample_map_fpath

--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -5,6 +5,7 @@ import logging
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
+from cpg_workflows import get_batch
 from cpg_workflows.jobs import align
 from cpg_workflows.jobs.align import MissingAlignmentInputException
 from cpg_workflows.workflow import (
@@ -51,7 +52,7 @@ class Align(SampleStage):
 
         try:
             jobs = align.align(
-                b=self.b,
+                b=get_batch(),
                 sample=sample,
                 output_path=sample.make_cram_path(),
                 job_attrs=self.get_job_attrs(sample),

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
+from cpg_workflows import get_batch
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.jobs import somalier
 from cpg_workflows.jobs.multiqc import multiqc
@@ -141,7 +142,7 @@ class CramQC(SampleStage):
             }
             if qc.func:
                 j = qc.func(  # type: ignore
-                    self.b,
+                    get_batch(),
                     CramPath(cram_path, crai_path),
                     job_attrs=self.get_job_attrs(sample),
                     overwrite=not get_config()['workflow'].get('check_intermediates'),
@@ -212,7 +213,7 @@ class SomalierPedigree(DatasetStage):
                 self.expected_outputs(dataset)['expected_ped']
             )
             jobs = somalier.pedigree(
-                b=self.b,
+                b=get_batch(),
                 dataset=dataset,
                 expected_ped_path=expected_ped_path,
                 somalier_path_by_sid=somalier_path_by_sid,
@@ -310,7 +311,7 @@ class CramMultiQC(DatasetStage):
             return self.make_outputs(dataset)
 
         jobs = multiqc(
-            self.b,
+            get_batch(),
             tmp_prefix=dataset.tmp_prefix() / 'multiqc' / 'cram',
             paths=paths,
             ending_to_trim=ending_to_trim,

--- a/cpg_workflows/stages/fastqc.py
+++ b/cpg_workflows/stages/fastqc.py
@@ -5,6 +5,7 @@ import dataclasses
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
+from cpg_workflows import get_batch
 from cpg_workflows.filetypes import BamPath, FastqPairs
 from cpg_workflows.workflow import (
     Sample,
@@ -99,7 +100,7 @@ class FastQC(SampleStage):
         jobs = []
         for fqc_out in fqc_outs:
             j = fastqc.fastqc(
-                b=self.b,
+                b=get_batch(),
                 output_html_path=fqc_out.out_html,
                 output_zip_path=fqc_out.out_zip,
                 input_path=fqc_out.input_path,
@@ -141,7 +142,7 @@ class FastQCMultiQC(DatasetStage):
                 sample_id_map[fq_name] = f'{sample.rich_id}{fqc_out.suffix}'
 
         jobs = multiqc(
-            self.b,
+            get_batch(),
             tmp_prefix=dataset.tmp_prefix() / 'multiqc' / 'fastqc',
             paths=paths,
             dataset=dataset,

--- a/cpg_workflows/stages/gatk_sv.py
+++ b/cpg_workflows/stages/gatk_sv.py
@@ -14,7 +14,7 @@ from hailtop.batch.job import Job
 from cpg_utils import Path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import command, reference_path, image_path
-from cpg_workflows.batch import make_job_name, Batch
+from cpg_workflows.batch import make_job_name, Batch, get_batch
 from cpg_workflows.workflow import (
     stage,
     SampleStage,
@@ -203,7 +203,7 @@ class GatherSampleEvidence(SampleStage):
         expected_d = self.expected_outputs(sample)
 
         j = add_gatk_sv_job(
-            batch=self.b,
+            batch=get_batch(),
             dataset=sample.dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -276,7 +276,7 @@ class EvidenceQC(DatasetStage):
 
         expected_d = self.expected_outputs(dataset)
         j = add_gatk_sv_job(
-            batch=self.b,
+            batch=get_batch(),
             dataset=dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -435,7 +435,7 @@ class GatherBatchEvidence(DatasetStage):
 
         expected_d = self.expected_outputs(dataset)
         j = add_gatk_sv_job(
-            batch=self.b,
+            batch=get_batch(),
             dataset=dataset,
             wfl_name=self.name,
             input_dict=input_dict,

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -19,6 +19,7 @@ from cpg_workflows.jobs.happy import happy
 from cpg_workflows.jobs.picard import vcf_qc
 
 from .align import Align
+from .. import get_batch
 
 
 @stage(required_stages=Align, analysis_type='gvcf')
@@ -41,7 +42,7 @@ class Genotype(SampleStage):
         Use function from the jobs module
         """
         jobs = genotype.genotype(
-            b=self.b,
+            b=get_batch(),
             output_path=self.expected_outputs(sample)['gvcf'],
             sample_name=sample.id,
             cram_path=sample.make_cram_path(),

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -5,6 +5,7 @@ import logging
 
 from cpg_utils import to_path, Path
 from cpg_utils.config import get_config
+from cpg_workflows import get_batch
 from cpg_workflows.filetypes import GvcfPath
 from cpg_workflows.jobs.multiqc import multiqc
 
@@ -49,8 +50,8 @@ class GvcfQC(SampleStage):
         gvcf_path = inputs.as_path(sample, Genotype, 'gvcf')
 
         j = vcf_qc(
-            b=self.b,
-            vcf_or_gvcf=GvcfPath(gvcf_path).resource_group(self.b),
+            b=get_batch(),
+            vcf_or_gvcf=GvcfPath(gvcf_path).resource_group(get_batch()),
             is_gvcf=True,
             job_attrs=self.get_job_attrs(sample),
             output_summary_path=self.expected_outputs(sample)['qc_summary'],
@@ -88,9 +89,9 @@ class GvcfHappy(SampleStage):
         gvcf_path = inputs.as_path(sample, Genotype, 'gvcf')
 
         jobs = happy(
-            b=self.b,
+            b=get_batch(),
             sample=sample,
-            vcf_or_gvcf=GvcfPath(gvcf_path).resource_group(self.b),
+            vcf_or_gvcf=GvcfPath(gvcf_path).resource_group(get_batch()),
             is_gvcf=True,
             job_attrs=self.get_job_attrs(sample),
             output_path=self.expected_outputs(sample),
@@ -173,7 +174,7 @@ class GvcfMultiQC(DatasetStage):
         }
 
         jobs = multiqc(
-            self.b,
+            get_batch(),
             tmp_prefix=dataset.tmp_prefix() / 'multiqc' / 'gvcf',
             paths=paths,
             ending_to_trim=ending_to_trim,

--- a/cpg_workflows/stages/joint_genotyping.py
+++ b/cpg_workflows/stages/joint_genotyping.py
@@ -21,6 +21,7 @@ from cpg_workflows.jobs.happy import happy
 from cpg_workflows.jobs.picard import vcf_qc
 from cpg_workflows.jobs import joint_genotyping
 from .genotype import Genotype
+from .. import get_batch
 
 
 @stage(required_stages=Genotype)
@@ -35,7 +36,7 @@ class JointGenotyping(CohortStage):
         """
         h = cohort.alignment_inputs_hash()
         prefix = str(cohort.analysis_dataset.prefix() / self.name / h)
-        qc_prefix = self.cohort.analysis_dataset.prefix() / 'qc' / 'jc' / h / 'picard'
+        qc_prefix = cohort.analysis_dataset.prefix() / 'qc' / 'jc' / h / 'picard'
         return {
             'prefix': prefix,
             'vcf': to_path(f'{prefix}.vcf.gz'),
@@ -71,7 +72,7 @@ class JointGenotyping(CohortStage):
         siteonly_vcf_path = self.expected_outputs(cohort)['siteonly']
 
         jc_jobs = joint_genotyping.make_joint_genotyping_jobs(
-            b=self.b,
+            b=get_batch(),
             out_vcf_path=vcf_path,
             out_siteonly_vcf_path=siteonly_vcf_path,
             tmp_bucket=to_path(self.expected_outputs(cohort)['prefix']),
@@ -86,8 +87,8 @@ class JointGenotyping(CohortStage):
         jobs.extend(jc_jobs)
 
         qc_j = vcf_qc(
-            b=self.b,
-            vcf_or_gvcf=self.b.read_input_group(
+            b=get_batch(),
+            vcf_or_gvcf=get_batch().read_input_group(
                 **{
                     'vcf.gz': str(vcf_path),
                     'vcf.gz.tbi': str(vcf_path) + '.tbi',

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -10,6 +10,7 @@ from cpg_workflows.workflow import (
     get_workflow,
 )
 from .genotype import Genotype
+from .. import get_batch
 
 
 @stage(required_stages=[Genotype])
@@ -232,7 +233,7 @@ class Vqsr(CohortStage):
 
         vcf_path = inputs.as_path(cohort, MakeSiteOnlyVcf, key='vcf')
         jobs = vqsr.make_vqsr_jobs(
-            b=self.b,
+            b=get_batch(),
             input_siteonly_vcf_path=vcf_path,
             gvcf_count=len(cohort.get_samples()),
             out_path=self.expected_outputs(cohort)['vcf'],

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -95,6 +95,7 @@ class AnnotateDataset(DatasetStage):
         """
         Uses analysis-runner's dataproc helper to run a hail query script
         """
+        assert dataset.cohort
         mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateCohort, key='mt')
 
         checkpoint_prefix = (

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -23,6 +23,7 @@ from cpg_workflows.jobs.seqr_loader import annotate_cohort_jobs, annotate_datase
 from .joint_genotyping import JointGenotyping
 from .vep import Vep
 from .vqsr import Vqsr
+from .. import get_cohort, get_batch
 
 
 @stage(required_stages=[JointGenotyping, Vqsr, Vep])
@@ -38,7 +39,7 @@ class AnnotateCohort(CohortStage):
         h = cohort.alignment_inputs_hash()
         return {
             'tmp_prefix': str(self.tmp_prefix / 'mt' / h),
-            'mt': self.cohort.analysis_dataset.prefix() / 'mt' / f'{h}.mt',
+            'mt': get_cohort().analysis_dataset.prefix() / 'mt' / f'{h}.mt',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -56,7 +57,7 @@ class AnnotateCohort(CohortStage):
         )
 
         jobs = annotate_cohort_jobs(
-            b=self.b,
+            b=get_batch(),
             vcf_path=vcf_path,
             siteonly_vqsr_vcf_path=siteonly_vqsr_vcf_path,
             vep_ht_path=vep_ht_path,
@@ -84,7 +85,7 @@ class AnnotateDataset(DatasetStage):
         """
         Expected to generate a matrix table
         """
-        h = self.cohort.alignment_inputs_hash()
+        h = get_cohort().alignment_inputs_hash()
         return {
             'tmp_prefix': str(self.tmp_prefix / 'mt' / f'{h}-{dataset.name}'),
             'mt': dataset.prefix() / 'mt' / f'{h}-{dataset.name}.mt',
@@ -94,14 +95,14 @@ class AnnotateDataset(DatasetStage):
         """
         Uses analysis-runner's dataproc helper to run a hail query script
         """
-        mt_path = inputs.as_path(target=self.cohort, stage=AnnotateCohort, key='mt')
+        mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateCohort, key='mt')
 
         checkpoint_prefix = (
             to_path(self.expected_outputs(dataset)['tmp_prefix']) / 'checkpoints'
         )
 
         jobs = annotate_dataset_jobs(
-            b=self.b,
+            b=get_batch(),
             mt_path=mt_path,
             sample_ids=dataset.get_sample_ids(),
             out_mt_path=self.expected_outputs(dataset)['mt'],
@@ -173,7 +174,7 @@ class MtToEs(DatasetStage):
         from analysis_runner import dataproc
 
         j = dataproc.hail_dataproc_job(
-            self.b,
+            get_batch(),
             f'dataproc_scripts/mt_to_es.py '
             f'--mt-path {dataset_mt_path} '
             f'--es-index {index_name} '

--- a/cpg_workflows/stages/vep.py
+++ b/cpg_workflows/stages/vep.py
@@ -14,6 +14,7 @@ from cpg_workflows.workflow import (
 
 from cpg_workflows.jobs import vep
 from .vqsr import Vqsr
+from .. import get_batch
 
 
 @stage(required_stages=[Vqsr])
@@ -44,7 +45,7 @@ class Vep(CohortStage):
             scatter_count = 200
 
         jobs = vep.add_vep_jobs(
-            self.b,
+            get_batch(),
             vcf_path=inputs.as_path(cohort, stage=Vqsr, key='siteonly'),
             out_path=self.expected_outputs(cohort)['ht'],
             tmp_prefix=to_path(self.expected_outputs(cohort)['prefix']),

--- a/cpg_workflows/stages/vqsr.py
+++ b/cpg_workflows/stages/vqsr.py
@@ -14,6 +14,7 @@ from cpg_workflows.workflow import (
 
 from cpg_workflows.jobs import vqsr
 from .joint_genotyping import JointGenotyping
+from .. import get_batch
 
 
 @stage(required_stages=JointGenotyping)
@@ -41,7 +42,7 @@ class Vqsr(CohortStage):
             stage=JointGenotyping, target=cohort, key='siteonly'
         )
         jobs = vqsr.make_vqsr_jobs(
-            b=self.b,
+            b=get_batch(),
             input_siteonly_vcf_path=siteonly_vcf_path,
             gvcf_count=len(cohort.get_samples()),
             out_path=self.expected_outputs(cohort)['siteonly'],

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -401,7 +401,7 @@ class Dataset(Target):
         if out_path is None:
             out_path = self.tmp_prefix() / 'ped' / f'{self.alignment_inputs_hash()}.ped'
 
-        if not get_config()['hail'].get('dry_run', False):
+        if not get_config()['workflow'].get('dry_run', False):
             with out_path.open('w') as fp:
                 df.to_csv(fp, sep='\t', index=False)
         return out_path

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -115,9 +115,11 @@ def test_status_reporter(mocker: MockFixture):
             return dataset_path(f'{sample.id}.tsv')
 
         def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
-            j = self.b.new_job('Echo', self.get_job_attrs(sample) | dict(tool='echo'))
+            j = get_batch().new_job(
+                'Echo', self.get_job_attrs(sample) | dict(tool='echo')
+            )
             j.command(f'echo {sample.id}_done >> {j.output}')
-            self.b.write_output(j.output, str(self.expected_outputs(sample)))
+            get_batch().write_output(j.output, str(self.expected_outputs(sample)))
             print(f'Writing to {self.expected_outputs(sample)}')
             return self.make_outputs(sample, self.expected_outputs(sample), [j])
 


### PR DESCRIPTION
Making `dry_run` more consistent:

* `hail/dry_run = true` would only be directly propagated as `batch.run(dry_run=True)`, in consistency with other `[hail]` options. So when it's set, we will run all the workflows code, but `batch.run()` will only print commands instead of actually creating any batches and jobs.
* `workflow/dry_run = true` however is more limiting: it should allow the code to be run without permissions, so it will skip any communication with Metamist, Hail Batch, and Cloud Storage, and will only print the final merged config and a list of stages to be submitted.

To support it, a few changes added:
* dropping `Stage.b` and `Stage.cohort` fields in favour of `get_batch()` and `get_cohort()` (so we don't need to initialise Cohort and Batch when only initialising a Workflow), 
* mocking `get_config()` in tests.