### PR TITLE
Allow passing remote path to `main.py --config <path>`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.10.0
+current_version = 1.11.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.10.0
+  VERSION: 1.11.0
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -1,5 +1,5 @@
 [images]
-cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.10.0'
+cpg_workflows = 'australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.11.0'
 
 [workflow]
 # Datasets to load inputs. If not provided, datasets will be determined

--- a/main.py
+++ b/main.py
@@ -38,7 +38,6 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     '--config',
     'config_paths',
     multiple=True,
-    type=click.Path(exists=True),
     help='Add configuration files to the files specified $CPG_CONFIG_PATH.'
     'Configs are merged left to right, meaning the rightmost file has the'
     'highest priority.',
@@ -93,6 +92,10 @@ def main(
 
     wfl_conf_path = to_path(__file__).parent / f'configs/defaults/{workflow}.toml'
     assert wfl_conf_path.exists(), wfl_conf_path
+
+    for path in config_paths:
+        assert to_path(path).exists(), path
+
     config_paths = os.environ['CPG_CONFIG_PATH'].split(',') + list(config_paths)
     # Assuming the defaults is already loaded in __init__.py:
     assert to_path(config_paths[0]) == defaults_config_path

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.10.0',
+    version='1.11.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Just handy for debugging.

Normally you would pass your config file via the analysis runner CLI, e.g.:

```sh
analysis-runner --dataset seqr --access-level test --description "Test" --output-dir output \
--image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest \
--config ~/tmp/myconfig.toml \
main.py seqr_loader
```

However, you might want to quicker iterate on debugging issues when running the main workflow code, and run `main.py seqr_loader` directly. In this case, it's handy to dig out the final merged config remote path as it's generated by the analysis runner by checking out job's `CPG_CONFIG_PATH` env variable, e.g.:

<img width="783" alt="Screen Shot 2023-01-06 at 14 31 53" src="https://user-images.githubusercontent.com/1575412/210924528-e70d2082-2728-4927-8fbd-53b7ec7f4d25.png">

And then pass it directly to `main.py` as follows:

```sh
python main.py seqr_loader --config gs://cpg-seqr-test-tmp/batch-tmp/config/4c1c812c-1907-43b5-9491-eb41b802d723.toml
```