### PR TITLE
Speed up pipeline startup

### DIFF
--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -34,17 +34,22 @@ def genotype(
     if utils.can_reuse(output_path, overwrite):
         return []
 
-    jobs = haplotype_caller(
-        b=b,
-        sample_name=sample_name,
-        job_attrs=job_attrs,
-        output_path=hc_gvcf_path,
-        cram_path=cram_path,
-        tmp_prefix=tmp_prefix,
-        scatter_count=get_config()['workflow'].get('scatter_count_genotype', 50),
-        overwrite=overwrite,
-        dragen_mode=dragen_mode,
-    )
+    # collect all the real jobs - [reuse] jobs substituted for None
+    jobs = [
+        job
+        for job in haplotype_caller(
+            b=b,
+            sample_name=sample_name,
+            job_attrs=job_attrs,
+            output_path=hc_gvcf_path,
+            cram_path=cram_path,
+            tmp_prefix=tmp_prefix,
+            scatter_count=get_config()['workflow'].get('scatter_count_genotype', 50),
+            overwrite=overwrite,
+            dragen_mode=dragen_mode,
+        )
+        if job is not None
+    ]
     postproc_j = postproc_gvcf(
         b=b,
         gvcf_path=GvcfPath(hc_gvcf_path),
@@ -53,8 +58,16 @@ def genotype(
         output_path=output_path,
         overwrite=overwrite,
     )
-    postproc_j.depends_on(*jobs)
-    return jobs + [postproc_j]
+
+    # only keep elements which are not None
+    # if both exist, set the dependency
+    if postproc_j and jobs:
+        postproc_j.depends_on(*jobs)
+
+    if postproc_j:
+        jobs.append(postproc_j)
+
+    return jobs
 
 
 intervals: list[hb.ResourceFile] | None = None
@@ -70,12 +83,13 @@ def haplotype_caller(
     output_path: Path | None = None,
     overwrite: bool = False,
     dragen_mode: bool = True,
-) -> list[Job]:
+) -> list[Job | None]:
     """
     Run GATK Haplotype Caller in parallel, split by intervals.
     """
     if utils.can_reuse(output_path, overwrite):
-        return [b.new_job('HaplotypeCaller [reuse]', job_attrs)]
+        logging.info(f'Reusing HaplotypeCaller {output_path}, job attrs: {job_attrs}')
+        return [None]
 
     jobs: list[Job] = []
 
@@ -97,7 +111,11 @@ def haplotype_caller(
         for idx in range(scatter_count):
             assert intervals[idx], intervals
             # give each fragment a tmp location
-            fragment = tmp_prefix / 'haplotypecaller' / f'{idx}_of_{scatter_count}_{sample_name}.g.vcf.gz'
+            fragment = (
+                tmp_prefix
+                / 'haplotypecaller'
+                / f'{idx}_of_{scatter_count}_{sample_name}.g.vcf.gz'
+            )
             j, result = _haplotype_caller_one(
                 b,
                 sample_name=sample_name,
@@ -109,7 +127,11 @@ def haplotype_caller(
                 overwrite=overwrite,
             )
             hc_fragments.append(result)
-            jobs.append(j)
+
+            # only consider jobs which weren't scheduled for [reuse]
+            if j is not None:
+                jobs.append(j)
+
         merge_j = merge_gvcfs_job(
             b=b,
             sample_name=sample_name,
@@ -118,7 +140,8 @@ def haplotype_caller(
             out_gvcf_path=output_path,
             overwrite=overwrite,
         )
-        jobs.append(merge_j)
+        if merge_j:
+            jobs.append(merge_j)
     else:
         hc_j, _result = _haplotype_caller_one(
             b,
@@ -128,7 +151,8 @@ def haplotype_caller(
             out_gvcf_path=output_path,
             overwrite=overwrite,
         )
-        jobs.append(hc_j)
+        if hc_j:
+            jobs.append(hc_j)
 
     return jobs
 
@@ -142,17 +166,17 @@ def _haplotype_caller_one(
     out_gvcf_path: Path | None = None,
     overwrite: bool = False,
     dragen_mode: bool = True,
-) -> tuple[Job, str | hb.ResourceGroup]:
+) -> tuple[Job, hb.ResourceGroup] | tuple[None, str]:
     """
     Add one GATK HaplotypeCaller job on an interval.
     """
     job_name = 'HaplotypeCaller'
-    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk HaplotypeCaller'))
 
     if utils.can_reuse(out_gvcf_path, overwrite):
-        j.name = f'{j.name} [reuse]'
-        return j, str(out_gvcf_path)
+        logging.info(f'Reusing HaplotypeCaller {out_gvcf_path}, job attrs: {job_attrs}')
+        return None, str(out_gvcf_path)
 
+    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk HaplotypeCaller'))
     j.image(image_path('gatk'))
 
     # Enough storage to localize CRAMs (can't pass GCS URL to CRAM to gatk directly
@@ -215,7 +239,7 @@ def _haplotype_caller_one(
     )
     if out_gvcf_path:
         b.write_output(j.output_gvcf, str(out_gvcf_path).replace('.g.vcf.gz', ''))
-    return (j, j.output_gvcf)
+    return j, j.output_gvcf
 
 
 def merge_gvcfs_job(
@@ -225,15 +249,16 @@ def merge_gvcfs_job(
     job_attrs: dict | None = None,
     out_gvcf_path: Path | None = None,
     overwrite: bool = False,
-) -> Job:
+) -> Job | None:
     """
     Combine by-interval GVCFs into a single sample-wide GVCF file.
     """
     job_name = f'Merge {len(gvcf_groups)} GVCFs'
-    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='picard MergeVcfs'))
     if utils.can_reuse(out_gvcf_path, overwrite):
-        j.name = f'{j.name} [reuse]'
-        return j
+        logging.info(f'Reusing {job_name} {out_gvcf_path}, job attrs: {job_attrs}')
+        return None
+
+    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='picard MergeVcfs'))
 
     j.image(image_path('picard'))
     j.cpu(2)
