### PR TITLE
Send output VCF location as a String

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.3
+current_version = 1.13.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.13.3
+  VERSION: 1.13.4
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -226,7 +226,7 @@ def cohort_to_vcf_job(
     Args:
         b (hb.Batch): the batch to add jobs into
         mt_path (str): path of the AnnotateDataset MT
-        out_vcf_path (str): path to write new VCF to
+        out_vcf_path (Path): path to write new VCF to
         job_attrs (dict):
         depends_on (hb.Job|list[hb.Job]): jobs to depend on
 
@@ -244,7 +244,7 @@ def cohort_to_vcf_job(
             seqr_loader,
             seqr_loader.vcf_from_mt_subset.__name__,
             str(mt_path),
-            out_vcf_path,
+            str(out_vcf_path),
             setup_gcp=True,
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.13.3',
+    version='1.13.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The query_command wrapper takes the GSPath it is passed, and interprets this literally as `GSPath('gs://...)` when sending it as input. Avoid this complication by making everything a String

see https://batch.hail.populationgenomics.org.au/batches/424488/jobs/1 