### PR TITLE
Enable QC reporting to Slack. Minor touches to Slack messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,3 +698,30 @@ CramQC = ['CPG13409']
 ### Available stages
 
 To see available workflow stages, explore the `cpg_workflows/stages` folder. A stage wrappers for Hail Batch jobs that allow to glue them together into genomics workflows. `cpg_workflows` also provides helper functions that create Hail Batch jobs for different domain-specific applications, e.g. alignment, deduplication, QC, variant calling, creating calling intervals, running VQSR, creating ES index, etc. Those jobs can be called from the `queue_jobs` method of a stage, or in isolation, as they don't need to know about the stage they are called from, but only need a `Batch` object.
+
+
+### Slack QC notifications
+
+Config's `[slack]` section activates QC reports to a Slack channel. For example:
+
+```toml
+[slack]
+channel = 'workflows-qc'
+token_secret_id = 'slack-seqr-loader-token'
+token_project_id = 'seqr-308602'
+```
+
+Would send messages on QC completion to the `workflows-qc` channel, flagging failed samples.
+
+Two scripts send Slack messages: `check_multiqc.py` and `check_pedigree.py`. Note that the MultiQC checks only work when the `qc_thresholds` section is also specified, for example:
+
+```toml
+[qc_thresholds.genome.min]
+"MEDIAN_COVERAGE" = 10
+"PCT_PF_READS_ALIGNED" = 80
+[qc_thresholds.genome.max]
+"FREEMIX" = 0.04
+"PERCENT_DUPLICATION" = 25
+```
+
+Thresholds can be adjusted as needed, per workflow or dataset. Note that the metrics names here should match the ones in the MultiQC JSON.

