### PR TITLE
Mechanics to pass a custom function to update `Analysis.meta`

### DIFF
--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -2,6 +2,7 @@
 Stage that generates a CRAM file.
 """
 import logging
+from cloudpathlib import CloudPath
 
 from cpg_utils import Path
 from cpg_utils.config import get_config

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -230,6 +230,7 @@ class MetamistStatusReporter(StatusReporter):
         cmd = f"""
 cat <<EOT >> update.py
 
+from typing import Any, Callable
 from cpg_workflows.metamist import AnalysisStatus
 
 {meta_updaters_definitions}

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -12,7 +12,7 @@ import traceback
 import unicodedata
 from functools import lru_cache
 from random import choices
-from typing import cast
+from typing import cast, Union
 
 from hailtop.batch import ResourceFile
 
@@ -146,3 +146,6 @@ def rich_sample_id_seds(
             cmd += f'sed -iBAK \'s/{sid}/{rich_sid}/g\' {fname}'
             cmd += '\n'
     return cmd
+
+
+ExpectedResultT = Union[Path, dict[str, Path], dict[str, str], str, None]

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -1,6 +1,7 @@
 """
 Test workflow status reporter.
 """
+from typing import Any
 
 import toml
 import pytest
@@ -135,6 +136,45 @@ def test_status_reporter(mocker: MockFixture):
         get_batch().job_by_tool['metamist']['job_n']
         == len(get_cohort().get_samples()) * 4
     )
+
+
+def _update_meta(output_path: str) -> dict[str, Any]:
+    from cloudpathlib import CloudPath
+
+    with CloudPath(output_path).open() as f:
+        return dict(result=f.read().strip())
+
+
+def test_status_reporter_with_custom_updater(mocker: MockFixture):
+    _common(mocker)
+
+    from cpg_utils.hail_batch import dataset_path
+    from cpg_workflows.targets import Sample
+    from cpg_workflows.batch import get_batch
+    from cpg_workflows.workflow import (
+        SampleStage,
+        StageInput,
+        StageOutput,
+        stage,
+        run_workflow,
+    )
+
+    @stage(analysis_type='qc', update_analysis_meta=_update_meta)
+    class MyQcStage(SampleStage):
+        def expected_outputs(self, sample: Sample) -> Path:
+            return to_path(dataset_path(f'{sample.id}.tsv'))
+
+        def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
+            j = get_batch().new_job(
+                'Echo', self.get_job_attrs(sample) | dict(tool='echo')
+            )
+            j.command(f'echo 42 >> {j.output}')
+            get_batch().write_output(j.output, str(self.expected_outputs(sample)))
+            return self.make_outputs(sample, self.expected_outputs(sample), [j])
+
+    run_workflow(stages=[MyQcStage])
+
+    assert 'metamist' in get_batch().job_by_tool, get_batch().job_by_tool
 
 
 def test_status_reporter_fails(mocker: MockFixture):


### PR DESCRIPTION
Supporting passing a custom python function to a stage that is evaluated after the stage is successfully finished. The function takes the output path as input, and returns a dictionary to merge into the `Analysis` entry's metadata.

Example usage is in the `test.test_status.py`:

```python
def _custom_update_meta(output_path: str) -> dict[str, Any]:
    from cloudpathlib import CloudPath

    with CloudPath(output_path).open() as f:
        return {'result': f.read().strip()}

@stage(analysis_type='custom', update_analysis_meta=_custom_update_meta)
class MyStage(SampleStage):
    def expected_outputs(self, sample: Sample) -> Path:
        return to_path(dataset_path('my_output.txt'))

    def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
        j = get_batch().new_job('My job', self.get_job_attrs(sample))
        j.command(f'echo 42 >> {j.output}')
        get_batch().write_output(j.output, str(self.expected_outputs(sample)))
        return self.make_outputs(sample, self.expected_outputs(sample), [j])

run_workflow(stages=[MyStage])
```

Successful job will produce an `Analysis` entry with the `result` field in `meta`:

```yaml
id = 1
output = 'gs://.../my_output.txt'
meta:
    result = 42
``` 

Context and inspiration for this feature: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1671765903071339?thread_ts=1671672065.519439&cid=C030X7WGFCL