### PR TITLE
Update Config to Skip sample

### DIFF
--- a/configs/prophecy.toml
+++ b/configs/prophecy.toml
@@ -7,6 +7,7 @@ skip_samples = [
   'CPG216010',  # https://batch.hail.populationgenomics.org.au/batches/74382
   'CPG214858',  # missing GVCF
   'CPG216481',  # missing GVCF
+  'CPG241299',  # Replaced by CPG262907
 ]
 
 scatter_count = 20


### PR DESCRIPTION
Latest run https://batch.hail.populationgenomics.org.au/batches/393745/jobs/1 failed because CPG241299 doesn't have an alignment input. It can be skipped because it was replaced by CPG262907 in a later batch. 