### PR TITLE
Revert analysis_keys on CramQC

### DIFF
--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -112,21 +112,7 @@ def qc_functions() -> list[Qc]:
     return qcs
 
 
-@stage(
-    required_stages=Align,
-    analysis_type='qc',
-    analysis_keys=[
-        'somalier',
-        'verify_bamid',
-        'samtools_stats',
-        'alignment_summary_metrics',
-        'base_distribution_by_cycle_metrics',
-        'insert_size_metrics',
-        'quality_by_cycle_metrics',
-        'quality_yield_metrics',
-        'picard_wgs_metrics',
-    ],
-)
+@stage(required_stages=Align)
 class CramQC(SampleStage):
     """
     Calling tools that process CRAM for QC purposes.


### PR DESCRIPTION
As described https://github.com/populationgenomics/production-pipelines/issues/294

The latest change does not handle the exome case. We need to think about this more carefully, but this quick fix is proposed to minimise any blocks. 
