### PR TITLE
Revert seqr loader changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.6
+current_version = 1.12.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.12.6
+  VERSION: 1.12.7
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/vep.py
+++ b/cpg_workflows/query_modules/vep.py
@@ -82,8 +82,9 @@ def vep_json_to_ht(vep_results_paths, out_path):
     # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it
     # happens for indels). So instead parsing POS from the original VCF line stored
     # as ht.vep.input field.
-    start = hl.parse_int(ht.vep.input.split('\t')[1])
+    original_vcf_line = ht.vep.input
+    start = hl.parse_int(original_vcf_line.split('\t')[1])
     chrom = ht.vep.seq_region_name
-    ht = ht.annotate(locus=hl.locus(chrom, start), alleles=ht.vep.allele_string.split('/'))
-    ht = ht.key_by(ht.locus, ht.alleles)
+    ht = ht.annotate(locus=hl.locus(chrom, start))
+    ht = ht.key_by(ht.locus)
     ht.write(str(out_path), overwrite=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.12.6',
+    version='1.12.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Reverts changes to the VEP/Seqr Loader script

This will restore the previous behaviour, possible bug still dangling around with annotations applied to incorrect alleles