### PR TITLE
Skip stages 

### DIFF
--- a/configs/prophecy.toml
+++ b/configs/prophecy.toml
@@ -6,9 +6,9 @@ skip_samples = [
   'CPG216010',  # replaced by CPG262915
   'CPG241299',  # Replaced by CPG262907
 ]
-skip_stages = ['SomalierPedigree']
+skip_stages = ['SomalierPedigree', 'SampleQC', 'MakeSiteOnlyVcf']
 first_stages = ['DenseSubset']
-last_stages=['AncestryPlots']
+last_stages=['AncestryPlots', 'MakeSiteOnlyVcf']
 skip_samples_with_missing_input = true
 highmem_workers = true
 


### PR DESCRIPTION
You need to explicitly set MakeSiteOnlyVcf as a last_stage, and then skip it, in order to skip all subsequent stages. It is not enough to set 'AncestryPlots' as a last_stage otherwise all the VQSR steps will still run. 

FYI @KatalinaBobowik 