### PR TITLE
Update verifybamid path

### DIFF
--- a/cpg_workflows/jobs/verifybamid.py
+++ b/cpg_workflows/jobs/verifybamid.py
@@ -54,7 +54,7 @@ def verifybamid(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
         
-    /root/micromamba/share/verifybamid2-2.0.1-7/VerifyBamID \
+    /root/micromamba/share/verifybamid2-2.0.1-8/VerifyBamID \
     --NumThread {res.get_nthreads()} \
     --Verbose \
     --NumPC 4 \


### PR DESCRIPTION
Path to verifybamid has changed in latest image.  Is there a better way to manage changes to container internal paths or do we just need to update them like this when they break?