### PR TITLE
Fix issue where ht is overwriting previous ht

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_plots.py
+++ b/cpg_workflows/large_cohort/ancestry_plots.py
@@ -76,9 +76,7 @@ def run(
 
     # Key samples by their external IDs
     use_external_id = get_config()['large_cohort']['use_external_id']
-    if use_external_id:
-        ht = key_by_external_id(scores_ht, sample_ht)
-    ht = scores_ht.cache()
+    ht = key_by_external_id(scores_ht, sample_ht) if use_external_id else scores_ht.cache()
 
     # Use eigenvalues to calculate variance
     eigenvalues = eigenvalues_ht.f0.collect()


### PR DESCRIPTION
This should allow for the user to specify whether they would like external IDs (as a boolean) in the config file. The previous command was overwriting the ht with the original ht