### PR TITLE
Don't depend on a specific VEP version for LOFTEE

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.4.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.4.0
+  VERSION: 1.4.1
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -1,6 +1,6 @@
 [images]
 dragmap = 'australia-southeast1-docker.pkg.dev/cpg-common/images/dragmap:1.3.0'
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.4.0'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.4.1'
 
 [workflow]
 # Datasets to load inputs. If not provided, datasets will be determined

--- a/cpg_workflows/jobs/vep.py
+++ b/cpg_workflows/jobs/vep.py
@@ -233,7 +233,7 @@ def vep_one(
     ls {vep_dir}
     ls {vep_dir}/vep
 
-    LOFTEE_PLUGIN_PATH=/root/micromamba/share/ensembl-vep
+    LOFTEE_PLUGIN_PATH=$MAMBA_ROOT_PREFIX/share/ensembl-vep
     FASTA={vep_dir}/vep/homo_sapiens/*/Homo_sapiens.GRCh38*.fa.gz
 
     vep \\

--- a/cpg_workflows/jobs/vep.py
+++ b/cpg_workflows/jobs/vep.py
@@ -233,8 +233,8 @@ def vep_one(
     ls {vep_dir}
     ls {vep_dir}/vep
 
-    LOFTEE_PLUGIN_PATH=/root/micromamba/share/ensembl-vep-105.0-1
-    FASTA={vep_dir}/vep/homo_sapiens/105_GRCh38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz
+    LOFTEE_PLUGIN_PATH=/root/micromamba/share/ensembl-vep
+    FASTA={vep_dir}/vep/homo_sapiens/*/Homo_sapiens.GRCh38*.fa.gz
 
     vep \\
     --format vcf \\

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.4.0',
+    version='1.4.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Depends on images being built after https://github.com/populationgenomics/images/pull/68.

Using a similar wildcard as here: https://github.com/populationgenomics/references/blob/9aeb22804da19193b679087269459d9eeaafb2ea/vep/dataproc-init.sh#L46