### PR TITLE
fix annotate_cohort.py invocation typo

### DIFF
--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -31,7 +31,7 @@ def annotate_cohort_jobs(
 
         # Script path and pyfiles should be relative to the repository root
         script = (
-            'cpg_workflows/dataproc_scripts/annotate_cohort.py'
+            'cpg_workflows/dataproc_scripts/annotate_cohort.py '
             f'--vcf-path {vcf_path} '
             f'--vep-ht-path {vep_ht_path} '
             f'--out-mt-path {out_mt_path} '


### PR DESCRIPTION
The invocation of annotate_cohort.py is mis formated leading to this error: https://batch.hail.populationgenomics.org.au/batches/420104/jobs/206