### PR TITLE
Add `workflow.output_version` property that defaults to `alignment_inputs_hash`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.1
+current_version = 1.10.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.9.1
+  VERSION: 1.10.0
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -47,7 +47,7 @@ token_project_id = 'seqr-308602'
 
 [elasticsearch]
 # Configure access to ElasticSearch server
-port = 9243
+port = '9243'
 host = 'elasticsearch.es.australia-southeast1.gcp.elastic-cloud.com'
 username = 'seqr'
 # Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -1,5 +1,5 @@
 [images]
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.9.1'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.10.0'
 
 [workflow]
 # Datasets to load inputs. If not provided, datasets will be determined

--- a/cpg_workflows/stages/joint_genotyping_qc.py
+++ b/cpg_workflows/stages/joint_genotyping_qc.py
@@ -12,6 +12,7 @@ from cpg_workflows.workflow import (
     StageInputNotFoundError,
     Cohort,
     SampleStage,
+    get_workflow,
 )
 
 from cpg_workflows.jobs.multiqc import multiqc
@@ -32,8 +33,13 @@ class JointVcfQC(CohortStage):
         """
         Generate a pVCF and a site-only VCF.
         """
-        h = cohort.alignment_inputs_hash()
-        qc_prefix = cohort.analysis_dataset.prefix() / 'qc' / 'jc' / h / 'picard'
+        qc_prefix = (
+            cohort.analysis_dataset.prefix()
+            / 'qc'
+            / 'jc'
+            / get_workflow().output_version
+            / 'picard'
+        )
         d = {
             'qc_summary': to_path(f'{qc_prefix}.variant_calling_summary_metrics'),
             'qc_detail': to_path(f'{qc_prefix}.variant_calling_detail_metrics'),
@@ -77,13 +83,12 @@ class JointVcfHappy(SampleStage):
         ):
             return None
 
-        h = get_cohort().alignment_inputs_hash()
         return (
             get_cohort().analysis_dataset.prefix()
             / 'qc'
             / 'jc'
             / 'hap.py'
-            / f'{h}-{sample.id}.summary.csv'
+            / f'{get_workflow().output_version}-{sample.id}.summary.csv'
         )
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
@@ -131,13 +136,12 @@ class JointVcfMultiQC(CohortStage):
         if get_config()['workflow'].get('skip_qc', False) is True:
             return {}
 
-        h = cohort.alignment_inputs_hash()
         return {
             'html': cohort.analysis_dataset.web_prefix() / 'qc' / 'jc' / 'multiqc.html',
             'json': cohort.analysis_dataset.prefix()
             / 'qc'
             / 'jc'
-            / h
+            / get_workflow().output_version
             / 'multiqc_data.json',
             'checks': cohort.analysis_dataset.prefix() / 'qc' / 'jc' / h / '.checks',
         }

--- a/cpg_workflows/stages/joint_genotyping_qc.py
+++ b/cpg_workflows/stages/joint_genotyping_qc.py
@@ -143,7 +143,11 @@ class JointVcfMultiQC(CohortStage):
             / 'jc'
             / get_workflow().output_version
             / 'multiqc_data.json',
-            'checks': cohort.analysis_dataset.prefix() / 'qc' / 'jc' / h / '.checks',
+            'checks': cohort.analysis_dataset.prefix()
+            / 'qc'
+            / 'jc'
+            / get_workflow().output_version
+            / '.checks',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -22,7 +22,6 @@ class Combiner(CohortStage):
                 vds_version = f'v{vds_version}'
 
         vds_version = vds_version or get_workflow().output_version
-        vds_version = vds_version or cohort.alignment_inputs_hash()
         return cohort.analysis_dataset.prefix() / 'vds' / f'{vds_version}.vds'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -22,7 +22,7 @@ from cpg_workflows.jobs.seqr_loader import annotate_cohort_jobs, annotate_datase
 from .joint_genotyping import JointGenotyping
 from .vep import Vep
 from .vqsr import Vqsr
-from .. import get_cohort, get_batch
+from .. import get_batch
 
 
 @stage(required_stages=[JointGenotyping, Vqsr, Vep])
@@ -85,10 +85,13 @@ class AnnotateDataset(DatasetStage):
         """
         Expected to generate a matrix table
         """
-        h = get_cohort().alignment_inputs_hash()
         return {
             'tmp_prefix': str(self.tmp_prefix / dataset.name),
-            'mt': dataset.prefix() / 'mt' / f'{h}-{dataset.name}.mt',
+            'mt': (
+                dataset.prefix()
+                / 'mt'
+                / f'{get_workflow().output_version}-{dataset.name}.mt'
+            ),
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:

--- a/scripts/populate_metamist.py
+++ b/scripts/populate_metamist.py
@@ -17,6 +17,7 @@ from cpg_utils.config import get_config, set_config_paths
 from cpg_workflows.inputs import get_cohort
 from cpg_workflows.status import MetamistStatusReporter
 from cpg_workflows.utils import exists
+from cpg_workflows.workflow import get_workflow
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
@@ -34,6 +35,7 @@ def main(command: str, config_paths: list[str]):
     set_config_paths(list(config_paths))
 
     sequencing_type = get_config()['workflow']['sequencing_type']
+    wfl = get_workflow()
     cohort = get_cohort()
     status = MetamistStatusReporter()
 
@@ -126,8 +128,7 @@ def main(command: str, config_paths: list[str]):
             )
 
     if command == 'joint-calling':
-        h = cohort.alignment_inputs_hash()
-        path = cohort.analysis_dataset.prefix() / 'mt' / f'{h}.mt'
+        path = cohort.analysis_dataset.prefix() / 'mt' / f'{wfl.output_version}.mt'
         if exists(path):
             status.create_analysis(
                 str(path),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.9.1',
+    version='1.10.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
One use case is to rerun `MtToEs` for older generated joint calls, even after new samples were added into metamist. E.g. if the previous alignment hash was `0f83bfc5de1170b059445b840b4cfac735c0c5_865`, the configuration below would make the workflow pick up results from the run with that hash (i.e. `gs://cpg-leukodystrophies-main/exome/mt/0f83bfc5de1170b059445b840b4cfac735c0c5_865-leukodystrophies.mt`):

```toml
[workflow]
sequencing_type = "exome"
first_stages = ["MtToEs"]
create_es_index_for_datasets = ["leukodystrophies"]
output_version = "0f83bfc5de1170b059445b840b4cfac735c0c5_865"
```

You can also override the timestamp used for the elastic search suffix; in this case, the es index name will be `leukodystrophies-exome-2022_1220_0250_dfs17`:

```toml
[workflow]
run_timestamp = "2022_1220_0250_dfs17"
```