--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ Two scripts send Slack messages: `check_multiqc.py` and `check_pedigree.py`. Not
 ```toml
 [qc_thresholds.genome.min]
 "MEDIAN_COVERAGE" = 10
-"PCT_PF_READS_ALIGNED" = 80
+"PCT_PF_READS_ALIGNED" = 0.80
 [qc_thresholds.genome.max]
 "FREEMIX" = 0.04
 "PERCENT_DUPLICATION" = 25

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -56,7 +56,7 @@ token_project_id = 'seqr-308602'
 
 [qc_thresholds.genome.min]
 "MEDIAN_COVERAGE" = 10
-"PCT_PF_READS_ALIGNED" = 80
+"PCT_PF_READS_ALIGNED" = 0.80
 [qc_thresholds.genome.max]
 "FREEMIX" = 0.04
 "PERCENT_DUPLICATION" = 25

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -48,3 +48,15 @@ delete_scratch_on_exit = false
 [references.gnomad]
 tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht"
 predetermined_qc_variants = "gs://cpg-common-main/references/gnomad/v0/sample_qc/pre_ld_pruning_qc_variants.ht"
+
+[slack]
+channel = 'workflows-qc'
+token_secret_id = 'slack-seqr-loader-token'
+token_project_id = 'seqr-308602'
+
+[qc_thresholds.genome.min]
+"MEDIAN_COVERAGE" = 10
+"PCT_PF_READS_ALIGNED" = 80
+[qc_thresholds.genome.max]
+"FREEMIX" = 0.04
+"PERCENT_DUPLICATION" = 25

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -48,15 +48,3 @@ delete_scratch_on_exit = false
 [references.gnomad]
 tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht"
 predetermined_qc_variants = "gs://cpg-common-main/references/gnomad/v0/sample_qc/pre_ld_pruning_qc_variants.ht"
-
-[slack]
-channel = 'workflows-qc'
-token_secret_id = 'slack-seqr-loader-token'
-token_project_id = 'seqr-308602'
-
-[qc_thresholds.genome.min]
-"MEDIAN_COVERAGE" = 10
-"PCT_PF_READS_ALIGNED" = 0.80
-[qc_thresholds.genome.max]
-"FREEMIX" = 0.04
-"PERCENT_DUPLICATION" = 25

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -31,7 +31,7 @@ indel_filter_level = 99.0
 
 [qc_thresholds.genome.min]
 "MEDIAN_COVERAGE" = 10
-"PCT_PF_READS_ALIGNED" = 80
+"PCT_PF_READS_ALIGNED" = 0.80
 [qc_thresholds.genome.max]
 "FREEMIX" = 0.04
 "PERCENT_DUPLICATION" = 25

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -41,7 +41,7 @@ pool_label = 'seqr'
 billing_project = 'seqr'
 
 [slack]
-channel = 'seqr-loader-test'
+channel = 'workflows-qc'
 token_secret_id = 'slack-seqr-loader-token'
 token_project_id = 'seqr-308602'
 

--- a/cpg_workflows/jobs/multiqc.py
+++ b/cpg_workflows/jobs/multiqc.py
@@ -13,6 +13,7 @@ from cpg_utils import to_path
 from cpg_utils.hail_batch import image_path, copy_common_env, command
 from cpg_utils import Path
 from cpg_workflows.resources import STANDARD
+from cpg_workflows.slack import slack_env
 from cpg_workflows.targets import Dataset
 from cpg_workflows.utils import rich_sample_id_seds
 from cpg_workflows.python_scripts import check_multiqc

--- a/cpg_workflows/python_scripts/check_multiqc.py
+++ b/cpg_workflows/python_scripts/check_multiqc.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 """
-Checks metrics in MultiQC output, based on thresholds in the `qc_thresholds` 
+Checks metrics in MultiQC output, based on thresholds in the qc_thresholds 
 config section.
 
-Script can send a report to a Slack channel. To enable that, set `SLACK_TOKEN`
-and `SLACK_CHANNEL` environment variables, and add "Seqr Loader" app into 
+Script can send a report to a Slack channel. To enable that, set SLACK_TOKEN
+and SLACK_CHANNEL environment variables, and add "Seqr Loader" app into 
 a channel with:
 
 /invite @Seqr Loader

--- a/cpg_workflows/python_scripts/check_multiqc.py
+++ b/cpg_workflows/python_scripts/check_multiqc.py
@@ -105,10 +105,11 @@ def run(
                         if is_fail(val, threshold):
                             line = f'{metric}={val:0.2f}{fail_sign}{threshold:0.2f}'
                             bad_lines_by_sample[sample].append(line)
-                            logging.info(f'⭕ {sample}: {line}')
+                            logging.info(f'❗ {sample}: {line}')
                         else:
                             line = f'{metric}={val:0.2f}{good_sign}{threshold:0.2f}'
                             logging.info(f'✅ {sample}: {line}')
+    logging.info('')
 
     # Constructing Slack message
     if dataset and html_url:
@@ -117,9 +118,9 @@ def run(
         title = 'MultiQC report'
     messages = []
     if bad_lines_by_sample:
-        messages.append(f'{title}')
+        messages.append(f'{title}. {len(bad_lines_by_sample)} samples are flagged:')
         for sample, bad_lines in bad_lines_by_sample.items():
-            messages.append(f'⭕ {sample}: ' + ', '.join(bad_lines))
+            messages.append(f'❗ {sample}: ' + ', '.join(bad_lines))
     else:
         messages.append(f'✅ {title}')
     text = '\n'.join(messages)

--- a/cpg_workflows/python_scripts/check_multiqc.py
+++ b/cpg_workflows/python_scripts/check_multiqc.py
@@ -13,14 +13,13 @@ a channel with:
 import logging
 import json
 import pprint
-import os
 from collections import defaultdict
 from typing import Optional
 
 import click
 from cpg_utils import to_path
 from cpg_utils.config import get_config
-
+from cpg_workflows.slack import send_message
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
@@ -126,23 +125,8 @@ def run(
     text = '\n'.join(messages)
     logging.info(text)
 
-    slack_channel = get_config().get('slack', {}).get('channel')
-    slack_token = os.environ.get('SLACK_TOKEN')
-    if send_to_slack and slack_token and slack_channel:
-        from slack_sdk.errors import SlackApiError
-        from slack_sdk import WebClient
-
-        slack_client = WebClient(token=slack_token)
-        try:
-            slack_client.api_call(  # pylint: disable=duplicate-code
-                'chat.postMessage',
-                json={
-                    'channel': slack_channel,
-                    'text': text,
-                },
-            )
-        except SlackApiError as err:
-            logging.error(f'Error posting to Slack: {err}')
+    if send_to_slack:
+        send_message(text)
 
 
 if __name__ == '__main__':

--- a/cpg_workflows/python_scripts/check_pedigree.py
+++ b/cpg_workflows/python_scripts/check_pedigree.py
@@ -47,7 +47,7 @@ logging.getLogger().setLevel(logging.DEBUG)
     required=True,
     help='Path to PED file with expected pedigree',
 )
-@click.option('--html-url', 'html_url', required=True, help='Somalier HTML URL')
+@click.option('--html-url', 'html_url', help='Somalier HTML URL')
 @click.option('--dataset', 'dataset', help='Dataset name')
 @click.option('--title', 'title', help='Report title')
 @click.option(
@@ -59,8 +59,8 @@ def main(
     somalier_samples_fpath: str,
     somalier_pairs_fpath: str,
     expected_ped_fpath: str,
-    html_url: str,
-    dataset: str,
+    html_url: Optional[str] = None,
+    dataset: Optional[str] = None,
     title: Optional[str] = None,
     send_to_slack: bool = True,
 ):
@@ -129,7 +129,7 @@ def run(
     bad = df.gt_depth_mean == 0.0
     if bad.any():
         warning(
-            f'Excluded {len(df[bad])}/{len(df)} samples with zero '
+            f'⚠️ Excluded {len(df[bad])}/{len(df)} samples with zero '
             f'mean GT depth from pedigree/sex checks: {", ".join(df[bad].sample_id)}'
         )
         info('')
@@ -164,22 +164,24 @@ def run(
             )
 
     if mismatching_sex.any():
-        info(f'{len(df[mismatching_sex])}/{len(df)} PED samples with mismatching sex:')
+        info(
+            f'❗ {len(df[mismatching_sex])}/{len(df)} PED samples with mismatching sex:'
+        )
         _print_stats(mismatching_sex)
     if missing_provided_sex.any():
         info(
-            f'{len(df[missing_provided_sex])}/{len(df)} samples with missing provided sex:'
+            f'⚠️ {len(df[missing_provided_sex])}/{len(df)} samples with missing provided sex:'
         )
         _print_stats(missing_provided_sex)
     if missing_inferred_sex.any():
         info(
-            f'{len(df[missing_inferred_sex])}/{len(df)} samples with failed inferred sex:'
+            f'⚠️ {len(df[missing_inferred_sex])}/{len(df)} samples with failed inferred sex:'
         )
         _print_stats(missing_inferred_sex)
     inferred_cnt = len(df[~missing_inferred_sex])
     matching_cnt = len(df[matching_sex])
     info(
-        f'Sex inferred for {inferred_cnt}/{len(df)} samples, matching '
+        f'✅ Sex inferred for {inferred_cnt}/{len(df)} samples, matching '
         f'for {matching_cnt if matching_cnt != inferred_cnt else "all"} samples.'
     )
     info('')
@@ -247,7 +249,7 @@ def run(
 
     if mismatching_unrelated_to_related:
         info(
-            f'Found {len(mismatching_unrelated_to_related)} '
+            f'⚠️ Found {len(mismatching_unrelated_to_related)} '
             f'sample pair(s) that are provided as unrelated, are inferred as '
             f'related:'
         )
@@ -255,13 +257,13 @@ def run(
             info(f' {i + 1}. {pair}')
     if mismatching_related_to_unrelated:
         info(
-            f'Found {len(mismatching_related_to_unrelated)} sample pair(s) '
+            f'❗ Found {len(mismatching_related_to_unrelated)} sample pair(s) '
             f'that are provided as related, but inferred as unrelated:'
         )
         for i, pair in enumerate(mismatching_related_to_unrelated):
             info(f' {i + 1}. {pair}')
     if not mismatching_unrelated_to_related and not mismatching_related_to_unrelated:
-        info(f'Inferred pedigree matches for all provided related pairs.')
+        info(f'✅ Inferred pedigree matches for all provided related pairs.')
     info('')
 
     print_contents(

--- a/cpg_workflows/python_scripts/check_pedigree.py
+++ b/cpg_workflows/python_scripts/check_pedigree.py
@@ -4,8 +4,8 @@
 This script parses "somalier relate" (https://github.com/brentp/somalier) outputs,
 and returns a report whether sex and pedigree matches the provided PED file.
 
-Script can send a report to a Slack channel. To enable that, set `SLACK_TOKEN`
-and `SLACK_CHANNEL` environment variables, and add "Seqr Loader" app into 
+Script can send a report to a Slack channel. To enable that, set SLACK_TOKEN
+and SLACK_CHANNEL environment variables, and add "Seqr Loader" app into 
 a channel with:
 
 /invite @Seqr Loader
@@ -21,8 +21,7 @@ import pandas as pd
 from peddy import Ped
 
 from cpg_utils import to_path
-from cpg_utils.config import get_config
-
+from cpg_workflows.slack import send_message
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
@@ -280,23 +279,8 @@ def run(
         title = 'Somalier pedigree report'
     text = '\n'.join([title] + _messages)
 
-    slack_channel = get_config().get('slack', {}).get('channel')
-    slack_token = os.environ.get('SLACK_TOKEN')
-    if send_to_slack and slack_token and slack_channel:
-        from slack_sdk.errors import SlackApiError
-        from slack_sdk import WebClient
-
-        slack_client = WebClient(token=slack_token)
-        try:
-            slack_client.api_call(  # pylint: disable=duplicate-code
-                'chat.postMessage',
-                json={
-                    'channel': slack_channel,
-                    'text': text,
-                },
-            )
-        except SlackApiError as err:
-            logging.error(f'Error posting to Slack: {err}')
+    if send_to_slack:
+        send_message(text)
 
 
 def print_contents(

--- a/cpg_workflows/slack.py
+++ b/cpg_workflows/slack.py
@@ -18,8 +18,12 @@ from hailtop.batch.job import Job
 
 
 def send_message(text: str):
-    slack_channel = get_config().get('slack', {}).get('channel')
-    if slack_channel:
+    """
+    Send text as a Slack message, reading credentials from the config.
+    """
+    if slack_channel := (
+        os.environ.get('SLACK_CHANNEL') or get_config().get('slack', {}).get('channel')
+    ):
         slack_token = get_token()
         from slack_sdk.errors import SlackApiError
         from slack_sdk import WebClient

--- a/test/test_check_multiqc.py
+++ b/test/test_check_multiqc.py
@@ -26,6 +26,6 @@ def test_check_multiqc(mocker: MockFixture, caplog):
 
     data_dir = to_path(__file__).parent / 'data' / 'check_multiqc'
     check_multiqc.run(str(data_dir / 'validation_multiqc.json'))
-    for expected_line in ['⭕ CPG243717|NA12878_KCCG: MEDIAN_COVERAGE=8.00<10.00']:
+    for expected_line in ['❗ CPG243717|NA12878_KCCG: MEDIAN_COVERAGE=8.00<10.00']:
         matching_lines = [expected_line in msg for msg in caplog.messages]
         assert any(matching_lines)

--- a/test/test_check_multiqc.py
+++ b/test/test_check_multiqc.py
@@ -12,7 +12,7 @@ sequencing_type = 'genome'
 
 [qc_thresholds.genome.min]
 "MEDIAN_COVERAGE" = 10
-"PCT_PF_READS_ALIGNED" = 80
+"PCT_PF_READS_ALIGNED" = 0.80
 [qc_thresholds.genome.max]
 "FREEMIX" = 0.04
 "PERCENT_DUPLICATION" = 25


### PR DESCRIPTION
Config's `[slack]` section - if added - activates QC reports to a Slack channel. For example:

```toml
[slack]
channel = 'workflows-qc'
token_secret_id = 'slack-seqr-loader-token'
token_project_id = 'seqr-308602'
```

Would send messages on QC completion to `workflows-qc`, flagging failed samples.

Here, re-enabling this functionality. I also renamed the existing `seqr-loader-test` channel to `workflows-qc`, as it should be relevant for any workflows. However, I'm only keeping it for the seqr loader now, as the secret `slack-seqr-loader-token` is maintained manually under the `seqr-308602` project, and other datasets can't read it, so we would need to move it under Pulumi to add read access for other datasets and enable it for large-cohort as well.

Two scripts send Slack messages: `check_multiqc.py` and `check_pedigree.py` (pedigree/sex checks with Somalier). Note that the MultiQC checks only work when the `qc_thresholds` section is also specified, for example:

```toml
[qc_thresholds.genome.min]
"MEDIAN_COVERAGE" = 10
"PCT_PF_READS_ALIGNED" = 0.80
[qc_thresholds.genome.max]
"FREEMIX" = 0.04
"PERCENT_DUPLICATION" = 25
```

Thresholds can be adjusted as needed, per workflow or dataset. Note that the metrics names here should match the ones in the MultiQC JSON; e.g. gs://cpg-validation-main/qc/cram/f5705fb1bb4bb1a966c4e970029d9072460d5e_6/multiqc_data.json

Additionally:
* abstracted sending Slack messages into a function in the `slack` module;
* reading the token from a gcloud secret directly inside the job, instead of passing it as an environment variable, to avoid expositing it;
* fixing the % of unalignment reads thresholds;
* removed backticks to get rid of misleading error logging in Batch jobs;
* added documentation for the Slack section;
* more emojis ✅