@@ -275,7 +300,7 @@ def postproc_gvcf(
     overwrite: bool = False,
     output_path: Path | None = None,
     depends_on: list[Job] | None = None,
-) -> Job:
+) -> Job | None:
     """
     1. Runs ReblockGVCF to annotate with allele-specific VCF INFO fields
     required for recalibration, and reduce the number of GVCF blocking bins to 2.
@@ -286,10 +311,11 @@ def postproc_gvcf(
     """
     logging.info(f'Adding GVCF postproc job for sample {sample_name}, gvcf {gvcf_path}')
     job_name = 'Postproc GVCF'
-    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk ReblockGVCF'))
     if utils.can_reuse(output_path, overwrite):
-        return b.new_job(job_name + ' [reuse]', job_attrs)
+        logging.info(f'Reusing {output_path} output for {job_name}. {job_attrs}')
+        return None
 
+    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk ReblockGVCF'))
     j.image(image_path('gatk'))
 
     # We need at least 2 CPU, so on 16-core instance it would be 8 jobs,

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -20,6 +20,18 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import get_config
 
 
+def exists_on_pre_collected(test: set[Path], known: set[Path]) -> Path | None:
+    """
+    Check if a path exists in a set of known paths.
+
+    This is useful when checking if a path exists in a set of paths that were
+    already collected. This method has been included to permit simple mocking
+    """
+    for path in test:
+        if path not in known:
+            return path
+    return None
+
 @lru_cache
 def exists(path: Path | str, verbose: bool = True) -> bool:
     """

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -32,6 +32,7 @@ def exists_on_pre_collected(test: set[Path], known: set[Path]) -> Path | None:
             return path
     return None
 
+
 @lru_cache
 def exists(path: Path | str, verbose: bool = True) -> bool:
     """

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -3,7 +3,6 @@ Utility functions and constants.
 """
 
 import logging
-import math
 import re
 import string
 import sys
@@ -20,17 +19,23 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import get_config
 
 
-def exists_on_pre_collected(test: set[Path], known: set[Path]) -> Path | None:
+def missing_from_pre_collected(test: set[Path], known: set[Path]) -> Path | None:
     """
     Check if a path exists in a set of known paths.
 
     This is useful when checking if a path exists in a set of paths that were
     already collected. This method has been included to permit simple mocking
