### PR TITLE
don't queue all the non-jobs for genotyping

### DIFF
--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -59,7 +59,7 @@ def genotype(
         overwrite=overwrite,
     )
 
-    # bit chaotic here now, only keep elements which are not None
+    # only keep elements which are not None
     # if both exist, set the dependency
     if postproc_j and jobs:
         postproc_j.depends_on(*jobs)
@@ -83,13 +83,13 @@ def haplotype_caller(
     output_path: Path | None = None,
     overwrite: bool = False,
     dragen_mode: bool = True,
-) -> list[Job] | None:
+) -> list[Job | None]:
     """
     Run GATK Haplotype Caller in parallel, split by intervals.
     """
     if utils.can_reuse(output_path, overwrite):
         logging.info(f'Reusing HaplotypeCaller {output_path}, job attrs: {job_attrs}')
-        return None
+        return [None]
 
     jobs: list[Job] = []
 

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -36,7 +36,8 @@ def genotype(
 
     # collect all the real jobs - [reuse] jobs substituted for None
     jobs = [
-        job for job in haplotype_caller(
+        job
+        for job in haplotype_caller(
             b=b,
             sample_name=sample_name,
             job_attrs=job_attrs,
@@ -46,7 +47,8 @@ def genotype(
             scatter_count=get_config()['workflow'].get('scatter_count_genotype', 50),
             overwrite=overwrite,
             dragen_mode=dragen_mode,
-        ) if job is not None
+        )
+        if job is not None
     ]
     postproc_j = postproc_gvcf(
         b=b,
@@ -109,7 +111,11 @@ def haplotype_caller(
         for idx in range(scatter_count):
             assert intervals[idx], intervals
             # give each fragment a tmp location
-            fragment = tmp_prefix / 'haplotypecaller' / f'{idx}_of_{scatter_count}_{sample_name}.g.vcf.gz'
+            fragment = (
+                tmp_prefix
+                / 'haplotypecaller'
+                / f'{idx}_of_{scatter_count}_{sample_name}.g.vcf.gz'
+            )
             j, result = _haplotype_caller_one(
                 b,
                 sample_name=sample_name,

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -34,17 +34,20 @@ def genotype(
     if utils.can_reuse(output_path, overwrite):
         return []
 
-    jobs = haplotype_caller(
-        b=b,
-        sample_name=sample_name,
-        job_attrs=job_attrs,
-        output_path=hc_gvcf_path,
-        cram_path=cram_path,
-        tmp_prefix=tmp_prefix,
-        scatter_count=get_config()['workflow'].get('scatter_count_genotype', 50),
-        overwrite=overwrite,
-        dragen_mode=dragen_mode,
-    )
+    # collect all the real jobs - [reuse] jobs substituted for None
+    jobs = [
+        job for job in haplotype_caller(
+            b=b,
+            sample_name=sample_name,
+            job_attrs=job_attrs,
+            output_path=hc_gvcf_path,
+            cram_path=cram_path,
+            tmp_prefix=tmp_prefix,
+            scatter_count=get_config()['workflow'].get('scatter_count_genotype', 50),
+            overwrite=overwrite,
+            dragen_mode=dragen_mode,
+        ) if job is not None
+    ]
     postproc_j = postproc_gvcf(
         b=b,
         gvcf_path=GvcfPath(hc_gvcf_path),
@@ -53,8 +56,16 @@ def genotype(
         output_path=output_path,
         overwrite=overwrite,
     )
-    postproc_j.depends_on(*jobs)
-    return jobs + [postproc_j]
+
+    # bit chaotic here now, only keep elements which are not None
+    # if both exist, set the dependency
+    if postproc_j and jobs:
+        postproc_j.depends_on(*jobs)
+
+    if postproc_j:
+        jobs.append(postproc_j)
+
+    return jobs
 
 
 intervals: list[hb.ResourceFile] | None = None
@@ -70,12 +81,13 @@ def haplotype_caller(
     output_path: Path | None = None,
     overwrite: bool = False,
     dragen_mode: bool = True,
-) -> list[Job]:
+) -> list[Job] | None:
     """
     Run GATK Haplotype Caller in parallel, split by intervals.
     """
     if utils.can_reuse(output_path, overwrite):
-        return [b.new_job('HaplotypeCaller [reuse]', job_attrs)]
+        logging.info(f'Reusing HaplotypeCaller {output_path}, job attrs: {job_attrs}')
+        return None
 
     jobs: list[Job] = []
 
@@ -109,7 +121,11 @@ def haplotype_caller(
                 overwrite=overwrite,
             )
             hc_fragments.append(result)
-            jobs.append(j)
+
+            # only consider jobs which weren't scheduled for [reuse]
+            if j is not None:
+                jobs.append(j)
+
         merge_j = merge_gvcfs_job(
             b=b,
             sample_name=sample_name,
@@ -118,7 +134,8 @@ def haplotype_caller(
             out_gvcf_path=output_path,
             overwrite=overwrite,
         )
-        jobs.append(merge_j)
+        if merge_j:
+            jobs.append(merge_j)
     else:
         hc_j, _result = _haplotype_caller_one(
             b,
@@ -128,7 +145,8 @@ def haplotype_caller(
             out_gvcf_path=output_path,
             overwrite=overwrite,
         )
-        jobs.append(hc_j)
+        if hc_j:
+            jobs.append(hc_j)
 
     return jobs
 
@@ -142,17 +160,17 @@ def _haplotype_caller_one(
     out_gvcf_path: Path | None = None,
     overwrite: bool = False,
     dragen_mode: bool = True,
-) -> tuple[Job, str | hb.ResourceGroup]:
+) -> tuple[Job, hb.ResourceGroup] | tuple[None, str]:
     """
     Add one GATK HaplotypeCaller job on an interval.
     """
     job_name = 'HaplotypeCaller'
-    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk HaplotypeCaller'))
 
     if utils.can_reuse(out_gvcf_path, overwrite):
-        j.name = f'{j.name} [reuse]'
-        return j, str(out_gvcf_path)
+        logging.info(f'Reusing HaplotypeCaller {out_gvcf_path}, job attrs: {job_attrs}')
+        return None, str(out_gvcf_path)
 
+    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk HaplotypeCaller'))
     j.image(image_path('gatk'))
 
     # Enough storage to localize CRAMs (can't pass GCS URL to CRAM to gatk directly
@@ -215,7 +233,7 @@ def _haplotype_caller_one(
     )
     if out_gvcf_path:
         b.write_output(j.output_gvcf, str(out_gvcf_path).replace('.g.vcf.gz', ''))
-    return (j, j.output_gvcf)
+    return j, j.output_gvcf
 
 
 def merge_gvcfs_job(
@@ -225,15 +243,16 @@ def merge_gvcfs_job(
     job_attrs: dict | None = None,
     out_gvcf_path: Path | None = None,
     overwrite: bool = False,
-) -> Job:
+) -> Job | None:
     """
     Combine by-interval GVCFs into a single sample-wide GVCF file.
     """
     job_name = f'Merge {len(gvcf_groups)} GVCFs'
-    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='picard MergeVcfs'))
     if utils.can_reuse(out_gvcf_path, overwrite):
-        j.name = f'{j.name} [reuse]'
-        return j
+        logging.info(f'Reusing {job_name} {out_gvcf_path}, job attrs: {job_attrs}')
+        return None
+
+    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='picard MergeVcfs'))
 
     j.image(image_path('picard'))
     j.cpu(2)
@@ -275,7 +294,7 @@ def postproc_gvcf(
     overwrite: bool = False,
     output_path: Path | None = None,
     depends_on: list[Job] | None = None,
-) -> Job:
+) -> Job | None:
     """
     1. Runs ReblockGVCF to annotate with allele-specific VCF INFO fields
     required for recalibration, and reduce the number of GVCF blocking bins to 2.
@@ -286,10 +305,11 @@ def postproc_gvcf(
     """
     logging.info(f'Adding GVCF postproc job for sample {sample_name}, gvcf {gvcf_path}')
     job_name = 'Postproc GVCF'
-    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk ReblockGVCF'))
     if utils.can_reuse(output_path, overwrite):
-        return b.new_job(job_name + ' [reuse]', job_attrs)
+        logging.info(f'Reusing {output_path} output for {job_name}. {job_attrs}')
+        return None
 
+    j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk ReblockGVCF'))
     j.image(image_path('gatk'))
 
     # We need at least 2 CPU, so on 16-core instance it would be 8 jobs,


### PR DESCRIPTION
Partially relates to #372 - All 4 of the jobs defined in cpg_workflows/jobs/genotype.py are able to detect when no action needs to be taken (output already exists), but they still create a Hail Batch Job with no operation, and that job has a place in the dependency graph for the workflow. 

In a workflow like https://batch.hail.populationgenomics.org.au/batches/424566 this means that 90% of the tasks are already complete, but the batch service takes 25mins setting up meaningless dependencies anyway. This change tidies up the logic used so that when a job doesn't need to run (output already exists and is reusable), this is reported to Logging and NO job is created, instead of creating a real placeholder job.