### PR TITLE
Overwrite dense_subset.mt if it exists and force_stages is true

### DIFF
--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -15,7 +15,7 @@ def run(
     and return a dense MatrixTable with split multiallelics.
     @return: filtered and densified MatrixTable.
     """
-    if can_reuse(out_dense_mt_path):
+    if can_reuse(out_dense_mt_path, overwrite=True):
         return hl.read_matrix_table(str(out_dense_mt_path))
 
     vds = hl.vds.read_vds(str(vds_path))


### PR DESCRIPTION
Currently, the output from the `DenseSubset` stage is not being overwritten when using `force_stages`. 

@violetbrina @lgruen I'm not sure if this is the only thing to change but I believe setting `overwrite=True` in the `can_reuse()` function will fix it?

[Here's](https://centrepopgen.slack.com/archives/C030X7WGFCL/p1679455741667319) a slack message with the issue for more context. 