+
+    Args:
+        test (set[Path]): all the files we want to check
+        known (set[Path]): all the files we know about
+
+    Returns:
+        Path | None: the first path that is missing from the known set, or None
+            Path is arbitrary, as the set is unordered
+            None indicates No missing files
     """
-    for path in test:
-        if path not in known:
-            return path
-    return None
+    return next((p for p in test if p not in known), None)
 
 
 @lru_cache

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -1246,7 +1246,7 @@ class SampleStage(Stage[Sample], ABC):
             # collect all expected outputs across all samples
             # find all directories which will be checked
             # list outputs in advance
-            all_outputs = set()
+            all_outputs: set[Path] = set()
             for sample in dataset.get_samples():
                 all_outputs = path_walk(self.expected_outputs(sample), all_outputs)
             all_parents = list_all_parent_dirs(all_outputs)

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -28,7 +28,7 @@ from cpg_utils import Path
 from .batch import get_batch
 from .status import MetamistStatusReporter
 from .targets import Target, Dataset, Sample, Cohort
-from .utils import exists, timestamp, slugify, ExpectedResultT
+from .utils import exists, exists_on_pre_collected, timestamp, slugify, ExpectedResultT
 from .inputs import get_cohort
 
 
@@ -728,9 +728,8 @@ class Stage(Generic[TargetT], ABC):
 
             # check against the pre-scanned files if possible
             if existing_outputs:
-                first_missing_path = next(
-                    (p for p in paths if p not in existing_outputs), None
-                )
+
+                first_missing_path = exists_on_pre_collected(paths, existing_outputs)
             # otherwise individual .exists() tests
             else:
                 first_missing_path = next((p for p in paths if not exists(p)), None)

--- a/test/stages/test_force_stages.py
+++ b/test/stages/test_force_stages.py
@@ -44,6 +44,10 @@ def test_force_stages(mocker: MockFixture, tmp_path):
     """
 
     mocker.patch('cpg_workflows.utils.exists_not_cached', lambda *args: True)
+    # dummy mocking to avoid file system scanning
+    mocker.patch('cpg_workflows.workflow.list_all_parent_dirs', lambda *args: {})
+    mocker.patch('cpg_workflows.workflow.list_of_all_dir_contents', lambda *args: {})
+    mocker.patch('cpg_workflows.workflow.exists_on_pre_collected', lambda *args: None)
     set_config(conf, tmp_path / 'config.toml')
     run_workflow(mocker)
 

--- a/test/stages/test_force_stages.py
+++ b/test/stages/test_force_stages.py
@@ -47,7 +47,7 @@ def test_force_stages(mocker: MockFixture, tmp_path):
     # dummy mocking to avoid file system scanning
     mocker.patch('cpg_workflows.workflow.list_all_parent_dirs', lambda *args: {})
     mocker.patch('cpg_workflows.workflow.list_of_all_dir_contents', lambda *args: {})
-    mocker.patch('cpg_workflows.workflow.exists_on_pre_collected', lambda *args: None)
+    mocker.patch('cpg_workflows.workflow.missing_from_pre_collected', lambda *args: None)
     set_config(conf, tmp_path / 'config.toml')
     run_workflow(mocker)
 

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -177,9 +177,6 @@ def test_seqr_loader_dry(mocker: MockFixture, tmp_path):
 
     mocker.patch('cpg_workflows.inputs.create_cohort', _mock_cohort)
 
-    def mock_exists(*args, **kwargs) -> bool:
-        return False
-
     def do_nothing(*args, **kwargs):
         return None
 
