### PR TITLE
Add udn-aus to seqr load datasets

### DIFF
--- a/configs/seqr-main.toml
+++ b/configs/seqr-main.toml
@@ -22,6 +22,7 @@ input_datasets = [
     'rdp-kidney',
     'schr-neuro',
     # 'udn-aus-training',
+    'udn-aus',
     'validation',
 ]
 


### PR DESCRIPTION
Include udn-aus project in the list of default datasets for seqr loader pipeline 
