### PR TITLE
Validation steps

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.4
+current_version = 1.13.5
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.3
+current_version = 1.13.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.13.4
+  VERSION: 1.13.5
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.13.3
+  VERSION: 1.13.4
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -1,0 +1,55 @@
+"""
+jobs relating to the validation steps of the pipeline
+"""
+
+
+from hailtop.batch.job import Job
+from hailtop.batch import Batch
+
+from cpg_utils import Path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import image_path, query_command
+
+
+def validation_mt_to_vcf_job(
+    b: Batch,
+    mt_path: Path,
+    sample_id: str,
+    out_vcf_path: Path,
+    job_attrs: dict | None = None,
+    depends_on: list[Job] | None = None
+):
+    """
+    Take the single-dataset MT, and write to a VCF
+
+    Args:
+        b (hb.Batch): the batch to add jobs into
+        mt_path (str): path of the AnnotateDataset MT
+        sample_id (str): sample name
+        out_vcf_path (str): path to write new VCF to
+        job_attrs (dict):
+        depends_on (hb.Job|list[hb.Job]): jobs to depend on
+
+    Returns:
+        this single Job
+    """
+    from cpg_workflows.query_modules import validation
+
+    vcf_j = b.new_job(
+        f'VCF from dataset MT', (job_attrs or {}) | {'tool': 'hail query'}
+    )
+    vcf_j.image(image_path('cpg_workflows'))
+    vcf_j.command(
+        query_command(
+            validation,
+            validation.single_sample_vcf_from_dataset_vcf.__name__,
+            str(mt_path),
+            sample_id,
+            out_vcf_path,
+            setup_gcp=True,
+        )
+    )
+    if depends_on:
+        vcf_j.depends_on(*depends_on)
+
+    return vcf_j

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -159,7 +159,7 @@ def run_happy_on_vcf(
     if stratification := get_config()['stratification']:
         strat_folder = to_path(stratification)
         strat_dict = {file.name: str(file) for file in strat_folder.glob('*')}
-        assert ('definition.tsv' in strat_dict, f'definition.tsv file does not exist')
+        assert 'definition.tsv' in strat_dict, f'definition.tsv file does not exist'
         batch_beds = b.read_input_group(**strat_dict)
         command += f'--stratification {batch_beds["definition.tsv"]}'
     # endregion

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -158,21 +158,8 @@ def run_happy_on_vcf(
     # region: stratification BED files
     if stratification := get_config()['stratification']:
         strat_folder = to_path(stratification)
-        assert (
-            strat_folder.exists()
-        ), f'{stratification} does not exist, or was not accessible'
-
-        definitions = strat_folder / 'definition.tsv'
-        assert (
-            definitions.exists()
-        ), f'the region file {str(definitions)} does not exist'
-
-        strat_bed_files = list(strat_folder.glob('*.bed*'))
-        assert len(strat_bed_files) > 0, 'No bed files in the stratified BED folder'
-
-        # create a dictionary to pass to input generation
-        strat_dict = {'definition.tsv': str(definitions)}
-        strat_dict.update({file.name: str(file) for file in strat_bed_files})
+        strat_dict = {file.name: str(file) for file in strat_folder.glob('*')}
+        assert ('definition.tsv' in strat_dict, f'definition.tsv file does not exist')
         batch_beds = b.read_input_group(**strat_dict)
         command += f'--stratification {batch_beds["definition.tsv"]}'
     # endregion

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -6,9 +6,9 @@ jobs relating to the validation steps of the pipeline
 from hailtop.batch.job import Job
 from hailtop.batch import Batch
 
-from cpg_utils import Path
+from cpg_utils import to_path, Path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import image_path, query_command
+from cpg_utils.hail_batch import fasta_res_group, image_path, query_command
 
 
 def validation_mt_to_vcf_job(
@@ -53,3 +53,103 @@ def validation_mt_to_vcf_job(
         vcf_j.depends_on(*depends_on)
 
     return vcf_j
+
+
+def run_happy_on_vcf(
+    b: Batch,
+    vcf_path: str,
+    sample_ext_id: str,
+    out_prefix: str,
+    job_attrs: dict | None = None,
+    depends_on: list[Job] | None = None
+):
+    """
+    Run hap.py on the for this single-sample VCF
+    Use Truth data from config
+
+    Args:
+        b (): the batch to create a new job in
+        vcf_path (str): path to the single-sample VCF
+        sample_ext_id (str): external ID to find reference data
+        out_prefix (str): where to export happy outputs
+        job_attrs ():
+        depends_on ():
+
+    Returns:
+        This Job or None
+    """
+
+    happy_j = b.new_job(
+        f'Run Happy on {sample_ext_id} VCF', (job_attrs or {}) | {'tool': 'hap.py'}
+    )
+    happy_j.image(image_path('happy')).memory('100Gi').storage('100Gi').cpu(4)
+    if depends_on:
+        happy_j.depends_on(*depends_on)
+
+    # region: read input data into batch
+    vcf_input = b.read_input_group(vcf=vcf_path, index=f'{vcf_path}.tbi')
+
+    ref_data = get_config()['references'][sample_ext_id]
+    assert all(key in ref_data for key in ['vcf', 'index', 'bed'])
+
+    # read in sample-specific truth data from config
+    truth_input = b.read_input_group(
+        vcf=ref_data['vcf'], index=ref_data['index'], bed=ref_data['bed']
+    )
+
+    happy_j.declare_resource_group(
+        output={
+            'happy_extended.csv': '{root}/output.extended.csv',
+            'happy.vcf.gz': '{root}/output.vcf.gz',
+            'happy.vcf.gz.tbi': '{root}/output.vcf.gz.tbi',
+            'happy_roc.all.csv.gz': '{root}/output.roc.all.csv.gz',
+            'happy_metrics.json.gz': '{root}/output.metrics.json.gz',
+            'happy_runinfo.json': '{root}/output.runinfo.json',
+            'summary.csv': '{root}/output.summary.csv',
+        },
+    )
+
+    # read in all the SDF genome indices used by hap.py
+    ref_genome_sdf = get_config()['references']['refgenome_sdf']
+    sdf = b.read_input_group(
+        **{file.name: file.as_uri() for file in to_path(ref_genome_sdf).glob('*')},
+    )
+    # endregion
+
+    # includes the creation of the output temp file, which hap.py won't do
+    command = (
+        f'mkdir {happy_j.output} && '
+        f'hap.py {truth_input["vcf"]} {vcf_input["vcf"]} '
+        f'-r {fasta_res_group(b)["base"]} -R {truth_input["bed"]} '
+        f'-o {happy_j.output}/output --leftshift '
+        f'--threads 4 --preprocess-truth '
+        f'--engine-vcfeval-path=/opt/hap.py/libexec/rtg-tools-install/rtg '
+        f'--engine-vcfeval-template {sdf} --engine=vcfeval '
+    )
+
+    # region: stratification BED files
+    if stratification := get_config()['stratification']:
+        strat_folder = to_path(stratification)
+        assert (
+            strat_folder.exists()
+        ), f'{stratification} does not exist, or was not accessible'
+
+        definitions = strat_folder / 'definition.tsv'
+        assert (
+            definitions.exists()
+        ), f'the region file {str(definitions)} does not exist'
+
+        strat_bed_files = list(strat_folder.glob('*.bed*'))
+        assert len(strat_bed_files) > 0, 'No bed files in the stratified BED folder'
+
+        # create a dictionary to pass to input generation
+        strat_dict = {'definition.tsv': str(definitions)}
+        strat_dict.update({file.name: str(file) for file in strat_bed_files})
+        batch_beds = b.read_input_group(**strat_dict)
+        command += f'--stratification {batch_beds["definition.tsv"]}'
+    # endregion
+
+    happy_j.command(command)
+
+    b.write_output(happy_j.output, out_prefix)
+    return happy_j

--- a/cpg_workflows/query_modules/validation.py
+++ b/cpg_workflows/query_modules/validation.py
@@ -1,0 +1,31 @@
+"""
+Hail query method(s) for validation.
+"""
+
+import hail as hl
+
+
+def single_sample_vcf_from_dataset_vcf(input_mt: str, sample_id: str, out_path: str):
+    """
+    takes the validation datatset VCF, filters to single sample
+    removes variants not relevant to this sample, and writes to VCF
+    Args:
+        input_mt ():
+        sample_id ():
+        out_path ():
+    """
+    # read full MT
+    mt = hl.read_matrix_table(input_mt)
+
+    # filter to this column
+    mt = mt.filter_cols(mt.s == sample_id)
+
+    # filter to this sample's non-ref calls
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.n_non_ref > 0)
+
+    # filter out any Filter-failures
+    mt = mt.filter_rows(mt.filters.length() == 0)
+
+    hl.export_vcf(mt, out_path, tabix=True)
+

--- a/cpg_workflows/query_modules/validation.py
+++ b/cpg_workflows/query_modules/validation.py
@@ -10,9 +10,9 @@ def single_sample_vcf_from_dataset_vcf(input_mt: str, sample_id: str, out_path: 
     takes the validation datatset VCF, filters to single sample
     removes variants not relevant to this sample, and writes to VCF
     Args:
-        input_mt ():
-        sample_id ():
-        out_path ():
+        input_mt (str): where to read the MT
+        sample_id (str): this Sequencing Group ID
+        out_path (str): where to write the VCF to
     """
     # read full MT
     mt = hl.read_matrix_table(input_mt)
@@ -28,4 +28,3 @@ def single_sample_vcf_from_dataset_vcf(input_mt: str, sample_id: str, out_path: 
     mt = mt.filter_rows(mt.filters.length() == 0)
 
     hl.export_vcf(mt, out_path, tabix=True)
-

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -5,10 +5,6 @@ Content relating to the hap.py validation process
 """
 
 
-from typing import Any
-
-from cpg_utils import to_path, Path
-from cpg_utils.cloud import read_secret
 from cpg_utils.config import get_config
 from cpg_workflows.workflow import (
     stage,
@@ -16,10 +12,6 @@ from cpg_workflows.workflow import (
     Sample,
     StageInput,
     StageOutput,
-    CohortStage,
-    DatasetStage,
-    Cohort,
-    Dataset,
     get_workflow,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, _sg_vcf_meta
@@ -133,4 +125,3 @@ class ValidationHappyOnVcf(SampleStage):
         )
 
         return self.make_outputs(sample, data=exp_outputs, jobs=job)
-

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -23,7 +23,7 @@ from cpg_workflows.workflow import (
     get_workflow,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, _sg_vcf_meta
-from cpg_workflows.jobs.validation import validation_mt_to_vcf_job
+from cpg_workflows.jobs.validation import validation_mt_to_vcf_job, run_happy_on_vcf
 from .. import get_batch
 
 
@@ -57,6 +57,10 @@ class ValidationMtToVcf(SampleStage):
         if sample.dataset.name != 'validation':
             return None
 
+        # only keep the samples with reference data
+        if sample.external_id not in get_config()['references']:
+            return None
+
         # get the input mt for this dataset
         mt_path = inputs.as_path(target=sample.dataset, stage=AnnotateDataset, key='mt')
         exp_outputs = self.expected_outputs(sample)
@@ -71,6 +75,8 @@ class ValidationMtToVcf(SampleStage):
         )
 
         return self.make_outputs(sample, data=exp_outputs, jobs=job)
+
+
 @stage(
     required_stages=ValidationMtToVcf,
     analysis_type='custom',
@@ -80,20 +86,20 @@ class ValidationMtToVcf(SampleStage):
 class ValidationHappyOnVcf(SampleStage):
 
     def expected_outputs(self, sample: Sample):
-
+        output_prefix = (
+            sample.dataset.prefix() /
+            'validation' /
+            get_workflow().output_version /
+            sample.id
+        )
         return {
-            'vcf': (
-                sample.dataset.prefix()
-                / 'validation'
-                / get_workflow().output_version
-                / f'{sample.id}.vcf.bgz'
-            ),
-            'index': (
-                sample.dataset.prefix()
-                / 'validation'
-                / get_workflow().output_version
-                / f'{sample.id}.vcf.bgz.tbi'
-            )
+            'vcf': output_prefix / 'happy.vcf.bgz',
+            'index': output_prefix / 'happy.vcf.bgz.tbi',
+            'happy_csv': output_prefix / 'happy_extended.csv',
+            'happy_roc': output_prefix / 'happy_roc.all.csv.gz',
+            'happy_metrics': output_prefix / 'happy_metrics.json.gz',
+            'happy_runinfo': output_prefix / 'happy_runinfo.json',
+            'happy_summary': output_prefix / 'summary.csv',
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
@@ -101,17 +107,29 @@ class ValidationHappyOnVcf(SampleStage):
         if sample.dataset.name != 'validation':
             return None
 
-        # get the input mt for this dataset
-        mt_path = inputs.as_path(target=sample.dataset, stage=AnnotateDataset, key='mt')
-        exp_outputs = self.expected_outputs(sample)
+        # only keep the samples with reference data
+        if sample.external_id not in get_config()['references']:
+            return None
 
-        job = validation_mt_to_vcf_job(
+        # get the input vcf for this sequence group
+        input_vcf = inputs.as_path(target=sample, stage=ValidationMtToVcf, key='vcf')
+
+        # set the prefix to write outputs to
+        output_prefix = (
+            sample.dataset.prefix() /
+            'validation' /
+            get_workflow().output_version /
+            sample.id
+        )
+
+        exp_outputs = self.expected_outputs(sample)
+        job = run_happy_on_vcf(
             b=get_batch(),
-            mt_path=mt_path,
-            sample_id=sample.id,
-            out_vcf_path=exp_outputs['vcf'],
+            vcf_path=str(input_vcf),
+            sample_ext_id=sample.external_id,
+            out_prefix=str(output_prefix),
             job_attrs=self.get_job_attrs(sample),
-            depends_on=inputs.get_jobs(sample),
+            depends_on=inputs.get_jobs(sample)
         )
 
         return self.make_outputs(sample, data=exp_outputs, jobs=job)

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -71,9 +71,8 @@ class ValidationMtToVcf(SampleStage):
 
 @stage(
     required_stages=ValidationMtToVcf,
-    analysis_type='custom',
-    update_analysis_meta=_sg_vcf_meta,
-    analysis_keys=['vcf'],
+    analysis_type='qc',
+    analysis_keys=['happy_csv'],
 )
 class ValidationHappyOnVcf(SampleStage):
 

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -15,7 +15,11 @@ from cpg_workflows.workflow import (
     get_workflow,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, _sg_vcf_meta
-from cpg_workflows.jobs.validation import validation_mt_to_vcf_job, run_happy_on_vcf
+from cpg_workflows.jobs.validation import (
+    validation_mt_to_vcf_job,
+    run_happy_on_vcf,
+    parse_and_post_results,
+)
 from .. import get_batch
 
 
@@ -26,9 +30,7 @@ from .. import get_batch
     analysis_keys=['vcf'],
 )
 class ValidationMtToVcf(SampleStage):
-
     def expected_outputs(self, sample: Sample):
-
         return {
             'vcf': (
                 sample.dataset.prefix()
@@ -41,7 +43,7 @@ class ValidationMtToVcf(SampleStage):
                 / 'validation'
                 / get_workflow().output_version
                 / f'{sample.id}.vcf.bgz.tbi'
-            )
+            ),
         }
 
     def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
@@ -75,13 +77,12 @@ class ValidationMtToVcf(SampleStage):
     analysis_keys=['happy_csv'],
 )
 class ValidationHappyOnVcf(SampleStage):
-
     def expected_outputs(self, sample: Sample):
         output_prefix = (
-            sample.dataset.prefix() /
-            'validation' /
-            get_workflow().output_version /
-            sample.id
+            sample.dataset.prefix()
+            / 'validation'
+            / get_workflow().output_version
+            / sample.id
         )
         return {
             'vcf': output_prefix / 'happy.vcf.bgz',
@@ -107,10 +108,10 @@ class ValidationHappyOnVcf(SampleStage):
 
         # set the prefix to write outputs to
         output_prefix = (
-            sample.dataset.prefix() /
-            'validation' /
-            get_workflow().output_version /
-            sample.id
+            sample.dataset.prefix()
+            / 'validation'
+            / get_workflow().output_version
+            / sample.id
         )
 
         exp_outputs = self.expected_outputs(sample)
@@ -120,7 +121,47 @@ class ValidationHappyOnVcf(SampleStage):
             sample_ext_id=sample.external_id,
             out_prefix=str(output_prefix),
             job_attrs=self.get_job_attrs(sample),
-            depends_on=inputs.get_jobs(sample)
+            depends_on=inputs.get_jobs(sample),
+        )
+
+        return self.make_outputs(sample, data=exp_outputs, jobs=job)
+
+
+@stage(required_stages=ValidationHappyOnVcf)
+class ValidationParseHappy(SampleStage):
+    def expected_outputs(self, sample: Sample):
+        return {
+            'json_summary': (
+                sample.dataset.prefix()
+                / 'validation'
+                / get_workflow().output_version
+                / sample.id,
+                'happy_summary.json',
+            )
+        }
+
+    def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
+        # only run this on validation samples
+        if sample.dataset.name != 'validation':
+            return None
+
+        # only keep the samples with reference data
+        if sample.external_id not in get_config()['references']:
+            return None
+
+        # get the input vcf for this sequence group
+        input_vcf = inputs.as_path(target=sample, stage=ValidationMtToVcf, key='vcf')
+        happy_results = inputs.as_dict_by_target(stage=ValidationHappyOnVcf)[sample.id]
+
+        exp_outputs = self.expected_outputs(sample)
+        job = parse_and_post_results(
+            b=get_batch(),
+            vcf_path=str(input_vcf),
+            sample=sample,
+            happy_results=happy_results,
+            out_file=exp_outputs['json_summary'],
+            job_attrs=self.get_job_attrs(sample),
+            depends_on=inputs.get_jobs(sample),
         )
 
         return self.make_outputs(sample, data=exp_outputs, jobs=job)

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -71,4 +71,48 @@ class ValidationMtToVcf(SampleStage):
         )
 
         return self.make_outputs(sample, data=exp_outputs, jobs=job)
+@stage(
+    required_stages=ValidationMtToVcf,
+    analysis_type='custom',
+    update_analysis_meta=_sg_vcf_meta,
+    analysis_keys=['vcf'],
+)
+class ValidationHappyOnVcf(SampleStage):
+
+    def expected_outputs(self, sample: Sample):
+
+        return {
+            'vcf': (
+                sample.dataset.prefix()
+                / 'validation'
+                / get_workflow().output_version
+                / f'{sample.id}.vcf.bgz'
+            ),
+            'index': (
+                sample.dataset.prefix()
+                / 'validation'
+                / get_workflow().output_version
+                / f'{sample.id}.vcf.bgz.tbi'
+            )
+        }
+
+    def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
+        # only run this on validation samples
+        if sample.dataset.name != 'validation':
+            return None
+
+        # get the input mt for this dataset
+        mt_path = inputs.as_path(target=sample.dataset, stage=AnnotateDataset, key='mt')
+        exp_outputs = self.expected_outputs(sample)
+
+        job = validation_mt_to_vcf_job(
+            b=get_batch(),
+            mt_path=mt_path,
+            sample_id=sample.id,
+            out_vcf_path=exp_outputs['vcf'],
+            job_attrs=self.get_job_attrs(sample),
+            depends_on=inputs.get_jobs(sample),
+        )
+
+        return self.make_outputs(sample, data=exp_outputs, jobs=job)
 

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+"""
+Content relating to the hap.py validation process
+"""
+
+
+from typing import Any
+
+from cpg_utils import to_path, Path
+from cpg_utils.cloud import read_secret
+from cpg_utils.config import get_config
+from cpg_workflows.workflow import (
+    stage,
+    SampleStage,
+    Sample,
+    StageInput,
+    StageOutput,
+    CohortStage,
+    DatasetStage,
+    Cohort,
+    Dataset,
+    get_workflow,
+)
+from cpg_workflows.stages.seqr_loader import AnnotateDataset, _sg_vcf_meta
+from cpg_workflows.jobs.validation import validation_mt_to_vcf_job
+from .. import get_batch
+
+
+@stage(
+    required_stages=AnnotateDataset,
+    analysis_type='custom',
+    update_analysis_meta=_sg_vcf_meta,
+    analysis_keys=['vcf'],
+)
+class ValidationMtToVcf(SampleStage):
+
+    def expected_outputs(self, sample: Sample):
+
+        return {
+            'vcf': (
+                sample.dataset.prefix()
+                / 'validation'
+                / get_workflow().output_version
+                / f'{sample.id}.vcf.bgz'
+            ),
+            'index': (
+                sample.dataset.prefix()
+                / 'validation'
+                / get_workflow().output_version
+                / f'{sample.id}.vcf.bgz.tbi'
+            )
+        }
+
+    def queue_jobs(self, sample: Sample, inputs: StageInput) -> StageOutput | None:
+        # only run this on validation samples
+        if sample.dataset.name != 'validation':
+            return None
+
+        # get the input mt for this dataset
+        mt_path = inputs.as_path(target=sample.dataset, stage=AnnotateDataset, key='mt')
+        exp_outputs = self.expected_outputs(sample)
+
+        job = validation_mt_to_vcf_job(
+            b=get_batch(),
+            mt_path=mt_path,
+            sample_id=sample.id,
+            out_vcf_path=exp_outputs['vcf'],
+            job_attrs=self.get_job_attrs(sample),
+            depends_on=inputs.get_jobs(sample),
+        )
+
+        return self.make_outputs(sample, data=exp_outputs, jobs=job)
+

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -97,6 +97,17 @@ def _dataset_vcf_meta(
     return {'type': 'dataset-vcf'}
 
 
+def _sg_vcf_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, Any]:
+    """
+    Add meta.type to custom analysis object
+
+    TODO: Replace this once dynamic analysis types land in metamist.
+    """
+    return {'type': 'dataset-vcf'}
+
+
 @stage(
     required_stages=[AnnotateCohort],
     analysis_type='custom',
@@ -182,14 +193,13 @@ class DatasetVCF(DatasetStage):
         Uses analysis-runner's dataproc helper to run a hail query script
         only run this on manually defined list of cohorts
         """
-        assert dataset.cohort
 
         # only run this selectively, most datasets it's not required
         eligible_datasets = get_config()['workflow']['write_vcf']
         if dataset.name not in eligible_datasets:
             return None
 
-        mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateDataset, key='mt')
+        mt_path = inputs.as_path(target=dataset, stage=AnnotateDataset, key='mt')
 
         job = cohort_to_vcf_job(
             b=get_batch(),

--- a/main.py
+++ b/main.py
@@ -19,11 +19,20 @@ from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.seqr_loader import MtToEs, AnnotateDataset, DatasetVCF
 from cpg_workflows.stages.gatk_sv import AnnotateVcf
 from cpg_workflows.stages.stripy import Stripy
+from cpg_workflows.stages.happy_validation import ValidationParseHappy
 
 
 WORKFLOWS: dict[str, list[StageDecorator]] = {
     'pre_alignment': [FastQCMultiQC],
-    'seqr_loader': [DatasetVCF, AnnotateDataset, MtToEs, GvcfMultiQC, CramMultiQC, Stripy],
+    'seqr_loader': [
+        DatasetVCF,
+        AnnotateDataset,
+        MtToEs,
+        GvcfMultiQC,
+        CramMultiQC,
+        Stripy,
+        ValidationParseHappy
+    ],
     'large_cohort': [LoadVqsr, Frequencies, AncestryPlots, GvcfMultiQC, CramMultiQC],
     'gatk_sv': [AnnotateVcf],
 }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.13.3',
+    version='1.13.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.13.4',
+    version='1.13.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Not for urgent review...

Related to: 

- https://github.com/populationgenomics/references/pull/28
- https://github.com/populationgenomics/analysis-runner/pull/633
- https://github.com/populationgenomics/rare-disease/tree/main/validation

This is the pipeline-ification of the RD validation. Tidies up the whole process, splits into 3 jobs:

1. Generate a single sample VCF from the Dataset VCF
2. Run hap.py on that VCF
3. Publish the results to Metamist

All reference data is now pushed into the standard config file, rather than push/pulling from metamist.