### PR TITLE
Fix Annotation Bug

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.5
+current_version = 1.12.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.12.5
+  VERSION: 1.12.6
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -90,12 +90,18 @@ def annotate_cohort(
     logging.info('Annotating with seqr-loader fields: round 1')
 
     # Add potentially missing fields
-    if not all(attr in mt.info for attr in ['AC', 'AF', 'AN']):
+    all_attr_found = all(attr in mt.info for attr in ['AC', 'AF', 'AN'])
+    logging.info(f'All AC/AF/AN attributes found: {all_attr_found}')
+    if not all_attr_found:
+        logging.info('Adding AC/AF/AN attributes manually')
         mt = hl.variant_qc(mt)
         mt = mt.annotate_rows(
             info=mt.info.annotate(AN=mt.variant_qc.AN, AF=mt.variant_qc.AF, AC=mt.variant_qc.AC)
         )
         mt = mt.drop('variant_qc')
+    else:
+        logging.info('AC/AF/AN attributes already present')
+        logging.info(mt.info)
 
     # don't fail if the AC/AF attributes are an inappropriate type
     for attr in ['AC', 'AF']:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -93,7 +93,7 @@ def annotate_cohort(
     if not all(attr in mt.info for attr in ['AC', 'AF', 'AN']):
         if mt.count_cols() == 0:
             logging.info('No samples in the Matrix Table, adding dummy values')
-            mt = mt.annotate_rows(info=mt.info.annotate(AN=[1], AF=[0.01], AC=1))
+            mt = mt.annotate_rows(info=mt.info.annotate(AN=1, AF=[0.01], AC=[1]))
         else:
             logging.info('Adding AC/AF/AN attributes from variant_qc')
             mt = hl.variant_qc(mt)

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -60,7 +60,7 @@ def annotate_cohort(
     # and hl.split_multi_hts can handle multiallelic VEP field.
     vep_ht = hl.read_table(str(vep_ht_path))
     logging.info(f'Adding VEP annotations into the Matrix Table from {vep_ht_path}')
-    mt = mt.annotate_rows(vep=vep_ht[mt.locus].vep)
+    mt = mt.annotate_rows(vep=vep_ht[mt.locus, mt.alleles].vep)
 
     # Splitting multi-allelics. We do not handle AS info fields here - we handle
     # them when loading VQSR instead, and populate entire "info" from VQSR.

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -7,6 +7,7 @@ import os
 
 import hail as hl
 
+from cpg_utils import Path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import reference_path, genome_build
 from hail_scripts.computed_fields import vep, variant_id
@@ -27,13 +28,15 @@ def annotate_cohort(
     annotations.
     """
 
-    def _read(path):
+    def _read(path: str | Path):
+        if not isinstance(path, str):
+            path = str(path)
         if path.strip('/').endswith('.ht'):
             t = hl.read_table(str(path))
         else:
             assert path.strip('/').endswith('.mt')
             t = hl.read_matrix_table(str(path))
-        logging.info(f'Read checkpoint {path}')
+        logging.info(f'Read data from {path}')
         return t
 
     def _checkpoint(t, file_name):
@@ -42,9 +45,8 @@ def annotate_cohort(
             if can_reuse(path):
                 t = _read(str(path))
             else:
-                t.write(str(path), overwrite=True)
+                t.checkpoint(str(path), overwrite=True)
                 logging.info(f'Wrote checkpoint {path}')
-                t = _read(str(path))
         return t
 
     mt = hl.import_vcf(
@@ -58,7 +60,7 @@ def annotate_cohort(
     logging.info(f'Loading VEP Table from {vep_ht_path}')
     # Annotate VEP. Do ti before splitting multi, because we run VEP on unsplit VCF,
     # and hl.split_multi_hts can handle multiallelic VEP field.
-    vep_ht = hl.read_table(str(vep_ht_path))
+    vep_ht = _read(vep_ht_path)
     logging.info(f'Adding VEP annotations into the Matrix Table from {vep_ht_path}')
     mt = mt.annotate_rows(vep=vep_ht[mt.locus, mt.alleles].vep)
 
@@ -84,11 +86,6 @@ def annotate_cohort(
         )
         mt = _checkpoint(mt, 'mt-vep-split-vqsr.mt')
 
-    ref_ht = hl.read_table(str(reference_path('seqr_combined_reference_data')))
-    clinvar_ht = hl.read_table(str(reference_path('seqr_clinvar')))
-
-    logging.info('Annotating with seqr-loader fields: round 1')
-
     # Add potentially missing fields
     if not all(attr in mt.info for attr in ['AC', 'AF', 'AN']):
         if mt.count_cols() == 0:
@@ -108,6 +105,8 @@ def annotate_cohort(
     for attr in ['AC', 'AF']:
         if not isinstance(mt.info[attr], hl.ArrayExpression):
             mt = mt.annotate_rows(info=mt.info.annotate(**{attr: [mt.info[attr]]}))
+
+    logging.info('Annotating with computed fields: round 1')
 
     mt = mt.annotate_rows(
         AC=mt.info.AC[mt.a_index - 1],
@@ -130,11 +129,19 @@ def annotate_cohort(
         alt=mt.alleles[1],
         xpos=variant_id.get_expr_for_xpos(mt.locus),
         xstart=variant_id.get_expr_for_xpos(mt.locus),
-        xstop=variant_id.get_expr_for_xpos(mt.locus) + hl.len(mt.alleles[0]) - 1,
+        xstop=variant_id.get_expr_for_xpos(mt.locus) + hl.len(mt.alleles[0]) - 1
+    )
+    mt = _checkpoint(mt, 'mt-vep-split-hail-methods.mt')
+
+    logging.info('Annotating with seqr-loader aggregate data')
+
+    ref_ht = _read(reference_path('seqr_combined_reference_data'))
+    clinvar_ht = _read(reference_path('seqr_clinvar'))
+    mt = mt.annotate_rows(
         clinvar_data=clinvar_ht[mt.row_key],
         ref_data=ref_ht[mt.row_key],
     )
-    mt = _checkpoint(mt, 'mt-vep-split-vqsr-round1.mt')
+    mt = _checkpoint(mt, 'mt-vep-split-external-data.mt')
 
     logging.info(
         'Annotating with seqr-loader fields: round 2 '

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -90,18 +90,13 @@ def annotate_cohort(
     logging.info('Annotating with seqr-loader fields: round 1')
 
     # Add potentially missing fields
-    all_attr_found = all(attr in mt.info for attr in ['AC', 'AF', 'AN'])
-    logging.info(f'All AC/AF/AN attributes found: {all_attr_found}')
-    if not all_attr_found:
+    if not all(attr in mt.info for attr in ['AC', 'AF', 'AN']):
         logging.info('Adding AC/AF/AN attributes manually')
         mt = hl.variant_qc(mt)
         mt = mt.annotate_rows(
             info=mt.info.annotate(AN=mt.variant_qc.AN, AF=mt.variant_qc.AF, AC=mt.variant_qc.AC)
         )
         mt = mt.drop('variant_qc')
-    else:
-        logging.info('AC/AF/AN attributes already present')
-        logging.info(mt.info)
 
     # don't fail if the AC/AF attributes are an inappropriate type
     for attr in ['AC', 'AF']:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -90,7 +90,7 @@ def annotate_cohort(
     logging.info('Annotating with seqr-loader fields: round 1')
 
     # Add potentially missing fields
-    if not all(attr in mt.row_value for attr in ['AC', 'AF', 'AN']):
+    if not all(attr in mt.info for attr in ['AC', 'AF', 'AN']):
         mt = hl.variant_qc(mt)
         mt = mt.annotate_rows(
             info=mt.info.annotate(AN=mt.variant_qc.AN, AF=mt.variant_qc.AF, AC=mt.variant_qc.AC)

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -89,6 +89,14 @@ def annotate_cohort(
 
     logging.info('Annotating with seqr-loader fields: round 1')
 
+    # Add potentially missing fields
+    if not all(attr in mt.row_value for attr in ['AC', 'AF', 'AN']):
+        mt = hl.variant_qc(mt)
+        mt = mt.annotate_rows(
+            info=mt.info.annotate(AN=mt.variant_qc.AN, AF=mt.variant_qc.AF, AC=mt.variant_qc.AC)
+        )
+        mt = mt.drop('variant_qc')
+
     # don't fail if the AC/AF attributes are an inappropriate type
     for attr in ['AC', 'AF']:
         if not isinstance(mt.info[attr], hl.ArrayExpression):

--- a/cpg_workflows/query_modules/vep.py
+++ b/cpg_workflows/query_modules/vep.py
@@ -82,9 +82,8 @@ def vep_json_to_ht(vep_results_paths, out_path):
     # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it
     # happens for indels). So instead parsing POS from the original VCF line stored
     # as ht.vep.input field.
-    original_vcf_line = ht.vep.input
-    start = hl.parse_int(original_vcf_line.split('\t')[1])
+    start = hl.parse_int(ht.vep.input.split('\t')[1])
     chrom = ht.vep.seq_region_name
-    ht = ht.annotate(locus=hl.locus(chrom, start))
-    ht = ht.key_by(ht.locus)
+    ht = ht.annotate(locus=hl.locus(chrom, start), alleles=ht.vep.allele_string.split('/'))
+    ht = ht.key_by(ht.locus, ht.alleles)
     ht.write(str(out_path), overwrite=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.12.5',
+    version='1.12.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Currently the pipeline annotation method requires the AC/AN/AF attributes to be present, and will fail if they aren't in the `info` Struct. This prevents my odd use-case from working; annotation of the ClinVar VCF (also generalised to annotation of any sites-only VCF)

This change will only trigger if the required fields are absent (so core pipeline runs will be unaffected).

Additional:

There's a bug in the application of VEP annotation - When the cpg_workflows VEP annotation is built, the data is keyed on locus. The Variant data it's joined to is keyed on both locus and alleles.

This means that if the data set contains two different variant alleles at the same start position the annotation from one variant will/may be applied to both. This is the root cause of [this issue (slack)](https://centrepopgen.slack.com/archives/C035QN8C0DN/p1678921210039299?thread_ts=1678918786.123119&cid=C035QN8C0DN)

This fix updates the VEP annotation to be indexed and joined on both position and ref/alt allele.

Unsure if this has caused erroneous annotations elsewhere in the datasets, which will be shown in Seqr. I think we should have a chat about this and consider re-annotating and rebuilding the latest ES indices.

Closes https://github.com/populationgenomics/automated-interpretation-pipeline/issues/269