### PR TITLE
Expose parameters

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -1,7 +1,9 @@
 [workflow]
 name = 'large_cohort'
-scatter_count = 50
+scatter_count_genotype = 50
 status_reporter = 'metamist'
+# define reference fasta
+ref_fasta='gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
 # Realign CRAM when available, instead of using FASTQ.
 # The parameter value should correspond to CRAM version
@@ -52,6 +54,10 @@ min_n_snps = 2400000  # minimum number of SNPs for a sample
 max_n_singletons = 800000  # maximum number of unique SNPs for a sample
 max_r_duplication = 0.3  # maximum rate of duplicated reads (from picard metrics)
 max_r_het_hom = 3.3  # maximum rate of heterozygous to homozygous SNPs
+
+[large_cohort.cram_qc]
+assume_sorted = true
+num_pcs = 4
 
 [hail]
 pool_label = 'large-cohort'

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -2,8 +2,8 @@
 name = 'large_cohort'
 scatter_count_genotype = 50
 status_reporter = 'metamist'
-# define reference fasta
-ref_fasta='gs://gcp-public-data--broad-references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+# define reference fasta. If not specified here, the reference file is pulled from [references.broad][ref_fasta]
+ref_fasta='gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
 # Realign CRAM when available, instead of using FASTQ.
 # The parameter value should correspond to CRAM version

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -41,7 +41,7 @@ def genotype(
         output_path=hc_gvcf_path,
         cram_path=cram_path,
         tmp_prefix=tmp_prefix,
-        scatter_count=50,
+        scatter_count=get_config()['workflow'].get('scatter_count_genotype'),
         overwrite=overwrite,
         dragen_mode=dragen_mode,
     )

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -41,7 +41,7 @@ def genotype(
         output_path=hc_gvcf_path,
         cram_path=cram_path,
         tmp_prefix=tmp_prefix,
-        scatter_count=get_config()['workflow'].get('scatter_count_genotype'),
+        scatter_count=get_config()['workflow'].get('scatter_count_genotype', 50),
         overwrite=overwrite,
         dragen_mode=dragen_mode,
     )

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -257,6 +257,8 @@ def picard_collect_metrics(
     res.attach_disk_storage_gb = storage_for_cram_qc_job()
     res.set_to_job(j)
     reference = fasta_res_group(b)
+    # define variable for whether picard output is sorted or not
+    sorted_output = get_config()['large_cohort']['cram_qc']['assume_sorted']
 
     assert cram_path.index_path
     cmd = f"""\
@@ -272,7 +274,7 @@ def picard_collect_metrics(
       INPUT=$CRAM \\
       REFERENCE_SEQUENCE={reference.base} \\
       OUTPUT=$BATCH_TMPDIR/prefix \\
-      ASSUME_SORTED=true \\
+      ASSUME_SORTED={sorted_output} \\
       PROGRAM=null \\
       VALIDATION_STRINGENCY=SILENT \\
       PROGRAM=CollectAlignmentSummaryMetrics \\

--- a/cpg_workflows/jobs/verifybamid.py
+++ b/cpg_workflows/jobs/verifybamid.py
@@ -40,6 +40,8 @@ def verifybamid(
     contam_ud = reference_path(f'broad/{sequencing_type}_contam_ud')
     contam_bed = reference_path(f'broad/{sequencing_type}_contam_bed')
     contam_mu = reference_path(f'broad/{sequencing_type}_contam_mu')
+    # define number of PCs used in estimation of contamination
+    num_pcs = get_config()['large_cohort']['cram_qc']['num_pcs']
     if sequencing_type == 'exome':
         extra_opts = '--max-depth 1000'
     else:
@@ -57,7 +59,7 @@ def verifybamid(
     /root/micromamba/share/verifybamid2-2.0.1-8/VerifyBamID \
     --NumThread {res.get_nthreads()} \
     --Verbose \
-    --NumPC 4 \
+    --NumPC {num_pcs} \
     --Output OUTPUT \
     --BamFile $CRAM \
     --Reference {reference.base} \


### PR DESCRIPTION
This PR addresses a few hard-coded parameters that should instead be configurable input (exposing the number of PCs for the VerifyBamID job; allowing for assorted input in the Picard job; exposing the reference fasta; and exposing the scatter_count parameter in the genotyping job).