### PR TITLE
Option to force stage rerun

### DIFF
--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -31,6 +31,9 @@ cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workf
 # Finish at this stage:
 #last_stages = []
 
+# Force stage rerun
+#force_stages = []
+
 # Map of stages to lists of samples, to skip for specific stages
 #[workflow.skip_samples_stages]
 #CramQC = ['CPG13409']

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -352,7 +352,9 @@ class Stage(Generic[TargetT], ABC):
         self.output_by_target: dict[str, StageOutput | None] = dict()
 
         self.skipped = skipped
-        self.forced = forced
+        self.forced = forced or self.name in get_config()['workflow'].get(
+            'force_stages', []
+        )
         self.assume_outputs_exist = assume_outputs_exist
 
     @property


### PR DESCRIPTION
Add config option `workflow/force_stages` that can specify stage names that need force rerun, regardless whether their expected outputs already exists.