### PR TITLE
Add miscellaneous scripts (benchmarks, hail batch tests)

### DIFF
--- a/cpg_workflows/large_cohort/dataproc_script.py
+++ b/cpg_workflows/large_cohort/dataproc_script.py
@@ -13,12 +13,18 @@ from importlib import import_module
 @click.command()
 @click.argument('import_module_name')
 @click.argument('function_name')
-@click.argument('function_path_args', nargs=-1)
-def main(import_module_name: str, function_name: str, function_path_args: list[str]):
+@click.argument('function_str_args', nargs=-1)
+@click.option('-p', '--path', 'function_path_args', multiple=True)
+def main(
+    import_module_name: str,
+    function_name: str,
+    function_str_args: list[str],
+    function_path_args: list[str],
+):
     module = import_module(import_module_name)
     func = getattr(module, function_name)
     start_query_context()
-    func(*[to_path(path) for path in function_path_args])
+    func(*[to_path(path) for path in function_path_args], *function_str_args)
 
 
 if __name__ == '__main__':

--- a/cpg_workflows/large_cohort/dataproc_utils.py
+++ b/cpg_workflows/large_cohort/dataproc_utils.py
@@ -55,8 +55,8 @@ def dataproc_job(
     script = (
         f'{rel_script_path} '
         f'{function.__module__} {function.__name__} '
-        f'{" ".join([f"-p {p}" for p in function_path_args.values()])}'
-        f'{" ".join([a for a in function_str_args or []])}'
+        f'{" ".join([f"-p {p}" for p in function_path_args.values()])} '
+        f'{" ".join([a for a in function_str_args or []])} '
     )
 
     if cluster_id := get_config()['hail'].get('dataproc', {}).get('cluster_id'):

--- a/cpg_workflows/large_cohort/dataproc_utils.py
+++ b/cpg_workflows/large_cohort/dataproc_utils.py
@@ -33,6 +33,7 @@ def dataproc_job(
     job_name: str,
     function,
     function_path_args: dict[str, Path],
+    function_str_args: list[str] | None = None,
     preemptible: bool = True,
     num_workers: int | None = None,
     depends_on: list[Job | None] = None,
@@ -54,7 +55,8 @@ def dataproc_job(
     script = (
         f'{rel_script_path} '
         f'{function.__module__} {function.__name__} '
-        f'{" ".join([str(p) for p in function_path_args.values()])}'
+        f'{" ".join([f"-p {p}" for p in function_path_args.values()])}'
+        f'{" ".join([a for a in function_str_args or []])}'
     )
 
     if cluster_id := get_config()['hail'].get('dataproc', {}).get('cluster_id'):

--- a/misc/attach_disk_test.py
+++ b/misc/attach_disk_test.py
@@ -1,5 +1,14 @@
+#!/usr/bin/env python3
+
 """
-Test how Hail Batch attaches disks to instances
+Test how Hail Batch attaches disks to instances. Motivation: job.storage(...) option
+does not directly translate into available_storage value that you can see in job logs.
+The `cpg_workflows.resources` module solves this problem by adding adjustments to the
+requested storage, and this script runs some tests to determine those adjustments.
+Additionally, when a larger storage is requested than available on a worker by default,
+Hail Batch would attempt to attach an external disk. We want to determine at what
+point it performs that attachment, as often we want to avoid extra costs incurred by
+external disk, and use the default space only.
 """
 
 from cpg_utils.config import update_dict, get_config

--- a/misc/attach_disk_test.py
+++ b/misc/attach_disk_test.py
@@ -1,0 +1,47 @@
+"""
+Test how Hail Batch attaches disks to instances
+"""
+
+from cpg_utils.config import update_dict, get_config
+from cpg_workflows import get_batch
+
+
+def main():  # pylint: disable=missing-function-docstring
+    update_dict(
+        get_config()['workflow'],
+        {
+            'name': 'test_attach_disk',
+            'dataset': 'fewgenomes',
+            'access_level': 'test',
+            'datasets': ['fewgenomes'],
+        },
+    )
+    b = get_batch()
+
+    def add_storage_job(
+        storage: float,
+        ncpu: int | None = None,
+        memory: float | None = None,
+    ):
+        j = b.new_job(f'Disk {storage}G')
+        j.storage(f'{storage}G')
+
+        if ncpu:
+            j.name += f' ncpu={ncpu}'
+            j.cpu(ncpu)
+
+        if memory:
+            j.name += f' memory={memory}G'
+            j.memory(f'{memory}G')
+
+        j.command(f'sleep {60*6}')
+        return j
+
+    for _ in range(16):
+        add_storage_job(storage=185 // 4, ncpu=8, memory=30.0)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=E1120

--- a/misc/benchmark_combiner.py
+++ b/misc/benchmark_combiner.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 """
-Benchmarking VCF combiner.
+Benchmarking Hail VDS combiner. Run with analysis runner:
 
-analysis-runner --dataset tob-wgs --access-level standard
+analysis-runner --dataset thousand-genomes --access-level standard <script>
 """
 
 import logging

--- a/misc/benchmark_combiner.py
+++ b/misc/benchmark_combiner.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+"""
+Benchmarking VCF combiner.
+
+analysis-runner --dataset tob-wgs --access-level standard
+"""
+
+import logging
+
+import pandas as pd
+
+from cpg_utils import to_path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import output_path, dataset_path
+from cpg_workflows import get_cohort, get_batch
+
+
+# benchmark matrix:
+N_WORKERS = [10, 30, 20, 40, 50]
+N_SAMPLES = [100, 200, 300, 400, 500]
+
+
+def main():
+    df = pd.DataFrame(
+        [
+            {'s': s.id, 'gvcf': s.make_gvcf_path()}
+            for s in get_cohort().get_samples()
+            if s.make_gvcf_path().exists()
+        ]
+    )
+    logging.info(
+        f'Found {len(df)}/{len(get_cohort().get_samples())} samples '
+        f'in {get_config()["workflow"]["dataset"]} with GVCFs'
+    )
+
+    out_prefix = to_path(dataset_path('benchmark-combiner'))
+    tmp_prefix = to_path(dataset_path('benchmark-combiner', category='tmp'))
+
+    for n_workers in N_WORKERS:
+        for n_samples in N_SAMPLES:
+            label = f'nsamples-{n_samples}-nworkers-{n_workers}'
+            out_vds_path = out_prefix / label / 'combined.vds'
+            sample_ids = get_cohort().get_sample_ids()[:n_samples]
+
+            from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
+            from cpg_workflows.large_cohort.combiner import run
+
+            dataproc_job(
+                job_name=f'Combine {n_samples} GVCFs on {n_workers} workers',
+                function=run,
+                function_path_args=dict(
+                    out_vds_path=out_vds_path,
+                    tmp_prefix=tmp_prefix,
+                ),
+                function_str_args=sample_ids,
+                autoscaling_policy=(
+                    get_config()['hail']
+                    .get('dataproc', {})
+                    .get('combiner_autoscaling_policy')
+                ),
+                num_workers=n_workers,
+            )
+
+    get_batch().run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/misc/benchmark_metamist_read_pedigree.py
+++ b/misc/benchmark_metamist_read_pedigree.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+"""
+Test Metamist's get_pedigree which might get stuck for too many samples, as it uses
+a GET request with a limit on the URL string length. This script was used to determine
+parameters for the hack in `cpg_workflows.metamist.get_ped_entries()` to get around
+this issue.
+"""
+
+import logging
+import time
+
+from sample_metadata.apis import FamilyApi
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.INFO)
+
+
+metamist_proj = 'thousand-genomes'
+
+fapi = FamilyApi()
+
+entries = fapi.get_families(metamist_proj)
+family_ids = [entry['id'] for entry in entries]
+print(f'families: {family_ids}')
+print(f'total families count: {len(family_ids)}')
+
+subset_n = 550
+while True:
+    start_time = time.time()
+
+    # subset_n = 2**i
+    if subset_n >= len(family_ids):
+        break
+
+    print(f'Taking first {subset_n} families... ', end='')
+    fids = family_ids[:subset_n]
+    ped_entries = fapi.get_pedigree(
+        internal_family_ids=fids,
+        export_type='json',
+        project=metamist_proj,
+        replace_with_participant_external_ids=True,
+    )
+
+    current_time = time.time()
+    elapsed_time = current_time - start_time
+    print(f'finished in {elapsed_time} seconds')
+
+    subset_n += 10
+    time.sleep(0.01)


### PR DESCRIPTION
Completing moving stuff from the `initial` branch: adding some one-off scripts used in the past.

* Add `misc/benchmark_combiner.py` that benchmarks the Hail VDS combiner with different combinations of samples and workers numbers. Required some additional re-working for `dataproc_job` and `dataproc_script.py` (specifically, support extra custom non-path arguments, with path arguments converted into `-p` options).
* Add additional one-off scripts used in the past: `attach_disk_test.py` to test Hail Batch external disk attachment, and `benchmark_metamist_read_pedigree.py` to test issues with the get_pedigree GET requests.