### PR TITLE
Script to remove arbitrary workflow output using suffix

### DIFF
--- a/scripts/remove_file.py
+++ b/scripts/remove_file.py
@@ -13,6 +13,7 @@ def main(suffix: str):
     Remove arbitrary file from a workflow run output prefix.
     """
 
+    print('Loading workflow...')
     wfl = get_workflow()
     path = wfl.prefix / suffix
     print(f'Using workflow prefix {wfl.prefix}, full path would be {path}')
@@ -21,3 +22,7 @@ def main(suffix: str):
     else:
         path.unlink()
         print(f'Removed object {path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Usage:

```python
python scripts/remove_file.py Vqsr/tmp/gathered.vcf.gz
```

The prefix is determined from the config, assuming same config as used for the original workflow.

E.g. for the recent exome seqr load, it will remove `gs://cpg-seqr-main/exome/seqr_loader/14433af228078f9910041fff009835c8c43709_862/Vqsr/tmp/gathered.vcf.gz`

I'm not sure though if it's too much flexible and unsafe, so leaving for Leo to review

cc @cassimons 