### PR TITLE
Fix force re-run 

### DIFF
--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -18,7 +18,7 @@ from cpg_workflows.workflow import (
 )
 
 
-@stage(analysis_type='cram', analysis_key='cram')
+@stage(analysis_type='cram', analysis_keys=['cram'])
 class Align(SampleStage):
     """
     Align or re-align input data to produce a CRAM file

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -144,6 +144,8 @@ class CramQC(SampleStage):
         crai_path = inputs.as_path(sample, Align, 'crai')
 
         jobs = []
+        # This should run if either the stage or the sample is being forced.
+        forced = self.forced or sample.forced
         for qc in qc_functions():
             out_path_kwargs = {
                 f'out_{key}_path': self.expected_outputs(sample)[key]
@@ -154,7 +156,7 @@ class CramQC(SampleStage):
                     get_batch(),
                     CramPath(cram_path, crai_path),
                     job_attrs=self.get_job_attrs(sample),
-                    overwrite=sample.forced,
+                    overwrite=forced,
                     **out_path_kwargs,
                 )
                 if j:

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -112,7 +112,16 @@ def qc_functions() -> list[Qc]:
     return qcs
 
 
-@stage(required_stages=Align)
+@stage(
+    required_stages=Align,
+    analysis_type='qc',
+    analysis_keys=[
+        'somalier',
+        'verify_bamid',
+        'samtools_stats',
+        'alignment_summary_metrics',
+    ],
+)
 class CramQC(SampleStage):
     """
     Calling tools that process CRAM for QC purposes.
@@ -248,7 +257,7 @@ def _update_meta(output_path: str) -> dict[str, Any]:
         SomalierPedigree,
     ],
     analysis_type='qc',
-    analysis_key='json',
+    analysis_keys=['json'],
     update_analysis_meta=_update_meta,
 )
 class CramMultiQC(DatasetStage):

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -120,6 +120,11 @@ def qc_functions() -> list[Qc]:
         'verify_bamid',
         'samtools_stats',
         'alignment_summary_metrics',
+        'base_distribution_by_cycle_metrics',
+        'insert_size_metrics',
+        'quality_by_cycle_metrics',
+        'quality_yield_metrics',
+        'picard_wgs_metrics',
     ],
 )
 class CramQC(SampleStage):

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -19,7 +19,7 @@ from .. import get_batch
 @stage(
     required_stages=Align,
     analysis_type='gvcf',
-    analysis_key='gvcf',
+    analysis_keys=['gvcf'],
 )
 class Genotype(SampleStage):
     """

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -119,7 +119,7 @@ def _update_meta(output_path: str) -> dict[str, Any]:
         GvcfHappy,
     ],
     analysis_type='qc',
-    analysis_key='json',
+    analysis_keys=['json'],
     update_analysis_meta=_update_meta,
 )
 class GvcfMultiQC(DatasetStage):

--- a/cpg_workflows/stages/joint_genotyping_qc.py
+++ b/cpg_workflows/stages/joint_genotyping_qc.py
@@ -133,7 +133,7 @@ def _update_meta(output_path: str) -> dict[str, Any]:
         JointVcfHappy,
     ],
     analysis_type='qc',
-    analysis_key='json',
+    analysis_keys=['json'],
     update_analysis_meta=_update_meta,
 )
 class JointVcfMultiQC(CohortStage):

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -135,7 +135,7 @@ def es_password() -> str:
 @stage(
     required_stages=[AnnotateDataset],
     analysis_type='es-index',
-    analysis_key='index_name',
+    analysis_keys=['index_name'],
 )
 class MtToEs(DatasetStage):
     """

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -20,7 +20,7 @@ from cpg_workflows.workflow import (
 )
 
 
