### PR TITLE
Investigating test/test_seqr_loader_dry.py unit test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           pip show aiodns aiohttp aiohttp_session google-auth hail pycares
 
       - name: Run unit tests
-        timeout-minutes: 5
+        timeout-minutes: 3
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           python -m pytest -s test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,10 +44,10 @@ jobs:
         run: |
           pip show aiodns aiohttp aiohttp_session google-auth hail pycares
 
-      - name: Remove aiodns
+      - name: Remove borkers
         continue-on-error: true
         run: |
-          pip uninstall -y aiodns
+          pip uninstall -y aiodns pycares
 
       - name: Run unit tests
         timeout-minutes: 5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           pip show aiodns aiohttp aiohttp_session google-auth hail pycares
 
       - name: Run unit tests
-        timeout-minutes: 15
+        timeout-minutes: 3
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           python -m pytest -s test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,15 +42,15 @@ jobs:
       - name: Debug
         continue-on-error: true
         run: |
-          pip show aiodns
-          pip show aiohttp
-          pip show aiohttp_session
-          pip show google-auth
-          pip show hail
-          pip show pycares
+          pip show aiodns aiohttp aiohttp_session google-auth hail pycares
+
+      - name: Remove aiodns
+        continue-on-error: true
+        run: |
+          pip uninstall -y aiodns
 
       - name: Run unit tests
-        timeout-minutes: 20
+        timeout-minutes: 5
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           python -m pytest test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           pip show aiodns aiohttp aiohttp_session google-auth hail pycares
 
       - name: Run unit tests
-        timeout-minutes: 3
+        timeout-minutes: 7
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           python -m pytest -s test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
         run: pip install .[test]
 
       - name: Debug
+        continue-on-error: true
         run: |
           pip show aiodns
           pip show aiohttp
@@ -48,6 +49,7 @@ jobs:
           pip show pycares
 
       - name: Run unit tests
+        timeout-minutes: 20
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           python -m pytest test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           pip show aiodns aiohttp aiohttp_session google-auth hail pycares
 
       - name: Run unit tests
-        timeout-minutes: 3
+        timeout-minutes: 15
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           python -m pytest -s test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,13 +44,8 @@ jobs:
         run: |
           pip show aiodns aiohttp aiohttp_session google-auth hail pycares
 
-      - name: Remove borkers
-        continue-on-error: true
-        run: |
-          pip uninstall -y aiodns pycares
-
       - name: Run unit tests
         timeout-minutes: 5
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
-          python -m pytest test/test_${{ matrix.suffix }}.py
+          python -m pytest -s test/test_${{ matrix.suffix }}.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           pip show aiodns
           pip show aiohttp
+          pip show aiohttp_session
           pip show google-auth
           pip show hail
           pip show pycares

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,14 +18,14 @@ jobs:
       matrix:
         suffix:
           [
-            batch,
-            workflow,
-            cohort,
-            status,
-            large_cohort,
+            #batch,
+            #workflow,
+            #cohort,
+            #status,
+            #large_cohort,
             seqr_loader_dry,
-            check_multiqc,
-            check_pedigree,
+            #check_multiqc,
+            #check_pedigree,
           ]
     steps:
       - uses: actions/checkout@main
@@ -38,6 +38,14 @@ jobs:
 
       - name: Install
         run: pip install .[test]
+
+      - name: Debug
+        run: |
+          pip show aiodns
+          pip show aiohttp
+          pip show google-auth
+          pip show hail
+          pip show pycares
 
       - name: Run unit tests
         run: |

--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -8,7 +8,6 @@ import tempfile
 import logging
 import uuid
 from typing import Optional
-import trace
 
 import hailtop.batch as hb
 import toml
@@ -19,6 +18,10 @@ from cpg_utils.hail_batch import (
     copy_common_env,
     dataset_path,
 )
