### PR TITLE
add a new stage to the seqr_loader

### DIFF
--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -22,7 +22,7 @@ use_as_vqsr = true
 # create indices for all input datasets.
 #create_es_index_for_datasets = []
 
-write_vcf = ["udn-aus"]
+write_vcf = ["udn-aus", "validation"]
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -22,6 +22,8 @@ use_as_vqsr = true
 # create indices for all input datasets.
 #create_es_index_for_datasets = []
 
+write_vcf = ["udn-aus"]
+
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level
 # sensitivities. The tool matches them internally to a VQSLOD score cutoff 

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -218,7 +218,8 @@ def cohort_to_vcf_job(
     mt_path: Path,
     out_vcf_path: Path,
     job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None):
+    depends_on: list[Job] | None = None
+):
     """
     Take the single-dataset MT, and write to a VCF
 

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -224,11 +224,11 @@ def cohort_to_vcf_job(
     Take the single-dataset MT, and write to a VCF
 
     Args:
-        b ():
-        mt_path ():
-        out_vcf_path ():
-        job_attrs ():
-        depends_on ():
+        b (hb.Batch): the batch to add jobs into
+        mt_path (str): path of the AnnotateDataset MT
+        out_vcf_path (str): path to write new VCF to
+        job_attrs (dict):
+        depends_on (hb.Job|list[hb.Job]): jobs to depend on
 
     Returns:
         this single Job

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -211,3 +211,43 @@ def annotate_dataset_jobs(
         jobs = [subset_j, annotate_j]
 
     return jobs
+
+
+def cohort_to_vcf_job(
+    b: Batch,
+    mt_path: Path,
+    out_vcf_path: Path,
+    job_attrs: dict | None = None,
+    depends_on: list[Job] | None = None):
+    """
+    Take the single-dataset MT, and write to a VCF
+
+    Args:
+        b ():
+        mt_path ():
+        out_vcf_path ():
+        job_attrs ():
+        depends_on ():
+
+    Returns:
+        this single Job
+    """
+    from cpg_workflows.query_modules import seqr_loader
+
+    vcf_j = b.new_job(
+        f'VCF from dataset MT', (job_attrs or {}) | {'tool': 'hail query'}
+    )
+    vcf_j.image(image_path('cpg_workflows'))
+    vcf_j.command(
+        query_command(
+            seqr_loader,
+            seqr_loader.vcf_from_mt_subset.__name__,
+            str(mt_path),
+            out_vcf_path,
+            setup_gcp=True,
+        )
+    )
+    if depends_on:
+        vcf_j.depends_on(*depends_on)
+
+    return vcf_j

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -227,7 +227,7 @@ def subset_mt_to_samples(mt_path, sample_ids, out_mt_path):
     logging.info(f'Written {out_mt_path}')
 
 
-def vcf_from_mt_subset(mt_path:str , out_vcf_path: str):
+def vcf_from_mt_subset(mt_path: str, out_vcf_path: str):
     """
     Read the MT in, and write out to a VCF
     If we wanted to translate sample IDs to external samples

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -227,6 +227,23 @@ def subset_mt_to_samples(mt_path, sample_ids, out_mt_path):
     logging.info(f'Written {out_mt_path}')
 
 
