### PR TITLE
Add stripy

### DIFF
--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -55,6 +55,7 @@ password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
 
 [stripy]
-# Analysis_type can be "standard" (fast) or "extended" (slow but uses unmapped reads)
-analysis_type = "standard"
+# Analysis_type can be "standard" (fast) or "extended" (marginally slower 
+# but also uses unmapped reads for genotying)
+analysis_type = "extended"
 write_to_bam = false

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -53,3 +53,8 @@ username = 'seqr'
 # Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
 password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
+
+[stripy]
+# Analysis_type can be "standard" (fast) or "extended" (slow but uses unmapped reads)
+analysis_type = "standard"
+write_to_bam = false

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -101,6 +101,7 @@ multiqc = 'multiqc:v1.12'
 fastqc = 'fastqc:v0.11.9_cv8'
 hap.py = 'hap.py:v0.3.15'
 cpg_workflows = 'cpg_workflows:latest'
+stripy = 'stripy:latest'
 
 [references]
 # Genome build. Only GRCh38 is currently supported.

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -101,7 +101,7 @@ multiqc = 'multiqc:v1.12'
 fastqc = 'fastqc:v0.11.9_cv8'
 hap.py = 'hap.py:v0.3.15'
 cpg_workflows = 'cpg_workflows:latest'
