### PR TITLE
Resume task functionality for HaplotypeCaller

### DIFF
--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -252,10 +252,7 @@ def merge_gvcfs_job(
         # if the output was recoverable, read into the batch
         if isinstance(gvcf_group, str):
             gvcf_group = b.read_input_group(
-                **{
-                    "g.vcf.gz": gvcf_group,
-                    "g.vcf.gz.tbi": gvcf_group
-                }
+                **{"g.vcf.gz": gvcf_group, "g.vcf.gz.tbi": gvcf_group}
             )
         input_cmd += f'INPUT={gvcf_group["g.vcf.gz"]} '
 

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -151,7 +151,7 @@ def _haplotype_caller_one(
 
     if utils.can_reuse(out_gvcf_path, overwrite):
         j.name = f'{j.name} [reuse]'
-        return j, out_gvcf_path
+        return j, str(out_gvcf_path)
 
     j.image(image_path('gatk'))
 

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -252,7 +252,7 @@ def merge_gvcfs_job(
         # if the output was recoverable, read into the batch
         if isinstance(gvcf_group, str):
             gvcf_group = b.read_input_group(
-                **{'g.vcf.gz': gvcf_group, 'g.vcf.gz.tbi': gvcf_group}
+                **{'g.vcf.gz': gvcf_group, 'g.vcf.gz.tbi': f'{gvcf_group}.tbi'}
             )
         input_cmd += f'INPUT={gvcf_group["g.vcf.gz"]} '
 

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -252,7 +252,7 @@ def merge_gvcfs_job(
         # if the output was recoverable, read into the batch
         if isinstance(gvcf_group, str):
             gvcf_group = b.read_input_group(
-                **{"g.vcf.gz": gvcf_group, "g.vcf.gz.tbi": gvcf_group}
+                **{'g.vcf.gz': gvcf_group, 'g.vcf.gz.tbi': gvcf_group}
             )
         input_cmd += f'INPUT={gvcf_group["g.vcf.gz"]} '
 

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -97,7 +97,7 @@ def haplotype_caller(
         for idx in range(scatter_count):
             assert intervals[idx], intervals
             # give each fragment a tmp location
-            fragment = tmp_prefix / 'haplotypecaller' / f'{idx}_{sample_name}.g.vcf.gz'
+            fragment = tmp_prefix / 'haplotypecaller' / f'{idx}_of_{scatter_count}_{sample_name}.g.vcf.gz'
             j, result = _haplotype_caller_one(
                 b,
                 sample_name=sample_name,
@@ -326,7 +326,7 @@ def postproc_gvcf(
     # in the resulting merged blocks. It would pick the highest INFO/DP when merging
     # multiple blocks, so a variant in a small homopolymer region (surrounded by
     # long DP=0 areas), that attracted piles of low-MQ reads with INFO/DP=1000
-    # will translate into a long GQ<20 block with the same FORMAT/DP=1000, 
+    # will translate into a long GQ<20 block with the same FORMAT/DP=1000,
     # which is wrong, because most of this block has no reads.
     bcftools view $GVCF \\
     | bcftools annotate -x INFO/DP \\


### PR DESCRIPTION
- Give each fragment a location, the same way we do for the `scatters == 1` condition (i.e. write output to tmp upon completion)
- `_haplotype_caller_one` returns either the resource group (if a new one was generated) or a String filepath (if the output was reusable)
- The merge method receives the list of [String | ResourceGroups] 
- When building the input command, if the value is a String, read into the batch before adding the location to the merge cmd

reasoning:
- Without a write location (out_gvcf_path) the method doesn't persist the output to GCP, so we can never do a reuse check
- `_haplotype_caller_one` returning a specific output, whether the job runs or not, means that every interval (in order) has its output added to a list. This was found previously by doing `[j.output_gvcf for j in hc_jobs]`, but the different Hail structure between reading input files and declaring a resource group means that we can never satisfy this syntax requirement with new files read in from GCP.

```
when reading input files in, "resourceGroup.something" is always a file
when _declaring_ a resource group, "resourceGroup.something" is always a collection of files
```

- Passing results back as a String instead of a Path
  - A `str` is a much more specific test than Path (CloudPath | GCPath | Path)
  - `read_input_group` needs a String to work anyway