### PR TITLE
Changes from Miah (fix use Batch backend for seqr annotation)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.10
+current_version = 1.1.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.1.10
+  VERSION: 1.1.11
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,8 @@ jobs:
       IMAGE_NAME: australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows
     steps:
     - uses: actions/checkout@main
+      with:
+        submodules: recursive
 
     - name: gcloud auth
       uses: 'google-github-actions/auth@v0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 COPY README.md .
 COPY setup.py .
 COPY cpg_workflows cpg_workflows
+COPY seqr-loading-pipelines/hail_scripts hail_scripts
 RUN pip install .

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -76,7 +76,7 @@ def annotate_cohort_jobs(
                 str(vcf_path),
                 str(out_mt_path),
                 str(vep_ht_path),
-                str(siteonly_vqsr_vcf_path),
+                str(siteonly_vqsr_vcf_path) if siteonly_vqsr_vcf_path else None,
                 str(checkpoint_prefix),
                 setup_gcp=True,
             )

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -89,9 +89,10 @@ def annotate_cohort(
 
     logging.info('Annotating with seqr-loader fields: round 1')
 
-    # don't fail if the AC attribute is an inappropriate type
-    if isinstance(mt.info.AC, hl.Int32Expression):
-        mt = mt.annotate_rows(info=mt.info.annotate(AC=[mt.info.AC]))
+    # don't fail if the AC/AF attributes are an inappropriate type
+    for attr in ['AC', 'AF']:
+        if not isinstance(mt.info[attr], hl.ArrayExpression):
+            mt = mt.annotate_rows(info=mt.info.annotate(**{attr: [mt.info[attr]]}))
 
     mt = mt.annotate_rows(
         AC=mt.info.AC[mt.a_index - 1],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.1.10',
+    version='1.1.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
A couple more fixes from @jeremiahwander

- the docker image doesn't contain the hail-scripts submodule (@vladsavelyev this will probably also be an issue with the way cpg-workflows is being installed into the driver image? https://github.com/populationgenomics/analysis-runner/pull/561
  - e.g. https://batch.hail.populationgenomics.org.au/batches/381164/jobs/1 
- possibility of `siteonly_vqsr_vcf_path` being None and cast as a String, leading to `to_path('None')` downstream
- extending the array casting to apply to both AC and AF