### PR TITLE
i/o suggestions

### DIFF
--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -71,6 +71,6 @@ class DeterminePloidy(DatasetStage):
             get_config()['workflow'].get('ploidy_priors'),
             [inputs.as_path(s, CollectReadCounts, 'gcnv_counts') for s in dataset.get_samples()],
             self.get_job_attrs(dataset),
-            self._file_dir(dataset)
+            self._file_dir(dataset) / f'{dataset.name}-contig-ploidy'
         )
         return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=jobs)


### PR DESCRIPTION
Jjust making a suggestion PR. 

It looks like the copy-cloud-to-local functionality you're looking for here should be handled by the `batch.read_input()` methods, rather than by recreating the copy into batch TMP manually.

The exact syntax to use for declaring/extracting the outputs as a resource group I'm not 100% on. 