@@ -190,7 +187,7 @@ def test_seqr_loader_dry(mocker: MockFixture, tmp_path):
     # functions like get_intervals checks file existence
     mocker.patch('cpg_workflows.workflow.list_all_parent_dirs', lambda *args: {})
     mocker.patch('cpg_workflows.workflow.list_of_all_dir_contents', lambda *args: {})
-    mocker.patch('cpg_workflows.workflow.exists_on_pre_collected', lambda *args: False)
+    mocker.patch('cpg_workflows.workflow.exists_on_pre_collected', lambda *args: None)
     # cloudfuse (used in Vep) doesn't work with LocalBackend
     mocker.patch('hailtop.batch.job.Job.cloudfuse', do_nothing)
     # always_run (used in MtToEs -> hail_dataproc_job) doesn't work with LocalBackend

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -188,7 +188,9 @@ def test_seqr_loader_dry(mocker: MockFixture, tmp_path):
 
     mocker.patch('pathlib.Path.open', selective_mock_open)
     # functions like get_intervals checks file existence
-    mocker.patch('cloudpathlib.cloudpath.CloudPath.exists', mock_exists)
+    mocker.patch('cpg_workflows.workflow.list_all_parent_dirs', lambda *args: {})
+    mocker.patch('cpg_workflows.workflow.list_of_all_dir_contents', lambda *args: {})
+    mocker.patch('cpg_workflows.workflow.exists_on_pre_collected', lambda *args: False)
     # cloudfuse (used in Vep) doesn't work with LocalBackend
     mocker.patch('hailtop.batch.job.Job.cloudfuse', do_nothing)
     # always_run (used in MtToEs -> hail_dataproc_job) doesn't work with LocalBackend

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -187,7 +187,7 @@ def test_seqr_loader_dry(mocker: MockFixture, tmp_path):
     # functions like get_intervals checks file existence
     mocker.patch('cpg_workflows.workflow.list_all_parent_dirs', lambda *args: {})
     mocker.patch('cpg_workflows.workflow.list_of_all_dir_contents', lambda *args: {})
-    mocker.patch('cpg_workflows.workflow.exists_on_pre_collected', lambda *args: None)
+    mocker.patch('cpg_workflows.workflow.missing_from_pre_collected', lambda *args: None)
     # cloudfuse (used in Vep) doesn't work with LocalBackend
     mocker.patch('hailtop.batch.job.Job.cloudfuse', do_nothing)
     # always_run (used in MtToEs -> hail_dataproc_job) doesn't work with LocalBackend

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,28 @@
+"""
+utils tests
+"""
+
+from cpg_utils import to_path
+from cpg_workflows.utils import exists_on_pre_collected
+
+
+def test_exists_on_pre_collected():
+    """
+    checks that we find missing files from two lists
+    """
+
+    test = {to_path('a'), to_path('b')}
+    known = {to_path('a')}
+
+    assert exists_on_pre_collected(test, known) == to_path('b')
+
+
+def test_exists_on_pre_collected_negative():
+    """
+    checks that we don't find a missing file
+    """
+
+    test = {to_path('a'), to_path('b')}
+    known = {to_path('a'), to_path('b')}
+
+    assert exists_on_pre_collected(test, known) is None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,18 +3,33 @@ utils tests
 """
 
 from cpg_utils import to_path
-from cpg_workflows.utils import exists_on_pre_collected
+from cpg_workflows.utils import missing_from_pre_collected
 
 
 def test_exists_on_pre_collected():
     """
