### PR TITLE
Move conifg commands to more universal location

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -20,6 +20,10 @@ ref_fasta='gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens
 snp_filter_level = 99.7
 indel_filter_level = 99.0
 
+[cramqc]
+assume_sorted = true
+num_pcs = 4
+
 [large_cohort]
 # Parameters for reladness inference
 max_kin = 0.2  # maximum kin threshold to be considered unrelated in relatedness check (second degree)
@@ -54,10 +58,6 @@ min_n_snps = 2400000  # minimum number of SNPs for a sample
 max_n_singletons = 800000  # maximum number of unique SNPs for a sample
 max_r_duplication = 0.3  # maximum rate of duplicated reads (from picard metrics)
 max_r_het_hom = 3.3  # maximum rate of heterozygous to homozygous SNPs
-
-[large_cohort.cram_qc]
-assume_sorted = true
-num_pcs = 4
 
 [hail]
 pool_label = 'large-cohort'

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -29,6 +29,10 @@ use_as_vqsr = true
 snp_filter_level = 99.7
 indel_filter_level = 99.0
 
+[cramqc]
+assume_sorted = true
+num_pcs = 4
+
 [qc_thresholds.genome.min]
 "MEDIAN_COVERAGE" = 10
 "PCT_PF_READS_ALIGNED" = 0.80

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -258,7 +258,7 @@ def picard_collect_metrics(
     res.set_to_job(j)
     reference = fasta_res_group(b)
     # define variable for whether picard output is sorted or not
-    sorted_output = get_config()['large_cohort']['cram_qc']['assume_sorted']
+    sorted_output = get_config()['cramqc']['assume_sorted']
 
     assert cram_path.index_path
     cmd = f"""\

--- a/cpg_workflows/jobs/verifybamid.py
+++ b/cpg_workflows/jobs/verifybamid.py
@@ -41,7 +41,7 @@ def verifybamid(
     contam_bed = reference_path(f'broad/{sequencing_type}_contam_bed')
     contam_mu = reference_path(f'broad/{sequencing_type}_contam_mu')
     # define number of PCs used in estimation of contamination
-    num_pcs = get_config()['large_cohort']['cram_qc']['num_pcs']
+    num_pcs = get_config()['cramqc']['num_pcs']
     if sequencing_type == 'exome':
         extra_opts = '--max-depth 1000'
     else:


### PR DESCRIPTION
This addresses the issue caused by [this](https://github.com/populationgenomics/production-pipelines/pull/331/files) PR and discussed in [this ](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1679624807999289)slack post. 

@cassimons seeing as both commands occur within the cramqc stage, I've put both parameters in the `[cramqc]` section of the configs, but happy to change if you think they'd be placed better elsewhere. 