### PR TITLE
Build `cpg_workflows` docker directly from `driver`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_utils:latest
+FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
 COPY README.md .
 COPY setup.py .


### PR DESCRIPTION
So we don't have to rebuild `cpg_utils` first every time.