-    checks that we find missing files from two lists
+    checks that we find missing files between two sets
     """
 
     test = {to_path('a'), to_path('b')}
     known = {to_path('a')}
 
-    assert exists_on_pre_collected(test, known) == to_path('b')
+    assert missing_from_pre_collected(test, known) == to_path('b')
+
+
+def test_exists_on_pre_collected_multi():
+    """
+    checks that we find one of the missing files from two sets
+    """
+
+    test = {to_path('a'), to_path('b'), to_path('c'), to_path('d')}
+    known = {to_path('a')}
+
+    assert missing_from_pre_collected(test, known) in {
+        to_path('b'),
+        to_path('c'),
+        to_path('d')
+    }
 
 
 def test_exists_on_pre_collected_negative():
@@ -25,4 +40,4 @@ def test_exists_on_pre_collected_negative():
     test = {to_path('a'), to_path('b')}
     known = {to_path('a'), to_path('b')}
 
-    assert exists_on_pre_collected(test, known) is None
+    assert missing_from_pre_collected(test, known) is None

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -113,7 +113,6 @@ def test_workflow(tmp_path):
     print(f'Checking result in {output_path}:')
     with output_path.open() as f:
         result = f.read()
-        print(result)
         assert result.split() == ['CPG01_done', 'CPG02_done'], result
 
 
@@ -130,5 +129,5 @@ def test_path_walk():
         'b': [to_path('that.txt'), {'c': to_path('the_other.txt')}],
         'd': 'string.txt',
     }
-    act = path_walk(exp, set())
+    act = path_walk(exp)
     assert act == {to_path('this.txt'), to_path('that.txt'), to_path('the_other.txt')}


### PR DESCRIPTION
This PR is an attempt to speed up pipeline initiation in two ways:

1. Instead of running existence checks on each individual file in the per-sample stage outputs (gVCF, alignment, QC), update this to find and listdir in each of the output directories, then check for existence of the output file(s) in the already collected files. This should scale far better, so long as we stick with the current paradigm of adding single-sample outputs into a per-cohort folder (e.g. `gs://cpg-mcri-lrp-main/exome/cram/CPG289413.cram`)
2. When genotyping jobs (calling per interval, merging, post-processing) are required, the current `main` code creates a Batch job for each task, with all the corresponding dependency setting. This occurs even if the job doesn't do anything (i.e. `[reuse]` output). This change alters this behaviour so that the dummy jobs are not created, and the Stage(s) permit tasks to be `None`. 

At the sample Stage, before running existence checks on all SampleStage outputs individually:
- find all per-sample output files using the `expected_outputs` call
- find all unique directories containing those files
- list all contents in all those directories (here using `iterdir`, previously I've used `glob` to do the same thing. I've done a little check and it produces the same output)
- pass this as a [optional] set of Paths to `_get_action`, forwarded to `_is_reusable`
- if a set of existing Paths was given as an argument, instead of doing existence checks, check for existence in the list of files
- the rest of the does-the-output-exist logic is unaffected

e.g. 

```
@StageMakeABC

samples CPG1, CPG2

CPG1 expected files: [gs://cpg-test/folder1/foo.txt, gs://cpg-test/folder1/folder2/bar.txt]
CPG2 expected files: [gs://cpg-test/folder1/homer.txt, gs://cpg-test/folder1/folder2/bart.txt]

unique parents: {gs://cpg-test/folder1, gs://cpg-test/folder1/folder2}
listdir on all parents: {
    gs://cpg-test/folder1/foo.txt, 
    gs://cpg-test/folder1/homer.txt, 
    gs://cpg-test/folder1/folder2/bar.txt
}

gs://cpg-test/folder1/folder2/bart.txt will be identified as 'not in current file list'
without having to run exists() on all files

That's not a very succinct example is it...
```

Some other tweaks I spotted that I don't feel strongly about:

- name/description/analysis dataset is handled so weirdly... These are the relevant lines in main
```
analysis_dataset = get_config()['workflow']['dataset']
name = get_config()['workflow'].get('name')
description = get_config()['workflow'].get('description')
...
name = name or description or analysis_dataset
...
description = description or name
```

This is just a weird way of processing these 3 values, each capable of overwriting any other value. I've replaced this with
```
analysis_dataset = get_config()['workflow']['dataset']
name = get_config()['workflow'].get('name', analysis_dataset)
description = get_config()['workflow'].get('description', name)
```
Which might not achieve the exact same result under all circumstances, but isn't ridiculous to look at.