### PR TITLE
Missed wdl outputs

### DIFF
--- a/cpg_workflows/stages/gatk_sv.py
+++ b/cpg_workflows/stages/gatk_sv.py
@@ -317,7 +317,8 @@ class EvidenceQC(DatasetStage):
             'WGD_scores': 'WGD_scores.txt.gz',
             'bincov_matrix': 'RD.txt.gz',
             'bincov_matrix_index': 'RD.txt.gz.tbi',
-            'bincov_median': f'{dataset.name}_medianCov.transposed.bed'
+            'bincov_median': f'{dataset.name}_medianCov.transposed.bed',
+            'qc_table': '.evidence_qc_table.tsv'
         }
         for caller in SV_CALLERS:
             for k in ['low', 'high']:

--- a/cpg_workflows/stages/gatk_sv.py
+++ b/cpg_workflows/stages/gatk_sv.py
@@ -318,7 +318,7 @@ class EvidenceQC(DatasetStage):
             'bincov_matrix': 'RD.txt.gz',
             'bincov_matrix_index': 'RD.txt.gz.tbi',
             'bincov_median': f'{dataset.name}_medianCov.transposed.bed',
-            'qc_table': '.evidence_qc_table.tsv'
+            'qc_table': f'{dataset.name}_evidence_qc_table.tsv'
         }
         for caller in SV_CALLERS:
             for k in ['low', 'high']:


### PR DESCRIPTION
I dropped an output file from EvidenceQC - this is the metadata summary used in batching samples