### PR TITLE
enforce specific default python image

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.2
+current_version = 1.13.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.13.2
+  VERSION: 1.13.3
 
 jobs:
   docker:

--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -22,7 +22,7 @@ from cpg_utils.hail_batch import (
 _batch: Optional['Batch'] = None
 
 
-def get_batch(name: str | None = None) -> 'Batch':
+def get_batch(name: str | None = None, default_python_image: str | None = None) -> 'Batch':
     global _batch
     backend: hb.Backend
     if _batch is None:
@@ -45,6 +45,7 @@ def get_batch(name: str | None = None) -> 'Batch':
             cancel_after_n_failures=get_config()['hail'].get('cancel_after_n_failures'),
             default_timeout=get_config()['hail'].get('default_timeout'),
             default_memory=get_config()['hail'].get('default_memory'),
+            default_python_image=default_python_image or get_config()['workflow']['driver_image'],
         )
     return _batch
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.13.2',
+    version='1.13.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -12,6 +12,7 @@ dataset_gcp_project = 'fewgenomes'
 access_level = 'test'
 dataset = 'fewgenomes'
 sequencing_type = 'genome'
+driver_image = 'test'
 
 check_inputs = false
 check_intermediates = false

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -17,6 +17,7 @@ TOML = f"""
 dataset_gcp_project = 'fewgenomes'
 access_level = 'test'
 dataset = 'fewgenomes'
+driver_image = 'test'
 sequencing_type = 'genome'
 
 check_inputs = false


### PR DESCRIPTION
The cpg_workflows `get_batch()` wrapper doesn't allow a default Python image to be set. If the default isn't set and `job.image()` isn't set, the default suggested in code is `hailgenetics/python-dill:[major_version].[minor_version]-slim`

I can't see that we set the `default_image` either, and I can't see what the default would be. 

Do we override these defaults somewhere in our Hail Batch deployment?