+
+def bobprofile(frame, event, arg):
+    if event == 'call':
+        print(f'Called {frame.f_code.co_name} in {frame.f_code.co_filename}', file=sys.stderr)
 
 
 _batch: Optional['Batch'] = None
@@ -196,8 +199,9 @@ class Batch(hb.Batch):
                 del kwargs['wait']
         print('Hello do super run', file=sys.stderr)
         # kwargs.setdefault('verbose', True)
-        tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
-        bob = tracer.runfunc(super().run, **kwargs)
+        sys.setprofile(bobprofile)
+        bob = super().run(**kwargs)
+        sys.setprofile(None)
         print('Hello done super run', file=sys.stderr)
         return bob
 

--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -8,6 +8,7 @@ import tempfile
 import logging
 import uuid
 from typing import Optional
+import trace
 
 import hailtop.batch as hb
 import toml
@@ -194,8 +195,9 @@ class Batch(hb.Batch):
             if 'wait' in kwargs:
                 del kwargs['wait']
         print('Hello do super run', file=sys.stderr)
-        kwargs.setdefault('verbose', True)
-        bob = super().run(**kwargs)
+        # kwargs.setdefault('verbose', True)
+        tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
+        bob = tracer.runfunc(super().run, **kwargs)
         print('Hello done super run', file=sys.stderr)
         return bob
 

--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -194,6 +194,7 @@ class Batch(hb.Batch):
             if 'wait' in kwargs:
                 del kwargs['wait']
         print('Hello do super run', file=sys.stderr)
+        kwargs.setdefault('verbose', True)
         bob = super().run(**kwargs)
         print('Hello done super run', file=sys.stderr)
         return bob

--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -2,6 +2,7 @@
 Extending the Hail's `Batch` class.
 """
 
+import sys
 import os
 import tempfile
 import logging
@@ -192,7 +193,10 @@ class Batch(hb.Batch):
             # Local backend does not support "wait"
             if 'wait' in kwargs:
                 del kwargs['wait']
-        return super().run(**kwargs)
+        print('Hello do super run', file=sys.stderr)
+        bob = super().run(**kwargs)
+        print('Hello done super run', file=sys.stderr)
+        return bob
 
 
 def make_job_name(

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -890,7 +890,8 @@ class Workflow:
         print('Hello pre-run', file=sys.stderr)
         if not self.dry_run:
             print('Hello pre-run non-dry', file=sys.stderr)
-            get_batch().run(wait=wait, verbose=True)
+            # get_batch().run(wait=wait, verbose=True)
+            get_batch().run(wait=wait)
         else:
             print('Hello pre-run it was dry', file=sys.stderr)
         print('Hello post-run', file=sys.stderr)

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -11,6 +11,7 @@ stages together by resolving dependencies between different levels accordingly.
 Examples of workflows can be found in the `production-workflows` repository.
 """
 
+import sys
 import functools
 import networkx as nx
 import logging
@@ -886,13 +887,13 @@ class Workflow:
             raise WorkflowError('No stages added')
         self.set_stages(_stages)
 
-        print("Hello pre-run")
+        print('Hello pre-run', file=sys.stderr)
         if not self.dry_run:
-            print("Hello pre-run non-dry")
+            print('Hello pre-run non-dry', file=sys.stderr)
             get_batch().run(wait=wait, verbose=True)
         else:
