### PR TITLE
Do not use cached split intervals in the references bucket

### DIFF
--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -115,8 +115,6 @@ somalier_1kg_targz = 'somalier/v0/1kg.somalier.tar.gz'
 somalier_1kg_labels = 'somalier/v0/ancestry-labels-1kg.tsv'
 # Contains uncompressed VEP tarballs for mounting with cloudfuse.
 vep_mount = 'vep/105.0/mount'
-# To cache intervals.
-intervals_prefix = 'intervals'
 # Liftover chain file to translate from GRCh38 to GRCh37 coordinates
 liftover_38_to_37 = 'liftover/grch38_to_grch37.over.chain.gz'
 

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -63,24 +63,6 @@ def get_intervals(
             for idx in range(scatter_count)
         ]
 
-    if not source_intervals_path and exists(
-        (
-            existing_split_intervals_prefix := (
-                reference_path('intervals_prefix')
-                / sequencing_type
-                / f'{scatter_count}intervals'
-            )
-        )
-        / '1.interval_list'
-    ):
-        # We already have split intervals for this sequencing_type:
-        return None, [
-            b.read_input(
-                str(existing_split_intervals_prefix / f'{idx + 1}.interval_list')
-            )
-            for idx in range(scatter_count)
-        ]
-
     j = b.new_job(
         f'Make {scatter_count} intervals for {sequencing_type}',
         attributes=(job_attrs or {}) | dict(tool='picard IntervalListTools'),


### PR DESCRIPTION
We want the references bucket to be clean and [built automatically](https://github.com/populationgenomics/references/pull/2). Using it for storing cached split intervals for different scatter count is a not a good place.