### PR TITLE
corrected storage request

### DIFF
--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -486,7 +486,7 @@ def add_make_sitesonly_job(
     j.image(image_path('gatk'))
     res = STANDARD.set_resources(j, ncpu=2)
     if storage_gb:
-        j.storage(f'{storage_gb}Gi')
+        j.storage(f'{storage_gb}G')
     j.declare_resource_group(
         output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
     )

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -486,7 +486,7 @@ def add_make_sitesonly_job(
     j.image(image_path('gatk'))
     res = STANDARD.set_resources(j, ncpu=2)
     if storage_gb:
-        j.storage(storage_gb)
+        j.storage(f'{storage_gb}Gi')
     j.declare_resource_group(
         output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
     )


### PR DESCRIPTION
See https://hail.is/docs/batch/api/batch/hailtop.batch.job.Job.html#hailtop.batch.job.Job.storage

A call to `job.storage()` with just an integer assigns a Byte-sized volume, not a GB volume, though this is rounded up to the nearest 10.

All other storage calls I can find in `cpg_workflows` are suffixed either with G or Gi.