### PR TITLE
Fix test/test_large_cohort.py unit test

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -250,10 +250,11 @@ def _infer_pop_labels(
 
     if training_pop_ht.count() < 2:
         logging.warning(
-            'Need at least 2 samples with known `population` label to run PCA'
+            'Need at least 2 samples with known `population` label to run PCA '
             'and assign population labels to remaining samples'
         )
         pop_ht = scores_ht.annotate(
+            training_pop=hl.missing(hl.tstr),
             pop='Other',
             is_training=False,
             pca_scores=scores_ht.scores,

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -98,7 +98,8 @@ def run(
     sample_qc_ht = hl.read_table(str(sample_qc_ht_path))
     relateds_to_drop_ht = hl.read_table(str(relateds_to_drop_ht_path))
 
-    if pca_background := get_config()['large_cohort'].get('pca_background', {}):
+    pca_background = get_config()['large_cohort'].get('pca_background', {})
+    if 'datasets' in pca_background:
         logging.info(
             f'Adding background datasets using following config: {pca_background}'
         )

--- a/cpg_workflows/large_cohort/ancestry_plots.py
+++ b/cpg_workflows/large_cohort/ancestry_plots.py
@@ -95,7 +95,8 @@ def run(
     superpopulation_label = ht.training_pop.collect() if use_inferred else ht.superpopulation.collect()
     population_label = ht.training_pop.collect() if use_inferred else ht.population.collect()
     # Change 'none' values to dataset name
-    workflow_dataset = get_config()['workflow']['input_datasets']
+    analysis_dataset_name = get_config()['workflow']['dataset']
+    workflow_dataset = get_config()['workflow'].get('input_datasets', [analysis_dataset_name])
     # join dataset names with underscore, in case there are multiple
     workflow_dataset = '_'.join(workflow_dataset)
     superpopulation_label = [workflow_dataset if x is None else x for x in superpopulation_label]

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -178,5 +178,5 @@ def test_large_cohort(mocker: MockFixture):
     )
 
     assert exists(vds_path)
-    assert exists(res_pref / 'plots' / 'dataset_pc1.html')
+    assert exists(res_pref / 'plots' / 'dataset_pc1_hgdp_1kg_sites.html')
     assert exists(siteonly_vcf_path)

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -146,6 +146,7 @@ def test_large_cohort(mocker: MockFixture):
     eigenvalues_ht_path = res_pref / 'eigenvalues.ht'
     loadings_ht_path = res_pref / 'loadings.ht'
     inferred_pop_ht_path = res_pref / 'inferred_pop.ht'
+    ancestry_sample_qc_ht_path = res_pref / 'ancestry_sample_qc.ht'
 
     ancestry_pca.run(
         dense_mt_path=dense_mt_path,
@@ -156,11 +157,11 @@ def test_large_cohort(mocker: MockFixture):
         out_eigenvalues_ht_path=eigenvalues_ht_path,
         out_loadings_ht_path=loadings_ht_path,
         out_inferred_pop_ht_path=inferred_pop_ht_path,
-        out_sample_qc_ht_path=sample_qc_ht_path,
+        out_sample_qc_ht_path=ancestry_sample_qc_ht_path,
     )
     ancestry_plots.run(
         out_path_pattern=res_pref / 'plots' / '{scope}_pc{pci}_{pca_suffix}.{ext}',
-        sample_qc_ht_path=sample_qc_ht_path,
+        sample_qc_ht_path=ancestry_sample_qc_ht_path,
         scores_ht_path=scores_ht_path,
         eigenvalues_ht_path=eigenvalues_ht_path,
         loadings_ht_path=loadings_ht_path,

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -5,15 +5,12 @@ Test large-cohort workflow.
 import toml
 from os.path import exists
 from cpg_utils import to_path
-from cpg_utils.hail_batch import reference_path
 from pytest_mock import MockFixture
 from . import results_prefix, update_dict
 
 ref_prefix = to_path(__file__).parent / 'data/large_cohort/reference'
 gnomad_prefix = ref_prefix / 'gnomad/v0'
 broad_prefix = ref_prefix / 'hg38/v0'
-# get configurable sample_qc path from config file
-predetermined_qc_variants = str(reference_path('gnomad/predetermined_qc_variants'))
 
 TOML = f"""
 [workflow]
@@ -62,7 +59,7 @@ hapmap_ht = "{gnomad_prefix}/hapmap/hapmap_3.3.hg38.ht"
 kgp_omni_ht = "{gnomad_prefix}/kgp/1000G_omni2.5.hg38.ht"
 kgp_hc_ht = "{gnomad_prefix}/kgp/1000G_phase1.snps.high_confidence.hg38.ht"
 mills_ht = "{gnomad_prefix}/mills/Mills_and_1000G_gold_standard.indels.hg38.ht"
-predetermined_qc_variants = "{predetermined_qc_variants}"
+predetermined_qc_variants = "{gnomad_prefix}/sample_qc/pre_ld_pruning_qc_variants.ht"
 
 [references.broad]
 genome_calling_interval_lists = "{broad_prefix}/wgs_calling_regions.hg38.interval_list"


### PR DESCRIPTION
PR #326 changed `predetermined_qc_variants` so that its path is read from an external config file. However for these unit tests, there is no config other than what is hard-coded in the `TOML` string or merged from _cpg_workflows/defaults.toml_ and _configs/defaults/large_cohort.toml_.

Revert (most of) the previous PR so that this path is hard-coded, just as the other paths in `TOML` are. Thus it refers to _test/data/large_cohort/…/pre_ld_pruning_qc_variants.ht_ within this repository.