### PR TITLE
Joint genotyping: extract genomicsdb tar into $BATCH_TMPDIR

### DIFF
--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -377,9 +377,9 @@ def _add_joint_genotyper_job(
     if str(genomicsdb_path).endswith('.tar'):
         # can't use directly from cloud, need to copy and uncompress:
         input_cmd = f"""\
-        retry_gs_cp {genomicsdb_path} {genomicsdb_path.name}
-        tar -xf {genomicsdb_path.name}
-        WORKSPACE=gendb://{genomicsdb_path.with_suffix('').name}
+        retry_gs_cp {genomicsdb_path} $BATCH_TMPDIR/{genomicsdb_path.name}
+        tar -xf $BATCH_TMPDIR/{genomicsdb_path.name} -C $BATCH_TMPDIR/
+        WORKSPACE=gendb://$BATCH_TMPDIR/{genomicsdb_path.with_suffix('').name}
         """
     else:
         input_cmd = f"""\


### PR DESCRIPTION
GenomicsDB tar became large enough so it doesn't fit the default disk. Extracting instead into `$BATCH_TMPDIR` which is mounted to the attached volume.