### PR TITLE
Edit for table-key consistency

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,9 +43,11 @@ jobs:
       run: |
         docker build . -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }}
 
-    - name: push
+    - name: push PR
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
-        docker push $IMAGE_NAME:${{ github.sha }}
+        docker tag $IMAGE_NAME:${{ github.sha }} $IMAGE_NAME:pr-${{ github.event.number }}
+        docker push $IMAGE_NAME:pr-${{ github.event.number }}
         
     - name: push latest
       if: ${{ github.event_name != 'pull_request' }}

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -138,9 +138,10 @@ def annotate_cohort(
     ref_ht = _read(reference_path('seqr_combined_reference_data'))
     clinvar_ht = _read(reference_path('seqr_clinvar'))
     mt = mt.annotate_rows(
-        clinvar_data=clinvar_ht[mt.row_key],
-        ref_data=ref_ht[mt.row_key],
+        clinvar_data=clinvar_ht[mt.locus, mt.alleles],
+        ref_data=ref_ht[mt.locus, mt.alleles],
     )
+    mt.describe()
     mt = _checkpoint(mt, 'mt-vep-split-external-data.mt')
 
     logging.info(

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -54,8 +54,9 @@ def annotate_cohort(
         reference_genome=genome_build(),
         skip_invalid_loci=True,
         force_bgz=True,
+        block_size=20,
     )
-    logging.info(f'Importing VCF {vcf_path}')
+    logging.info(f'Importing VCF {vcf_path} with {mt.n_partitions()} partitions')
 
     logging.info(f'Loading VEP Table from {vep_ht_path}')
     # Annotate VEP. Do ti before splitting multi, because we run VEP on unsplit VCF,


### PR DESCRIPTION
Increases parallelisation when ingesting VCFs (20MB) per fragment, instead of the default 128. 

For context in our reference data Clinvar is split into 400 partitions, gnomAD/combined reference data is 186418 fragments. The 128MB default for our sites-only VCFs probably leads to something like 30 partitions