### PR TITLE
Add analysis record for AnnotateDataset job.

### DIFF
--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -3,6 +3,7 @@
 """
 Hail Query stages for the Seqr loader workflow.
 """
+from typing import Any
 
 from cpg_utils import to_path, Path
 from cpg_utils.cloud import read_secret
@@ -74,7 +75,22 @@ class AnnotateCohort(CohortStage):
         )
 
 
-@stage(required_stages=[AnnotateCohort])
+def _update_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, Any]:
+    """
+    Add meta.type to custom analysis object
+
+    TODO: Replace this once dynamic analysis types land in metamist.
+    """
+    return {'type': 'annotated-dataset-callset'}
+
+
+@stage(
+    required_stages=[AnnotateCohort],
+    analysis_type='custom',
+    update_analysis_meta=_update_meta,
+)
 class AnnotateDataset(DatasetStage):
     """
     Split mt by dataset and annotate dataset-specific fields (only for those datasets

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -90,6 +90,7 @@ def _update_meta(
     required_stages=[AnnotateCohort],
     analysis_type='custom',
     update_analysis_meta=_update_meta,
+    analysis_keys=['mt'],
 )
 class AnnotateDataset(DatasetStage):
     """


### PR DESCRIPTION
Adds a analyis record for annotated datasets. This will enable an easy comparison of new annotated datasets to the most recent ES index to detect if new samples have been added (suggesting and ES index build should be triggered).

This is a new analyis 'type', but as per this thread (https://centrepopgen.slack.com/archives/C020PDNH3N0/p1680127086008289), static analyis types are on the way out so in the interum this is implimneted using a custom type.