### PR TITLE
Avoid Hail parallel VCF export

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -240,7 +240,7 @@ def vcf_from_mt_subset(mt_path: str, out_vcf_path: str):
 
     mt = hl.read_matrix_table(str(mt_path))
     logging.info(f'Dataset MT dimensions: {mt.count()}')
-    hl.export_vcf(mt, out_vcf_path, parallel='header_per_shard', tabix=True)
+    hl.export_vcf(mt, out_vcf_path, tabix=True)
     logging.info(f'Written {out_vcf_path}')
 
 


### PR DESCRIPTION
As discussed on Slack, Hail's VCF export _can_ be parallelised for speed, but that means we either have to rebuild the VCF ourselves from parts, or send collaborators 400 separate files and a heartfelt apology.

Removing parallel export here, taking the runtime hit upfront to build the VCFs we're sending to collaborators