+def vcf_from_mt_subset(mt_path:str , out_vcf_path: str):
+    """
+    Read the MT in, and write out to a VCF
+    If we wanted to translate sample IDs to external samples
+    then we could do that here, otherwise rely on VCF re-heading
+
+    Args:
+        mt_path (str): path of the single-dataset MT to read in
+        out_vcf_path (str): path of the vcf.bgz to generate
+    """
+
+    mt = hl.read_matrix_table(str(mt_path))
+    logging.info(f'Dataset MT dimensions: {mt.count()}')
+    hl.export_vcf(mt, out_vcf_path, parallel='header_per_shard', tabix=True)
+    logging.info(f'Written {out_vcf_path}')
+
+
 def annotate_dataset_mt(mt_path, out_mt_path, checkpoint_prefix):
     """
     Add dataset-level annotations.

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -86,6 +86,17 @@ def _update_meta(
     return {'type': 'annotated-dataset-callset'}
 
 
+def _dataset_vcf_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, Any]:
+    """
+    Add meta.type to custom analysis object
+
+    TODO: Replace this once dynamic analysis types land in metamist.
+    """
+    return {'type': 'dataset-vcf'}
+
+
 @stage(
     required_stages=[AnnotateCohort],
     analysis_type='custom',
@@ -140,7 +151,7 @@ class AnnotateDataset(DatasetStage):
 @stage(
     required_stages=[AnnotateDataset],
     analysis_type='custom',
-    update_analysis_meta=_update_meta,
+    update_analysis_meta=_dataset_vcf_meta,
     analysis_keys=['vcf'],
 )
 class DatasetVCF(DatasetStage):

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -18,7 +18,7 @@ from cpg_workflows.workflow import (
     Dataset,
     get_workflow,
 )
-from cpg_workflows.jobs.seqr_loader import annotate_cohort_jobs, annotate_dataset_jobs
+from cpg_workflows.jobs.seqr_loader import annotate_cohort_jobs, annotate_dataset_jobs, cohort_to_vcf_job
 
 from .joint_genotyping import JointGenotyping
 from .vep import Vep
@@ -134,6 +134,62 @@ class AnnotateDataset(DatasetStage):
 
         return self.make_outputs(
             dataset, data=self.expected_outputs(dataset), jobs=jobs
+        )
+
+
+@stage(
+    required_stages=[AnnotateDataset],
+    analysis_type='custom',
+    update_analysis_meta=_update_meta,
+    analysis_keys=['vcf'],
+)
+class DatasetVCF(DatasetStage):
+    """
+    Take the per-dataset MT and write out as a VCF
+    only applies to a small subset of cohorts
+    """
+
+    def expected_outputs(self, dataset: Dataset):
+        """
+        Expected to generate a VCF from the single-dataset MT
+        """
+        return {
+            'vcf': (
+                dataset.prefix()
+                / 'vcf'
+                / f'{get_workflow().output_version}-{dataset.name}.vcf.bgz'
+            ),
+            'index': (
+                dataset.prefix()
+                / 'vcf'
+                / f'{get_workflow().output_version}-{dataset.name}.vcf.bgz.tbi'
+            )
+        }
+
+    def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:
+        """
+        Uses analysis-runner's dataproc helper to run a hail query script
+        only run this on manually defined list of cohorts
+        """
+        assert dataset.cohort
+
+        # only run this selectively, most datasets it's not required
+        eligible_datasets = get_config()['workflow']['write_vcf']
+        if dataset.name not in eligible_datasets:
+            return None
+
+        mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateDataset, key='mt')
+
+        job = cohort_to_vcf_job(
+            b=get_batch(),
+            mt_path=mt_path,
+            out_vcf_path=self.expected_outputs(dataset)['vcf'],
+            job_attrs=self.get_job_attrs(dataset),
+            depends_on=inputs.get_jobs(dataset),
+        )
+
+        return self.make_outputs(
+            dataset, data=self.expected_outputs(dataset), jobs=job
         )
 
 

--- a/main.py
+++ b/main.py
@@ -16,14 +16,14 @@ from cpg_workflows.stages.large_cohort import LoadVqsr, Frequencies, AncestryPlo
 from cpg_workflows.stages.cram_qc import CramMultiQC
 from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
 from cpg_workflows.stages.fastqc import FastQCMultiQC
-from cpg_workflows.stages.seqr_loader import MtToEs, AnnotateDataset
+from cpg_workflows.stages.seqr_loader import MtToEs, AnnotateDataset, DatasetVCF
 from cpg_workflows.stages.gatk_sv import AnnotateVcf
 from cpg_workflows.stages.stripy import Stripy
 
 
 WORKFLOWS: dict[str, list[StageDecorator]] = {
     'pre_alignment': [FastQCMultiQC],
-    'seqr_loader': [AnnotateDataset, MtToEs, GvcfMultiQC, CramMultiQC, Stripy],
+    'seqr_loader': [DatasetVCF, AnnotateDataset, MtToEs, GvcfMultiQC, CramMultiQC, Stripy],
     'large_cohort': [LoadVqsr, Frequencies, AncestryPlots, GvcfMultiQC, CramMultiQC],
     'gatk_sv': [AnnotateVcf],
 }


### PR DESCRIPTION
Partial solution to https://github.com/populationgenomics/seqr-private/issues/93

Adds a new stage after `AnnotateDataset` which will ingest the per-dataset MatrixTable, and write out to 

`<bucket>/vcf/<massive_hash>-<dataset_name>.vcf.bgz`

Inserted a new config variable to control which datasets this applies to, most cohorts will just return `None` - currently we only need to export the UDN-Aus and Validation datasets.

Updates the meta for the analysis entry in Metamist to be `type:dataset-vcf`