-            print("Hello pre-run it was dry")
-        print("Hello post-run")
+            print('Hello pre-run it was dry', file=sys.stderr)
+        print('Hello post-run', file=sys.stderr)
 
     @staticmethod
     def _process_first_last_stages(

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -886,8 +886,13 @@ class Workflow:
             raise WorkflowError('No stages added')
         self.set_stages(_stages)
 
+        print("Hello pre-run")
         if not self.dry_run:
-            get_batch().run(wait=wait)
+            print("Hello pre-run non-dry")
+            get_batch().run(wait=wait, verbose=True)
+        else:
+            print("Hello pre-run it was dry")
+        print("Hello post-run")
 
     @staticmethod
     def _process_first_last_stages(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'cpg-utils',
         'analysis-runner>=2.36.4',
-        'hail',
+        'hail==0.2.112',
         'networkx',
         'sample-metadata>=5.0.1',
         'pandas',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         'cpg-utils',
         'analysis-runner>=2.36.4',
         'hail',
-        'aiohttp_session>=2.7,<2.13',
         'networkx',
         'sample-metadata>=5.0.1',
         'pandas',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     install_requires=[
         'cpg-utils',
         'analysis-runner>=2.36.4',
-        'hail==0.2.112',
+        'hail',
+        'aiohttp_session>=2.7,<2.13',
         'networkx',
         'sample-metadata>=5.0.1',
         'pandas',

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -205,8 +205,8 @@ def test_seqr_loader_dry(mocker: MockFixture):
     from cpg_workflows.stages.seqr_loader import MtToEs
     print('Hello 9', file=sys.stderr)
 
-    #tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
-    #tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
+    # tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
+    # tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
     get_workflow().run(stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
 
     print('Hello 10', file=sys.stderr)

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -3,6 +3,7 @@ Test seqr-loader workflow.
 """
 from unittest.mock import mock_open
 
+import sys
 import toml
 from cpg_utils import to_path
 from pytest_mock import MockFixture
@@ -168,6 +169,8 @@ def test_seqr_loader_dry(mocker: MockFixture):
     mocker.patch('cpg_utils.config.get_config', _mock_config)
     mocker.patch('cpg_workflows.inputs.create_cohort', _mock_cohort)
 
+    print('Hello 1', file=sys.stderr)
+
     def mock_exists(*args, **kwargs) -> bool:
         return False
 
@@ -194,28 +197,42 @@ def test_seqr_loader_dry(mocker: MockFixture):
     )
     mocker.patch('sample_metadata.apis.AnalysisApi.update_analysis_status', do_nothing)
 
+    print('Hello 2', file=sys.stderr)
     from cpg_workflows.batch import get_batch
+    print('Hello 3', file=sys.stderr)
     from cpg_workflows.inputs import get_cohort
+    print('Hello 4', file=sys.stderr)
     from cpg_workflows.stages.cram_qc import CramMultiQC
+    print('Hello 5', file=sys.stderr)
     from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
+    print('Hello 6', file=sys.stderr)
     from cpg_workflows.stages.joint_genotyping_qc import JointVcfQC
+    print('Hello 7', file=sys.stderr)
     from cpg_workflows.workflow import get_workflow
+    print('Hello 8', file=sys.stderr)
     from cpg_workflows.stages.seqr_loader import MtToEs
+    print('Hello 9', file=sys.stderr)
 
     get_workflow().run(stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
 
+    print('Hello 10', file=sys.stderr)
     assert (
         get_batch().job_by_tool['gatk HaplotypeCaller']['job_n']
         == len(get_cohort().get_samples()) * 50
     )
+    print('Hello 11', file=sys.stderr)
     assert get_batch().job_by_tool['picard MergeVcfs']['job_n'] == len(
         get_cohort().get_samples()
     )
+    print('Hello 12', file=sys.stderr)
     assert get_batch().job_by_tool['gatk ReblockGVCF']['job_n'] == len(
         get_cohort().get_samples()
     )
+    print('Hello 13', file=sys.stderr)
     assert (
         get_batch().job_by_tool['picard CollectVariantCallingMetrics']['job_n']
         == len(get_cohort().get_samples()) + 1
     )
+    print('Hello 14', file=sys.stderr)
     assert get_batch().job_by_tool['gatk GenomicsDBImport']['job_n'] == 50
+    print('Hello 15', file=sys.stderr)

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -170,8 +170,6 @@ def test_seqr_loader_dry(mocker: MockFixture):
     mocker.patch('cpg_utils.config.get_config', _mock_config)
     mocker.patch('cpg_workflows.inputs.create_cohort', _mock_cohort)
 
-    print('Hello 1', file=sys.stderr)
-
     def mock_exists(*args, **kwargs) -> bool:
         return False
 
@@ -198,24 +196,18 @@ def test_seqr_loader_dry(mocker: MockFixture):
     )
     mocker.patch('sample_metadata.apis.AnalysisApi.update_analysis_status', do_nothing)
 
-    print('Hello 2', file=sys.stderr)
     from cpg_workflows.batch import get_batch
-    print('Hello 3', file=sys.stderr)
     from cpg_workflows.inputs import get_cohort
-    print('Hello 4', file=sys.stderr)
     from cpg_workflows.stages.cram_qc import CramMultiQC
-    print('Hello 5', file=sys.stderr)
     from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
-    print('Hello 6', file=sys.stderr)
     from cpg_workflows.stages.joint_genotyping_qc import JointVcfQC
-    print('Hello 7', file=sys.stderr)
     from cpg_workflows.workflow import get_workflow
-    print('Hello 8', file=sys.stderr)
     from cpg_workflows.stages.seqr_loader import MtToEs
     print('Hello 9', file=sys.stderr)
 
-    tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
-    tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
+    #tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
+    #tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
+    get_workflow().run(stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
 
     print('Hello 10', file=sys.stderr)
     assert (

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -215,7 +215,7 @@ def test_seqr_loader_dry(mocker: MockFixture):
     print('Hello 9', file=sys.stderr)
 
     tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
-    tracer.runfunc(get_workflow().run, verbose=True, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
+    tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
 
     print('Hello 10', file=sys.stderr)
     assert (

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -8,6 +8,7 @@ import toml
 from cpg_utils import to_path
 from pytest_mock import MockFixture
 from . import results_prefix, update_dict
+import trace
 
 TOML = f"""
 [workflow]
@@ -213,7 +214,8 @@ def test_seqr_loader_dry(mocker: MockFixture):
     from cpg_workflows.stages.seqr_loader import MtToEs
     print('Hello 9', file=sys.stderr)
 
-    get_workflow().run(stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
+    tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
+    tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
 
     print('Hello 10', file=sys.stderr)
     assert (

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -215,7 +215,7 @@ def test_seqr_loader_dry(mocker: MockFixture):
     print('Hello 9', file=sys.stderr)
 
     tracer = trace.Trace(trace=False, countfuncs=True, timing=True, ignoremods=['pathlib', 'decoder', 'mock', 'toml', 'google.protobuf'])
-    tracer.runfunc(get_workflow().run, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
+    tracer.runfunc(get_workflow().run, verbose=True, stages=[MtToEs, GvcfMultiQC, CramMultiQC, JointVcfQC])
 
     print('Hello 10', file=sys.stderr)
     assert (


### PR DESCRIPTION
This test started timing out on April 12th: [test run 631](https://github.com/populationgenomics/production-pipelines/actions/runs/4667615635/jobs/8263639017) is the last successful one, while [test run 632](https://github.com/populationgenomics/production-pipelines/actions/runs/4673207804/jobs/8276186524) was the first to time out.

The difference appears to be in the set of python packages selected:

```diff
--- installed-631-ok
+++ installed-632-borked

+aiodns-2.0.0
-aiohttp-session-2.12.0
+pycares-4.3.0

-boto3-1.26.110
-botocore-1.29.110
+boto3-1.26.111
+botocore-1.29.111
-google-auth-2.14.1
+google-auth-2.17.2
-hail-0.2.112
+hail-0.2.113
-plotly-5.10.0
+plotly-5.14.1
-sample-metadata-5.6.0
+sample-metadata-5.6.1
```

I suspect the cause of the job timeout is a DNS request that is being firewalled on the GitHub Actions host, coupled with code that isn't aborting its request after a sensible timeout. And I'm guessing that this has been caused by the change in DNS-related python packages at the bottom of this tower of dependencies…