### PR TITLE
Remove sort after gatherVCFs

### DIFF
--- a/cpg_workflows/jobs/vcf.py
+++ b/cpg_workflows/jobs/vcf.py
@@ -113,13 +113,8 @@ def gather_vcfs(
     --ignore-safety-checks \\
     --gather-type BLOCK \\
     {input_cmdl} \\
-    --output $BATCH_TMPDIR/gathered.vcf.gz
+    --output {j.output_vcf['vcf.gz']}
 
-    bcftools sort --temp-dir $BATCH_TMPDIR \
-    $BATCH_TMPDIR/gathered.vcf.gz -Oz \
-    -o {j.output_vcf['vcf.gz']}
-    
-    tabix -p vcf {j.output_vcf['vcf.gz']}
     """
     j.command(command(cmd, monitor_space=True))
     if out_vcf_path:


### PR DESCRIPTION
GatherVcfsCloud will produce a sorted vcf provided our intervals are non overlaping and listed in genomic order. This sort is therefore not needed and requried a huge abount of temp space with big vcfs so should be removed.