### PR TITLE
Fix passing `gnomad` package as dataproc `pyfiles`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.9.0
+  VERSION: 1.9.1
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -1,5 +1,5 @@
 [images]
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.9.0'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.9.1'
 
 [workflow]
 # Datasets to load inputs. If not provided, datasets will be determined

--- a/cpg_workflows/large_cohort/dataproc_utils.py
+++ b/cpg_workflows/large_cohort/dataproc_utils.py
@@ -51,6 +51,17 @@ def dataproc_job(
     script_path = to_path(dataproc_script.__file__)
     rel_script_path = script_path.relative_to(package_path.parent)
 
+    if not to_path(gnomad_path := 'gnomad_methods/gnomad').exists():
+        raise ValueError(
+            f'Cannot find gnomad_methods Git submodule: {gnomad_path}. Make sure '
+            f'you cloned the repo recursively with `git clone --recurse-submodules '
+            f'git@github.com:populationgenomics/production-pipelines.git`.'
+        )
+    pyfiles = [
+        cpg_workflows.__name__,
+        gnomad_path,
+    ]
+
     script = (
         f'{rel_script_path} '
         f'{function.__module__} {function.__name__} '
@@ -64,7 +75,7 @@ def dataproc_job(
             batch=get_batch(),
             cluster_id=cluster_id,
             script=script,
-            pyfiles=[cpg_workflows.__name__],
+            pyfiles=pyfiles,
             job_name=job_name,
             region='australia-southeast1',
         )
@@ -111,9 +122,6 @@ def dataproc_job(
         worker_machine_type='n1-highmem-8' if use_highmem_workers else 'n1-standard-8',
         worker_boot_disk_size=worker_boot_disk_size,
         secondary_worker_boot_disk_size=secondary_worker_boot_disk_size,
-        pyfiles=[
-            cpg_workflows.__name__,
-            'gnomad_methods/gnomad',
-        ],
+        pyfiles=pyfiles,
         init=['gs://cpg-common-main/hail_dataproc/install_common.sh'],
     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.9.0',
+    version='1.9.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
* Update pointer to gnomad_methods with this fix https://github.com/populationgenomics/gnomad_methods/pull/2 (adds `gnomad/__init__.py`
* Fix passing pyfiles for existing dataproc cluster (i.e. `hail.dataproc.cluster_id = ...`)
* Add error check in case if the repo wasn't cloned recursively.