### PR TITLE
link stage outputs correctly

### DIFF
--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -22,7 +22,7 @@ use_as_vqsr = true
 # create indices for all input datasets.
 #create_es_index_for_datasets = []
 
-write_vcf = ["udn-aus", "validation"]
+write_vcf = ["udn-aus"]
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -182,14 +182,13 @@ class DatasetVCF(DatasetStage):
         Uses analysis-runner's dataproc helper to run a hail query script
         only run this on manually defined list of cohorts
         """
-        assert dataset.cohort
 
         # only run this selectively, most datasets it's not required
         eligible_datasets = get_config()['workflow']['write_vcf']
         if dataset.name not in eligible_datasets:
             return None
 
-        mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateDataset, key='mt')
+        mt_path = inputs.as_path(target=dataset, stage=AnnotateDataset, key='mt')
 
         job = cohort_to_vcf_job(
             b=get_batch(),


### PR DESCRIPTION
The original implementation tries to find the outputs from the AnnotateDataset cohort by passing the `Cohort`, instead of passing the `Dataset`. This will probably cause the whole thing to explode.

Related: from recent runs the `validation` & `udn-aus` datasets have been removed from the default seqr-loader config
https://batch.hail.populationgenomics.org.au/batches/424408/jobs/1
https://github.com/populationgenomics/production-pipelines/blob/main/configs/defaults/seqr_loader.toml#L25

Was this removed because the stage was failing?

- From discussion on slack, this stage was deliberately blocked off, probably because of the aforementioned failure
- After this is fixed, we can use the output_prefix override to continue from the latest complete index and just generate VCFs