### PR TITLE
Remove version bump from `cpg_workflows/defaults.toml`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,6 +9,3 @@ tag = False
 search = VERSION: {current_version}
 replace = VERSION: {new_version}
 
-[bumpversion:file:cpg_workflows/defaults.toml]
-search = cpg_workflows:{current_version}
-replace = cpg_workflows:{new_version}


### PR DESCRIPTION
The setting got removed in https://github.com/populationgenomics/production-pipelines/pull/247/files#diff-9171370508067ddcecb12ba0b0c2572749216b6eb1cd2e14a6b3fc48ed6a687e.