### PR TITLE
Remove temporary MultiQC fix

### DIFF
--- a/cpg_workflows/jobs/multiqc.py
+++ b/cpg_workflows/jobs/multiqc.py
@@ -92,11 +92,6 @@ def multiqc(
     mkdir inputs
     cat {file_list} | gsutil -m cp -I inputs/
     
-    # Temporary fix for Somalier module before https://github.com/ewels/MultiQC/pull/1670
-    # is merged and released:
-    git clone --single-branch --branch fix-somalier https://github.com/vladsaveliev/MultiQC
-    pip3 install -e MultiQC
-
     multiqc -f inputs -o output \\
     {f"--replace-names {sample_map_file} " if sample_map_file else ''} \\
     --title "{title} for dataset <b>{dataset.name}</b>" \\

--- a/cpg_workflows/jobs/multiqc.py
+++ b/cpg_workflows/jobs/multiqc.py
@@ -91,7 +91,7 @@ def multiqc(
     cmd = f"""\
     mkdir inputs
     cat {file_list} | gsutil -m cp -I inputs/
-    
+
     multiqc -f inputs -o output \\
     {f"--replace-names {sample_map_file} " if sample_map_file else ''} \\
     --title "{title} for dataset <b>{dataset.name}</b>" \\


### PR DESCRIPTION
MultiQC 1.14 is finally released https://github.com/ewels/MultiQC/releases/tag/v1.14 and we updated our local images template  https://github.com/populationgenomics/images/pull/71 so it's safe now to remove the temporary fix for Somalier.