### PR TITLE
Skip missing 1KG samples

### DIFF
--- a/configs/thousand-genomes.toml
+++ b/configs/thousand-genomes.toml
@@ -7,6 +7,7 @@ scatter_count = 20
 last_stages = ['SampleQC']
 output_version = '1.0'
 skip_qc = true
+skip_samples = ['CPG88088', 'CPG88435']
 
 # CRAMs were aligned using an unmasked reference: 
 # gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta


### PR DESCRIPTION
https://batch.hail.populationgenomics.org.au/batches/420747/jobs/1 failed because those 2 samples are missing alignment inputs. Not sure why they were passed initially, but probably better to skip them for now (for our purposes). 
