### PR TITLE
Explicitly skip VQSR Stages

### DIFF
--- a/configs/prophecy.toml
+++ b/configs/prophecy.toml
@@ -6,9 +6,9 @@ skip_samples = [
   'CPG216010',  # replaced by CPG262915
   'CPG241299',  # Replaced by CPG262907
 ]
-skip_stages = ['SomalierPedigree', 'SampleQC', 'MakeSiteOnlyVcf']
+skip_stages = ['SomalierPedigree', 'SampleQC', 'MakeSiteOnlyVcf', 'Vqsr','LoadVqsr']
 first_stages = ['DenseSubset']
-last_stages=['AncestryPlots', 'MakeSiteOnlyVcf']
+last_stages=['AncestryPlots']
 skip_samples_with_missing_input = true
 highmem_workers = true
 


### PR DESCRIPTION
You need to make more explicit skips otherwise there are implications when constructing outputs. 