-@stage(required_stages=Align, analysis_type='web', analysis_key='stripy_html')
+@stage(required_stages=Align, analysis_type='web', analysis_keys=['stripy_html'])
 class Stripy(SampleStage):
     """
     Call stripy to run STR analysis on known pathogenic loci.

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -512,8 +512,8 @@ class Stage(Generic[TargetT], ABC):
                 if not all(key in outputs.data for key in self.analysis_keys):
                     raise WorkflowError(
                         f'Cannot create Analysis for stage {self.name}: `analysis_keys` '
-                        f'"{self.analysis_keys}" is not found in the expected_outputs '
-                        f'dict {outputs.data}'
+                        f'"{self.analysis_keys}" is not a subset of the expected_outputs '
+                        f'keys {outputs.data.keys()}'
                     )
 
                 for analysis_key in self.analysis_keys:

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -341,7 +341,6 @@ class Stage(Generic[TargetT], ABC):
         # If `analysis_type` is defined, it will be used to create/update Analysis
         # entries in Metamist.
         self.analysis_type = analysis_type
-        print(f'When initialising the stage the analysis type is {analysis_type}')
         # If `analysis_keys` are defined, it will be used to extract the value for
         # `Analysis.output` if the Stage.expected_outputs() returns a dict.
         self.analysis_keys = analysis_keys

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -320,7 +320,7 @@ class Stage(Generic[TargetT], ABC):
         name: str,
         required_stages: list[StageDecorator] | StageDecorator | None = None,
         analysis_type: str | None = None,
-        analysis_key: str | None = None,
+        analysis_keys: list[str] | None = None,
         update_analysis_meta: Callable[[str], dict] | None = None,
         skipped: bool = False,
         assume_outputs_exist: bool = False,
@@ -341,9 +341,10 @@ class Stage(Generic[TargetT], ABC):
         # If `analysis_type` is defined, it will be used to create/update Analysis
         # entries in Metamist.
         self.analysis_type = analysis_type
-        # If `analysis_key` is defined, it will be used to extract the value for
+        print(f'When initialising the stage the analysis type is {analysis_type}')
+        # If `analysis_keys` are defined, it will be used to extract the value for
         # `Analysis.output` if the Stage.expected_outputs() returns a dict.
-        self.analysis_key = analysis_key
+        self.analysis_keys = analysis_keys
         # if `update_analysis_meta` is defined, it is called on the `Analysis.output`
         # field, and result is merged into the `Analysis.meta` dictionary.
         self.update_analysis_meta = update_analysis_meta
@@ -499,36 +500,46 @@ class Stage(Generic[TargetT], ABC):
             and action == Action.QUEUE
             and outputs.data
         ):
-            output: str | Path
+
+            analysis_outputs: list[str | Path] = []
             if isinstance(outputs.data, dict):
-                if not self.analysis_key:
+                if not self.analysis_keys:
                     raise WorkflowError(
-                        f'Cannot create Analysis: `analysis_key` '
+                        f'Cannot create Analysis: `analysis_keys` '
                         f'must be set with the @stage decorator to select value from '
                         f'the expected_outputs dict: {outputs.data}'
                     )
-                if self.analysis_key not in outputs.data:
-                    raise WorkflowError(
-                        f'Cannot create Analysis for stage {self.name}: `analysis_key` '
-                        f'"{self.analysis_key}" is not found in the expected_outputs '
-                        f'dict {outputs.data}'
-                    )
-                output = outputs.data[self.analysis_key]
+                # TODO: Fix this
+                # if self.analysis_keys not in outputs.data:
+                #     raise WorkflowError(
+                #         f'Cannot create Analysis for stage {self.name}: `analysis_keys` '
+                #         f'"{self.analysis_keys}" is not found in the expected_outputs '
+                #         f'dict {outputs.data}'
+                #     )
+
+                for analysis_key in self.analysis_keys:
+                    analysis_outputs.append(outputs.data[analysis_key])
+
+                # analysis_output = outputs.data[self.analysis_keys]
             else:
-                output = outputs.data
+                analysis_outputs.append(outputs.data)
 
-            assert isinstance(output, str) or isinstance(output, Path), output
-
-            self.status_reporter.add_updaters_jobs(
-                b=get_batch(),
-                output=output,
-                analysis_type=self.analysis_type,
-                target=target,
-                jobs=outputs.jobs,
-                prev_jobs=inputs.get_jobs(target),
-                meta=outputs.meta,
-                job_attrs=self.get_job_attrs(target),
-                update_analysis_meta=self.update_analysis_meta,
+            # assert isinstance(output, str) or isinstance(output, Path), output
+            for analysis_output in analysis_outputs:
+                self.status_reporter.add_updaters_jobs(
+                    b=get_batch(),
+                    output=analysis_output,
+                    analysis_type=self.analysis_type,
+                    target=target,
+                    jobs=outputs.jobs,
+                    prev_jobs=inputs.get_jobs(target),
+                    meta=outputs.meta,
+                    job_attrs=self.get_job_attrs(target),
+                    update_analysis_meta=self.update_analysis_meta,
+                )
+        else:
+            logging.info(
+                f'Didnt add job checkout vars {self.analysis_type}, {self.status_reporter}, {action}, {outputs.data}'
             )
         return outputs
 
@@ -662,7 +673,7 @@ def stage(
     cls: Optional[Type['Stage']] = None,
     *,
     analysis_type: str | None = None,
-    analysis_key: str | None = None,
+    analysis_keys: list[str | Path] | None = None,
     update_analysis_meta: Callable[[str], dict] | None = None,
     required_stages: list[StageDecorator] | StageDecorator | None = None,
     skipped: bool = False,
@@ -683,7 +694,7 @@ def stage(
 
     @analysis_type: if defined, will be used to create/update `Analysis` entries
         using the status reporter.
-    @analysis_key: is defined, will be used to extract the value for `Analysis.output`
+    @analysis_keys: is defined, will be used to extract the value for `Analysis.output`
         if the Stage.expected_outputs() returns a dict.
     @update_analysis_meta: if defined, this function is called on the `Analysis.output`
         field, and returns a dictionary to be merged into the `Analysis.meta`
@@ -706,7 +717,7 @@ def stage(
                 name=_cls.__name__,
                 required_stages=required_stages,
                 analysis_type=analysis_type,
-                analysis_key=analysis_key,
+                analysis_keys=analysis_keys,
                 update_analysis_meta=update_analysis_meta,
                 skipped=skipped,
                 assume_outputs_exist=assume_outputs_exist,

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -509,23 +509,23 @@ class Stage(Generic[TargetT], ABC):
                         f'must be set with the @stage decorator to select value from '
                         f'the expected_outputs dict: {outputs.data}'
                     )
-                # TODO: Fix this
-                # if self.analysis_keys not in outputs.data:
-                #     raise WorkflowError(
-                #         f'Cannot create Analysis for stage {self.name}: `analysis_keys` '
-                #         f'"{self.analysis_keys}" is not found in the expected_outputs '
-                #         f'dict {outputs.data}'
-                #     )
+                if not all(key in outputs.data for key in self.analysis_keys):
+                    raise WorkflowError(
+                        f'Cannot create Analysis for stage {self.name}: `analysis_keys` '
+                        f'"{self.analysis_keys}" is not found in the expected_outputs '
+                        f'dict {outputs.data}'
+                    )
 
                 for analysis_key in self.analysis_keys:
                     analysis_outputs.append(outputs.data[analysis_key])
 
-                # analysis_output = outputs.data[self.analysis_keys]
             else:
                 analysis_outputs.append(outputs.data)
 
-            # assert isinstance(output, str) or isinstance(output, Path), output
             for analysis_output in analysis_outputs:
+                assert isinstance(
+                    analysis_output, (str, Path)
+                ), f'{analysis_output} should be a str or Path object'
                 self.status_reporter.add_updaters_jobs(
                     b=get_batch(),
                     output=analysis_output,

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -109,7 +109,7 @@ def test_status_reporter(mocker: MockFixture):
             print(f'Writing to {self.expected_outputs(sample)}')
             return self.make_outputs(sample, self.expected_outputs(sample), [j])
 
-    @stage(analysis_type='qc', analysis_key='bed')
+    @stage(analysis_type='qc', analysis_keys=['bed'])
     class MyQcStage2(SampleStage):
         """
         Just a sample-level stage.


### PR DESCRIPTION
Addresses #292 
This PR handles 2 issues. 
1. If the analysis_type is not set, then forcing re-running stages does not currently work. 
2. If sample.force is not set for each individual sample in CramQC, forcing re-running does not work. (see cram_qc.py)

Tested Here: 
https://batch.hail.populationgenomics.org.au/batches/421937 

Note: When this change is accepted there will be another accompanying PR to address adding `analysis_keys` and `analysis_type` in all other stages as well as other areas where sample.force and stage.force conflicts. 
