### PR TITLE
Correction to Hap.py workflow

### DIFF
--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -156,7 +156,7 @@ def run_happy_on_vcf(
     )
 
     # region: stratification BED files
-    if stratification := get_config()['stratification']:
+    if stratification := get_config()['references']['stratification']:
         strat_folder = to_path(stratification)
         strat_dict = {file.name: str(file) for file in strat_folder.glob('*')}
         assert 'definition.tsv' in strat_dict, f'definition.tsv file does not exist'
@@ -209,7 +209,7 @@ def parse_and_post_results(
         'truth_bed': ref_data['bed'],
     }
 
-    if stratification := get_config()['stratification']:
+    if stratification := get_config()['references']['stratification']:
         summary_data['stratified'] = stratification
 
     # read in the summary CSV file

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -127,7 +127,7 @@ class ValidationHappyOnVcf(SampleStage):
         return self.make_outputs(sample, data=exp_outputs, jobs=job)
 
 
-@stage(required_stages=ValidationHappyOnVcf)
+@stage(required_stages=[ValidationMtToVcf,ValidationHappyOnVcf])
 class ValidationParseHappy(SampleStage):
     def expected_outputs(self, sample: Sample):
         return {

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -127,7 +127,7 @@ class ValidationHappyOnVcf(SampleStage):
         return self.make_outputs(sample, data=exp_outputs, jobs=job)
 
 
-@stage(required_stages=[ValidationMtToVcf,ValidationHappyOnVcf])
+@stage(required_stages=[ValidationMtToVcf, ValidationHappyOnVcf])
 class ValidationParseHappy(SampleStage):
     def expected_outputs(self, sample: Sample):
         return {

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -307,7 +307,8 @@ class StageInput:
         if not self._outputs_by_target_by_stage.get(stage.__name__):
             raise StageInputNotFoundError(
                 f'Not found output from stage {stage.__name__}, required for stage '
-                f'{self.stage.name}. Available: {self._outputs_by_target_by_stage}'
+                f'{self.stage.name}. Is {stage.__name__} in the `required_stages`'
+                f'decorator? Available: {self._outputs_by_target_by_stage}'
             )
         if not self._outputs_by_target_by_stage[stage.__name__].get(target.target_id):
             raise StageInputNotFoundError(


### PR DESCRIPTION
Final stage decorator needs double dependency on prior stages to recall input. Pretty Esoteric bug... I've changed the error message as a more specific hint.

Updated expected location of the stratification files in config