### PR TITLE
Fix path for tabix output file

### DIFF
--- a/cpg_workflows/jobs/vcf.py
+++ b/cpg_workflows/jobs/vcf.py
@@ -210,6 +210,6 @@ def tabix_vcf(
 
     j.command(command(cmd, monitor_space=True))
     if out_tbi_path:
-        b.write_output(j.output_tbi, str(out_tbi_path))
+        b.write_output(j.output_tbi['vcf.gz.tbi'], str(out_tbi_path))
 
     return j


### PR DESCRIPTION
The tabix job is currently trying to output a resource group rather than just the index file resulting in errors like this:
https://batch.hail.populationgenomics.org.au/batches/421210/jobs/3

This PR scopes the output to just the index file.