### PR TITLE
Split picard markdup in 2

### DIFF
--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -24,6 +24,17 @@ use_as_vqsr = true
 
 write_vcf = ["udn-aus"]
 
+[resource_overrides]
+# Override default resource requirements for unusually large seq data without
+# demanding higher resources for all operations as standard. Examples below
+
+# picard override (int), GB to use in MarkDuplicates
+#picard = 100
+
+# haplotype caller overrides, see production-pipelines PR#381
+# defaults in code are 40 for genomes, none for exomes
+#haplotypecaller_storage = 80
+
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level
 # sensitivities. The tool matches them internally to a VQSLOD score cutoff 

--- a/configs/genome.toml
+++ b/configs/genome.toml
@@ -1,3 +1,2 @@
 [workflow]
 sequencing_type = 'genome'
-haplotypecaller_storage_gb = 40

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -193,14 +193,17 @@ def _haplotype_caller_one(
     # Based on an audit of RD crams on 19/05/23, 99% of crams are <34Gb. Will set the
     # default to 40Gb for genomes then use a run specific confg to run the rare
     # sequencing group that will fail from this limit.
-    if get_config()['workflow']['sequencing_type'] == 'genome':
-        storage_gb = get_config()['workflow'].get('haplotypecaller_storage_gb', 40)
+    if (
+        haplo_storage := get_config()['resource_overrides'].get(
+            'haplotypecaller_storage'
+        )
+    ) is not None:
+        storage_gb = haplo_storage
+    elif get_config()['workflow']['sequencing_type'] == 'genome':
+        storage_gb = 40
     else:
         storage_gb = None  # avoid extra disk for exomes
 
-    storage_gb = None  # avoid extra disk by default
-    if get_config()['workflow']['sequencing_type'] == 'genome':
-        storage_gb = 100
     job_res = HIGHMEM.request_resources(ncpu=2)
     # enough for input CRAM and output GVCF
     job_res.attach_disk_storage_gb = storage_gb

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -134,7 +134,7 @@ def markdup(
     resource.attach_disk_storage_gb = 250
 
     # check for a memory override for impossible samples
-    if (memory_override := get_config()['workflow'].get('exceptional_markdup_mem_gb')) is not None:
+    if (memory_override := get_config()['resource_overrides'].get('picard')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request
         j.memory(f'{memory_override}G')

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -134,6 +134,8 @@ def markdup(
     resource.attach_disk_storage_gb = 250
 
     # check for a memory override for impossible sequencing groups
+    # if RAM is overridden, leave CPU setting up to Hail based on
+    # RAM/CPU core ratios
     if (memory_override := get_config()['resource_overrides'].get('picard')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -134,7 +134,7 @@ def markdup(
     resource.attach_disk_storage_gb = 250
 
     # check for a memory override for impossible samples
-    if (memory_override := get_config()['workflow'].get('exceptional_picard')) is not None:
+    if (memory_override := get_config()['workflow'].get('exceptional_markdup_mem_gb')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request
         j.memory(f'{memory_override}G')

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -132,17 +132,14 @@ def markdup(
     resource = HIGHMEM.request_resources(ncpu=4)
     # enough for input BAM and output CRAM
     resource.attach_disk_storage_gb = 250
+    resource.set_to_job(j)
 
     # check for a memory override for impossible sequencing groups
-    # if RAM is overridden, leave CPU setting up to Hail based on
-    # RAM/CPU core ratios
+    # if RAM is overridden, update the memory resource setting
     if (memory_override := get_config()['resource_overrides'].get('picard')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request
         j.memory(f'{memory_override}G')
-        j.storage(f'{resource.get_storage_gb()}G')
-    else:
-        resource.set_to_job(j)
 
     j.declare_resource_group(
         output_cram={

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -144,12 +144,16 @@ def markdup(
     assert isinstance(j.output_cram, hb.ResourceGroup)
     cmd = f"""
     picard MarkDuplicates -Xms{resource.get_java_mem_mb()}M \\
-    I={sorted_bam} O=/dev/stdout M={j.markdup_metrics} \\
+    I={sorted_bam} O={j.output_bam} M={j.markdup_metrics} \\
     TMP_DIR=$(dirname {j.output_cram.cram})/picard-tmp \\
-    ASSUME_SORT_ORDER=coordinate \\
-    | samtools view -@{resource.get_nthreads() - 1} -T {fasta_reference.base} -O cram -o {j.output_cram.cram}
-    
-    samtools index -@{resource.get_nthreads() - 1} {j.output_cram.cram} {j.output_cram['cram.crai']}
+    ASSUME_SORT_ORDER=coordinate
+    echo "MarkDuplicates finished successfully"
+    samtools view --write-index -@{resource.get_nthreads() - 1} \\
+    -T {fasta_reference.base} \\
+    -O cram \\
+    -o {j.output_cram.cram} \\
+    {j.output_bam}
+    echo "samtools view finished successfully" 
     """
     j.command(command(cmd, monitor_space=True))
 

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -132,7 +132,16 @@ def markdup(
     resource = HIGHMEM.request_resources(ncpu=4)
     # enough for input BAM and output CRAM
     resource.attach_disk_storage_gb = 250
-    resource.set_to_job(j)
+
+    # check for a memory override for impossible samples
+    if (memory_override := get_config()['workflow']['exceptional_picard']) is not None:
+        assert isinstance(memory_override, int)
+        # Hail will select the right number of CPUs based on RAM request
+        j.memory(f'{memory_override}G')
+        j.storage(f'{resource.get_storage_gb()}G')
+    else:
+        resource.set_to_job(j)
+
     j.declare_resource_group(
         output_cram={
             'cram': '{root}.cram',

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -153,7 +153,7 @@ def markdup(
     assert isinstance(j.output_cram, hb.ResourceGroup)
     cmd = f"""
     picard MarkDuplicates -Xms{resource.get_java_mem_mb()}M \\
-    I={sorted_bam} O={j.output_bam} M={j.markdup_metrics} \\
+    I={sorted_bam} O={j.temp_bam} M={j.markdup_metrics} \\
     TMP_DIR=$(dirname {j.output_cram.cram})/picard-tmp \\
     ASSUME_SORT_ORDER=coordinate
     echo "MarkDuplicates finished successfully"
@@ -161,7 +161,7 @@ def markdup(
     -T {fasta_reference.base} \\
     -O cram \\
     -o {j.output_cram.cram} \\
-    {j.output_bam}
+    {j.temp_bam}
     echo "samtools view finished successfully" 
     """
     j.command(command(cmd, monitor_space=True))

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -134,7 +134,7 @@ def markdup(
     resource.attach_disk_storage_gb = 250
 
     # check for a memory override for impossible samples
-    if (memory_override := get_config()['workflow']['exceptional_picard']) is not None:
+    if (memory_override := get_config()['workflow'].get('exceptional_picard')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request
         j.memory(f'{memory_override}G')

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -133,7 +133,7 @@ def markdup(
     # enough for input BAM and output CRAM
     resource.attach_disk_storage_gb = 250
 
-    # check for a memory override for impossible samples
+    # check for a memory override for impossible sequencing groups
     if (memory_override := get_config()['resource_overrides'].get('picard')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request


### PR DESCRIPTION
Breaks Picard Markdup and Samtools view into distinct steps, within the same batch job.

Despite setting `set -x` and `pipefail`, the error messages being created at this stage are not useful - Picard's random termination is read as a samtools reading error, or a missing EOF. Decoupling these two steps is marginally 'less efficient', but we're getting desperate. A useful error message here may be helpful in diagnosing.

Picard also complains about having insufficient memory, so it resorts to an unbuffered mode prior to many of the crashes. A higher memory limit could mitigate this, but we don't want to just keep doubling it. I've added a config option `workflow. exceptional_markdup_mem_gb ` to boost memory provision, hopefully able to clean up these instances where there are only a few samples failing but they're failing consistently. The default remains the same as it is now.

Please review critically, I've no idea if this is a good idea or not. 
ref: https://batch.hail.populationgenomics.org.au/batches/424719?q=failed