-stripy = 'stripy:latest'
+stripy = 'stripy:v2.2'
 
 [references]
 # Genome build. Only GRCh38 is currently supported.

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -63,7 +63,8 @@ def stripy(
     echo "BATCH_TMPDIR = $BATCH_TMPDIR"
     ls $BATCH_TMPDIR/
   
-    cp $CRAM.bam.html {j.out_path}
+    # cp $CRAM.bam.html {j.out_path}
+    cp $CRAM.html {j.out_path}
 
     """
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -35,7 +35,8 @@ def stripy(
     job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
     j = b.new_job('STRipy', job_attrs)
     j.image(image_path('stripy'))
-    res = STANDARD.request_resources(ncpu=2, storage_gb=100)
+    # res = STANDARD.request_resources(ncpu=2, storage_gb=100)
+    res = STANDARD.request_resources(ncpu=2)
     res.set_to_job(j)
     reference = fasta_res_group(b)
 
@@ -51,12 +52,12 @@ def stripy(
     # samtools view -b -@ 2 -T {reference.base}  $CRAM > $CRAM.bam
     # samtools index $CRAM.bam
 
+    # --analysis extended 
     python3 stri.py \\
         --genome hg38 \\
         --reference {reference.base} \\
         --output $BATCH_TMPDIR/ \\
         --input $CRAM \\
-        --analysis extended \\
         --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,BEAN1,C9ORF72,CACNA1A,CBL,CNBP,COMP,DAB1,DIP2B,DMD,DMPK,FMR1,FOXL2,FXN,GIPC1,GLS,HOXA13_1,HOXA13_2,HOXA13_3,HOXD13,HTT,JPH3,LRP12,MARCHF6,NIPA1,NOP56,NOTCH2NLC,NUTM2B-AS1,PABPN1,PHOX2B,PPP2R2B,PRDM12,RAPGEF2,RFC1,RUNX2,SAMD12,SOX3,STARD7,TBP,TBX1,TCF4,TNRC6A,XYLT1,YEATS2,ZIC2,ZIC3
 
     echo "BATCH_TMPDIR = $BATCH_TMPDIR"

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -48,14 +48,20 @@ def stripy(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
+    samtools view -b -T {reference.base}  $CRAM > $CRAM.bam
+    samtools index $CRAM.bam
+
     python3 stri.py \\
         --genome hg38 \\
         --reference {reference.base} \\
         --output $BATCH_TMPDIR/ \\
         --locus AFF2,ATXN3,HTT,PHOX2B \\
-        --input $CRAM
+        --input $CRAM.bam
 
+    echo "BATCH_TMPDIR = $BATCH_TMPDIR"
     ls $BATCH_TMPDIR/
+    ls /
+    ls
     cp $BATCH_TMPDIR/foo {j.out_pdf_path}
     """
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -48,7 +48,7 @@ def stripy(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
-    samtools view -b -T {reference.base}  $CRAM > $CRAM.bam
+    samtools view -b -@ 3 -T {reference.base}  $CRAM > $CRAM.bam
     samtools index $CRAM.bam
 
     python3 stri.py \\
@@ -65,6 +65,6 @@ def stripy(
 
     """
 
-    j.command(command(cmd, define_retry_function=True))
+    j.command(command(cmd, define_retry_function=True, monitor_space=True))
     b.write_output(j.out_path, str(out_path))
     return j

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -1,0 +1,64 @@
+"""
+Create Hail Batch jobs to run STRipy
+"""
+
+import hailtop.batch as hb
+from hailtop.batch.job import Job
+
+from cpg_utils import Path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import image_path, fasta_res_group, reference_path
+from cpg_utils.hail_batch import command
+from cpg_workflows.resources import HIGHMEM, STANDARD
+from cpg_workflows.filetypes import CramPath
+from cpg_workflows.utils import can_reuse, exists
+
+
+def stripy(
+    b,
+    cram_path: CramPath,
+    out_pdf_path: Path,
+    job_attrs: dict | None = None,
+    overwrite: bool = False,
+) -> Job | None:
+    """
+    Run STRipy
+    """
+    if can_reuse(
+        [
+            out_pdf_path,
+        ],
+        overwrite,
+    ):
+        return None
+
+    job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
+    j = b.new_job('STRipy', job_attrs)
+    j.image(image_path('stripy'))
+    res = STANDARD.request_resources(ncpu=2)
+    res.set_to_job(j)
+    reference = fasta_res_group(b)
+
+    assert cram_path.index_path
+    cmd = f"""\
+    CRAM=$BATCH_TMPDIR/{cram_path.path.name}
+    CRAI=$BATCH_TMPDIR/{cram_path.index_path.name}
+
+    # Retrying copying to avoid google bandwidth limits
+    retry_gs_cp {str(cram_path.path)} $CRAM
+    retry_gs_cp {str(cram_path.index_path)} $CRAI
+
+    python3 stri.py \\
+        --genome hg38 \\
+        --reference {reference.base} \\
+        --output $BATCH_TMPDIR/ \\
+        --locus AFF2,ATXN3,HTT,PHOX2B \\
+        --input $CRAM
+
+    ls $BATCH_TMPDIR/
+    cp $BATCH_TMPDIR/foo {j.out_pdf_path}
+    """
+
+    j.command(command(cmd, define_retry_function=True))
+    b.write_output(j.out_pdf_path, str(out_pdf_path))
+    return j

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -68,8 +68,8 @@ def stripy(
         res.set_to_job(j)
         write_bam_cmd = """ALIGNMENT=$CRAM"""
     
-    if sample.sex:
-        sex_argument = f'--sex {str(sample.sex).lower()}'
+    if sample.pedigree.sex:
+        sex_argument = f'--sex {str(sample.pedigree.sex).lower()}'
     else:
         sex_argument = ""
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -35,7 +35,7 @@ def stripy(
     job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
     j = b.new_job('STRipy', job_attrs)
     j.image(image_path('stripy'))
-    res = STANDARD.request_resources(ncpu=2)
+    res = STANDARD.request_resources(ncpu=4, storage_gb=150)
     res.set_to_job(j)
     reference = fasta_res_group(b)
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -21,7 +21,7 @@ def stripy(
     cram_path: CramPath,
     out_path: Path,
     log_path: Path,
-    analysis_type: str = "standard",
+    analysis_type: str = 'standard',
     write_to_bam: bool = False,
     job_attrs: dict | None = None,
     overwrite: bool = False,
@@ -71,7 +71,7 @@ def stripy(
     if sample.pedigree.sex:
         sex_argument = f'--sex {str(sample.pedigree.sex).lower()}'
     else:
-        sex_argument = ""
+        sex_argument = ''
 
     cmd = f"""\
     ## Dodgy re-write of stripy config file

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -69,7 +69,7 @@ def stripy(
 
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}
     CRAI=$BATCH_TMPDIR/{cram_path.index_path.name}
-    LOG=$BATCH_TMPDIR/{log_path.index_path.name}
+    LOG=$BATCH_TMPDIR/{log_path.name}
 
     # Retrying copying to avoid google bandwidth limits
     retry_gs_cp {str(cram_path.path)} $CRAM

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -17,7 +17,7 @@ from cpg_workflows.utils import can_reuse, exists
 def stripy(
     b,
     cram_path: CramPath,
-    out_pdf_path: Path,
+    out_path: Path,
     job_attrs: dict | None = None,
     overwrite: bool = False,
 ) -> Job | None:
@@ -26,7 +26,7 @@ def stripy(
     """
     if can_reuse(
         [
-            out_pdf_path,
+            out_path,
         ],
         overwrite,
     ):
@@ -60,11 +60,11 @@ def stripy(
 
     echo "BATCH_TMPDIR = $BATCH_TMPDIR"
     ls $BATCH_TMPDIR/
-    ls $BATCH_TMPDIR/STRipy*
   
-    cp $BATCH_TMPDIR/foo {j.out_pdf_path}
+    cp $CRAM.bam.html {j.out_path}
+
     """
 
     j.command(command(cmd, define_retry_function=True))
-    b.write_output(j.out_pdf_path, str(out_pdf_path))
+    b.write_output(j.out_path, str(out_path))
     return j

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -64,7 +64,7 @@ def stripy(
     assert cram_path.index_path
     cmd = f"""\
     ## Dodgy write to config
-    sed -i 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' /usr/local/bin/stripy-pipeline/config.json > $BATCH_TMPDIR/config.json
+    sed 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' /usr/local/bin/stripy-pipeline/config.json > $BATCH_TMPDIR/config.json
     cat $BATCH_TMPDIR/config.json
 
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -60,8 +60,8 @@ def stripy(
 
     echo "BATCH_TMPDIR = $BATCH_TMPDIR"
     ls $BATCH_TMPDIR/
-    ls /
-    ls
+    ls $BATCH_TMPDIR/STRipy*
+  
     cp $BATCH_TMPDIR/foo {j.out_pdf_path}
     """
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -35,7 +35,7 @@ def stripy(
     job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
     j = b.new_job('STRipy', job_attrs)
     j.image(image_path('stripy'))
-    res = STANDARD.request_resources(ncpu=4, storage_gb=150)
+    res = STANDARD.request_resources(ncpu=2, storage_gb=100)
     res.set_to_job(j)
     reference = fasta_res_group(b)
 
@@ -48,15 +48,16 @@ def stripy(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
-    samtools view -b -@ 3 -T {reference.base}  $CRAM > $CRAM.bam
+    samtools view -b -@ 2 -T {reference.base}  $CRAM > $CRAM.bam
     samtools index $CRAM.bam
 
     python3 stri.py \\
         --genome hg38 \\
         --reference {reference.base} \\
         --output $BATCH_TMPDIR/ \\
-        --locus AFF2,ATXN3,HTT,PHOX2B \\
-        --input $CRAM.bam
+        --input $CRAM.bam \\
+        --analysis extended \\
+        --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,BEAN1,C9ORF72,CACNA1A,CBL,CNBP,COMP,DAB1,DIP2B,DMD,DMPK,FMR1,FOXL2,FXN,GIPC1,GLS,HOXA13_1,HOXA13_2,HOXA13_3,HOXD13,HTT,JPH3,LRP12,MARCHF6,NIPA1,NOP56,NOTCH2NLC,NUTM2B-AS1,PABPN1,PHOX2B,PPP2R2B,PRDM12,RAPGEF2,RFC1,RUNX2,SAMD12,SOX3,STARD7,TBP,TBX1,TCF4,TNRC6A,XYLT1,YEATS2,ZIC2,ZIC3
 
     echo "BATCH_TMPDIR = $BATCH_TMPDIR"
     ls $BATCH_TMPDIR/

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -48,14 +48,14 @@ def stripy(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
-    samtools view -b -@ 2 -T {reference.base}  $CRAM > $CRAM.bam
-    samtools index $CRAM.bam
+    # samtools view -b -@ 2 -T {reference.base}  $CRAM > $CRAM.bam
+    # samtools index $CRAM.bam
 
     python3 stri.py \\
         --genome hg38 \\
         --reference {reference.base} \\
         --output $BATCH_TMPDIR/ \\
-        --input $CRAM.bam \\
+        --input $CRAM \\
         --analysis extended \\
         --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,BEAN1,C9ORF72,CACNA1A,CBL,CNBP,COMP,DAB1,DIP2B,DMD,DMPK,FMR1,FOXL2,FXN,GIPC1,GLS,HOXA13_1,HOXA13_2,HOXA13_3,HOXD13,HTT,JPH3,LRP12,MARCHF6,NIPA1,NOP56,NOTCH2NLC,NUTM2B-AS1,PABPN1,PHOX2B,PPP2R2B,PRDM12,RAPGEF2,RFC1,RUNX2,SAMD12,SOX3,STARD7,TBP,TBX1,TCF4,TNRC6A,XYLT1,YEATS2,ZIC2,ZIC3
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -71,7 +71,6 @@ def stripy(
 
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}
     CRAI=$BATCH_TMPDIR/{cram_path.index_path.name}
-    LOG=$BATCH_TMPDIR/{log_path.name}
 
     # Retrying copying to avoid google bandwidth limits
     retry_gs_cp {str(cram_path.path)} $CRAM
@@ -84,7 +83,7 @@ def stripy(
         --reference {reference.base} \\
         --output $BATCH_TMPDIR/ \\
         --input $ALIGNMENT \\
-        --logflags $LOG \\
+        --logflags {j.log_path} \\
         --config $BATCH_TMPDIR/config.json \\
         --analysis {analysis_type} \\
         --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,\
@@ -96,7 +95,6 @@ TBX1,TCF4,TNRC6A,XYLT1,YEATS2,ZIC2,ZIC3
     ls $BATCH_TMPDIR/
   
     cp $ALIGNMENT.html {j.out_path}
-    cp $LOG {j.log_path}
 
     """
 

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -64,8 +64,8 @@ def stripy(
     assert cram_path.index_path
     cmd = f"""\
     ## Dodgy write to config
-    sed -i 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' stripy-pipeline/config.json
-    cat stripy-pipeline/config.json
+    sed -i 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' /usr/local/bin/stripy-pipeline/config.json > $BATCH_TMPDIR/config.json
+    cat $BATCH_TMPDIR/config.json
 
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}
     CRAI=$BATCH_TMPDIR/{cram_path.index_path.name}
@@ -83,6 +83,7 @@ def stripy(
         --output $BATCH_TMPDIR/ \\
         --input $ALIGNMENT \\
         --logflags $LOG \\
+        --config $BATCH_TMPDIR/config.json \\
         --analysis {analysis_type} \\
         --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,\
 BEAN1,C9ORF72,CACNA1A,CBL,CNBP,COMP,DAB1,DIP2B,DMD,DMPK,FMR1,FOXL2,FXN,GIPC1,GLS,\

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -18,11 +18,21 @@ def stripy(
     b,
     cram_path: CramPath,
     out_path: Path,
+    log_path: Path,
+    analysis_type: str = "standard",
+    write_to_bam: bool = False,
     job_attrs: dict | None = None,
     overwrite: bool = False,
 ) -> Job | None:
     """
     Run STRipy
+
+    Stripy currently is very inefficient at reading from cram files as it does not pass a local 
+    reference genome when opening the file reader. The right thing to do would be to patch this throughout
+    the package and upstream. As a workaround we can either use the slow default (write_to_bam=False) or
+    convert to a temporary bam then run stripy on that (write_to_bam=True) which is faster but more 
+    expensive due to the local storage required.
+
     """
     if can_reuse(
         [
@@ -35,36 +45,55 @@ def stripy(
     job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
     j = b.new_job('STRipy', job_attrs)
     j.image(image_path('stripy'))
-    # res = STANDARD.request_resources(ncpu=2, storage_gb=100)
-    res = STANDARD.request_resources(ncpu=2)
+    
+    if write_to_bam:
+        res = STANDARD.request_resources(storage_gb=100)
+        write_bam_cmd = '''
+            BAM=$BATCH_TMPDIR/{cram_path.path.stem}.bam
+            samtools view -b -@ 6 -T {reference.base}  $CRAM > $BAM
+            samtools index $BAM
+            ALIGNMENT=$BAM
+        '''
+    else:
+        res = STANDARD.request_resources(ncpu=2)
+        write_bam_cmd = '''ALIGNMENT=$CRAM'''
+    
     res.set_to_job(j)
     reference = fasta_res_group(b)
 
     assert cram_path.index_path
     cmd = f"""\
+    ## Dodgy write to config
+    sed -i 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' stripy-pipeline/config.json
+    cat stripy-pipeline/config.json
+
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}
     CRAI=$BATCH_TMPDIR/{cram_path.index_path.name}
+    LOG=$BATCH_TMPDIR/{log_path.index_path.name}
 
     # Retrying copying to avoid google bandwidth limits
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
-    # samtools view -b -@ 2 -T {reference.base}  $CRAM > $CRAM.bam
-    # samtools index $CRAM.bam
-
-    # --analysis extended 
+    {write_bam_cmd}
+    
     python3 stri.py \\
         --genome hg38 \\
         --reference {reference.base} \\
         --output $BATCH_TMPDIR/ \\
-        --input $CRAM \\
-        --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,BEAN1,C9ORF72,CACNA1A,CBL,CNBP,COMP,DAB1,DIP2B,DMD,DMPK,FMR1,FOXL2,FXN,GIPC1,GLS,HOXA13_1,HOXA13_2,HOXA13_3,HOXD13,HTT,JPH3,LRP12,MARCHF6,NIPA1,NOP56,NOTCH2NLC,NUTM2B-AS1,PABPN1,PHOX2B,PPP2R2B,PRDM12,RAPGEF2,RFC1,RUNX2,SAMD12,SOX3,STARD7,TBP,TBX1,TCF4,TNRC6A,XYLT1,YEATS2,ZIC2,ZIC3
+        --input $ALIGNMENT \\
+        --logflags $LOG \\
+        --analysis {analysis_type} \\
+        --locus AFF2,AR,ARX_1,ARX_2,ATN1,ATXN1,ATXN10,ATXN2,ATXN3,ATXN7,ATXN8OS,\
+BEAN1,C9ORF72,CACNA1A,CBL,CNBP,COMP,DAB1,DIP2B,DMD,DMPK,FMR1,FOXL2,FXN,GIPC1,GLS,\
+HOXA13_1,HOXA13_2,HOXA13_3,HOXD13,HTT,JPH3,LRP12,MARCHF6,NIPA1,NOP56,NOTCH2NLC,\
+NUTM2B-AS1,PABPN1,PHOX2B,PPP2R2B,PRDM12,RAPGEF2,RFC1,RUNX2,SAMD12,SOX3,STARD7,TBP,\
+TBX1,TCF4,TNRC6A,XYLT1,YEATS2,ZIC2,ZIC3
 
-    echo "BATCH_TMPDIR = $BATCH_TMPDIR"
     ls $BATCH_TMPDIR/
   
-    # cp $CRAM.bam.html {j.out_path}
-    cp $CRAM.html {j.out_path}
+    cp $ALIGNMENT.html {j.out_path}
+    cp $LOG {j.log_path}
 
     """
 

--- a/cpg_workflows/stages/gatk_sv.py
+++ b/cpg_workflows/stages/gatk_sv.py
@@ -778,4 +778,3 @@ class AnnotateVcf(DatasetStage):
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:
         pass
-

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -31,8 +31,12 @@ class Stripy(SampleStage):
 
     def expected_outputs(self, sample: Sample) -> dict[str, Path]:
         return {
-            'stripy_html': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html',
-            'stripy_log': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt'
+            'stripy_html': sample.dataset.web_prefix()
+            / 'stripy'
+            / f'{sample._external_id}.stripy.html',
+            'stripy_log': sample.dataset.prefix()
+            / 'stripy'
+            / f'{sample.id}.stripy.log.txt',
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
@@ -42,6 +46,7 @@ class Stripy(SampleStage):
         jobs = []
         j = stripy.stripy(
             b=get_batch(),
+            sample=sample,
             cram_path=CramPath(cram_path, crai_path),
             log_path=self.expected_outputs(sample)['stripy_log'],
             analysis_type=get_config()['stripy']['analysis_type'],

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -45,8 +45,8 @@ class Stripy(SampleStage):
         jobs = []
         j = stripy.stripy(
             b=get_batch(),
-            CramPath(cram_path, crai_path),
-            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.pdf',
+            cram_path=CramPath(cram_path, crai_path),
+            out_pdf_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.pdf',
             job_attrs=self.get_job_attrs(sample),
         )
         jobs.append(j)

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -1,0 +1,55 @@
+"""
+Stage to run STR analysis with SRRipy-pipeline.
+"""
+import logging
+import dataclasses
+from typing import Callable, Optional
+
+from cpg_utils import Path
+from cpg_utils.config import get_config
+from cpg_workflows import get_batch
+from cpg_workflows.filetypes import CramPath
+from cpg_workflows.jobs import stripy
+from cpg_workflows.stages.align import Align
+from cpg_workflows.targets import Sample, Dataset
+from cpg_workflows.utils import exists
+from cpg_workflows.workflow import (
+    stage,
+    StageInput,
+    StageOutput,
+    SampleStage,
+    DatasetStage,
+    StageInputNotFoundError,
+)
+
+
+@stage(required_stages=Align)
+class Stripy(SampleStage):
+    """
+    Call stripy to run STR analysis on known pathogenic loci.
+    """
+
+    def expected_outputs(self, sample: Sample) -> dict[str, Path]:
+        expected_output_path = (
+            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.pdf'
+        )
+
+        return {
+            'stripy_pdf': expected_output_path
+        }
+
+    def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
+        cram_path = inputs.as_path(sample, Align, 'cram')
+        crai_path = inputs.as_path(sample, Align, 'crai')
+
+        jobs = []
+        j = stripy.stripy(
+            b=get_batch(),
+            CramPath(cram_path, crai_path),
+            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.pdf',
+            job_attrs=self.get_job_attrs(sample),
+        )
+        jobs.append(j)
+
+        return self.make_outputs(sample, data=self.expected_outputs(sample), jobs=jobs)
+

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -50,7 +50,7 @@ class Stripy(SampleStage):
         j = stripy.stripy(
             b=get_batch(),
             cram_path=CramPath(cram_path, crai_path),
-            log_path=CramPath(cram_path, crai_path),
+            log_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt',
             analysis_type=get_config()['stripy']['analysis_type'],
             write_to_bam=get_config()['stripy']['write_to_bam'],
             out_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html',

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -53,7 +53,7 @@ class Stripy(SampleStage):
             log_path=self.expected_outputs(sample)['stripy_log'],
             analysis_type=get_config()['stripy']['analysis_type'],
             write_to_bam=get_config()['stripy']['write_to_bam'],
-            out_path=self.expected_outputs(sample)['stripy_html']',
+            out_path=self.expected_outputs(sample)['stripy_html'],
             job_attrs=self.get_job_attrs(sample),
         )
         jobs.append(j)

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -30,10 +30,10 @@ class Stripy(SampleStage):
     """
 
     def expected_outputs(self, sample: Sample) -> dict[str, Path]:
-        expected_output_path = (
+        stripy_html  = (
             sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html'
         )
-        log_path = (
+        stripy_log = (
             sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt'
         )
 
@@ -50,10 +50,10 @@ class Stripy(SampleStage):
         j = stripy.stripy(
             b=get_batch(),
             cram_path=CramPath(cram_path, crai_path),
-            log_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt',
+            log_path=self.expected_outputs(sample)['stripy_log'],
             analysis_type=get_config()['stripy']['analysis_type'],
             write_to_bam=get_config()['stripy']['write_to_bam'],
-            out_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html',
+            out_path=self.expected_outputs(sample)['stripy_html']',
             job_attrs=self.get_job_attrs(sample),
         )
         jobs.append(j)

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -32,7 +32,7 @@ class Stripy(SampleStage):
     def expected_outputs(self, sample: Sample) -> dict[str, Path]:
         return {
             'stripy_html': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html',
-            'stripy_log': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt
+            'stripy_log': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt'
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -30,16 +30,9 @@ class Stripy(SampleStage):
     """
 
     def expected_outputs(self, sample: Sample) -> dict[str, Path]:
-        stripy_html  = (
-            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html'
-        )
-        stripy_log = (
-            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt'
-        )
-
         return {
-            'stripy_html': expected_output_path,
-            'stripy_log': log_path
+            'stripy_html': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html',
+            'stripy_log': sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -31,11 +31,15 @@ class Stripy(SampleStage):
 
     def expected_outputs(self, sample: Sample) -> dict[str, Path]:
         expected_output_path = (
-            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.html'
+            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html'
+        )
+        log_path = (
+            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.log.txt'
         )
 
         return {
-            'stripy_html': expected_output_path
+            'stripy_html': expected_output_path,
+            'stripy_log': log_path
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
@@ -46,10 +50,12 @@ class Stripy(SampleStage):
         j = stripy.stripy(
             b=get_batch(),
             cram_path=CramPath(cram_path, crai_path),
-            out_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.html',
+            log_path=CramPath(cram_path, crai_path),
+            analysis_type=get_config()['stripy']['analysis_type'],
+            write_to_bam=get_config()['stripy']['write_to_bam'],
+            out_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.stripy.html',
             job_attrs=self.get_job_attrs(sample),
         )
         jobs.append(j)
 
         return self.make_outputs(sample, data=self.expected_outputs(sample), jobs=jobs)
-

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -31,11 +31,11 @@ class Stripy(SampleStage):
 
     def expected_outputs(self, sample: Sample) -> dict[str, Path]:
         expected_output_path = (
-            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.pdf'
+            sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.html'
         )
 
         return {
-            'stripy_pdf': expected_output_path
+            'stripy_html': expected_output_path
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
@@ -46,7 +46,7 @@ class Stripy(SampleStage):
         j = stripy.stripy(
             b=get_batch(),
             cram_path=CramPath(cram_path, crai_path),
-            out_pdf_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.pdf',
+            out_path=sample.dataset.prefix() / 'stripy' / f'{sample.external_id}.html',
             job_attrs=self.get_job_attrs(sample),
         )
         jobs.append(j)

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
 from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.seqr_loader import MtToEs, AnnotateDataset
 from cpg_workflows.stages.gatk_sv import ClusterBatch
+from cpg_workflows.stages.stripy import Stripy
 
 fmt = '%(asctime)s %(levelname)s (%(name)s %(lineno)s): %(message)s'
 coloredlogs.install(level='INFO', fmt=fmt)
@@ -25,7 +26,7 @@ coloredlogs.install(level='INFO', fmt=fmt)
 
 WORKFLOWS: dict[str, list[StageDecorator]] = {
     'pre_alignment': [FastQCMultiQC],
-    'seqr_loader': [AnnotateDataset, MtToEs, GvcfMultiQC, CramMultiQC],
+    'seqr_loader': [AnnotateDataset, MtToEs, GvcfMultiQC, CramMultiQC, Stripy],
     'large_cohort': [LoadVqsr, Frequencies, GvcfMultiQC, CramMultiQC],
     'gatk_sv': [ClusterBatch],
 }


### PR DESCRIPTION
Adds a non-default stage `Stripy` to the`seqr_loader` pipeline that runs the tool stripy on each cram.

[Stripy](https://gitlab.com/andreassh/stripy-pipeline/-/tree/main) is STR calling and visualisation tool used to identify STR expansions at known disease-associated STR loci (ie this tool is not useful for STR discovery). Stripy:
- Uses expansion hunter to perform the STR genotyping at each target loci 
- Compares the repeat number to a provided database of population controls and known pathogenic ranges per loci
- Produces an easy-to-read HTML report including a read-level viewer per loci. 

The current implementation does have two issues we will need to look at in the future if we keep using it:
1. It is very inefficient at reading crams as it does not pass a reference genome path to the cram parsers. This makes a job that takes ~3min to run on a bam take close to 3h on an equivalent cram. This could be easily addressed in stripy and (presumably) be upstreamed.
2. This implementation currently fails on a subset of our crams (2/10 tested). Unfortunately, even with the most verbose level of logging no meaningful error or stack trace is provided other than a message saying "run failed". Again, adding some logging to stripy should not be too hard.

Despite these current limitations, I am keen to use this initial implementation 'as is' for wider evaluation of the results in production datasets. Eventually, this is likely to be superseded by the STR calling in GATK-SV, but that will also require interfaces for reviewing the variant calls so this will not be fast even once the GATK-SV is running. 

Running this stage costs 15c per genome using the default setting or 30c per genome using the `write_to_bam` option which is ~3x faster wall time (handy for testing). 
