### PR TITLE
Sg sidebranch only datasets

### DIFF
--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -45,7 +45,6 @@ def validation_mt_to_vcf_job(
     sequencing_group_id: str,
     out_vcf_path: str,
     job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None,
 ):
     """
     Take the single-dataset MT, and write to a VCF
@@ -56,7 +55,6 @@ def validation_mt_to_vcf_job(
         sequencing_group_id (str): sequencing group name
         out_vcf_path (str): path to write new VCF to
         job_attrs (dict):
-        depends_on (hb.Job|list[hb.Job]): jobs to depend on
 
     Returns:
         this single Job
@@ -77,8 +75,6 @@ def validation_mt_to_vcf_job(
             setup_gcp=True,
         )
     )
-    if depends_on:
-        vcf_j.depends_on(*depends_on)
 
     return vcf_j
 
@@ -89,7 +85,6 @@ def run_happy_on_vcf(
     sequencing_group_ext_id: str,
     out_prefix: str,
     job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None,
 ):
     """
     Run hap.py on the for this single-sample VCF
@@ -101,7 +96,6 @@ def run_happy_on_vcf(
         sequencing_group_ext_id (str): external ID to find reference data
         out_prefix (str): where to export happy outputs
         job_attrs ():
-        depends_on ():
 
     Returns:
         This Job or None
@@ -112,8 +106,6 @@ def run_happy_on_vcf(
         (job_attrs or {}) | {'tool': 'hap.py'},
     )
     happy_j.image(image_path('hap-py')).memory('100Gi').storage('100Gi').cpu(4)
-    if depends_on:
-        happy_j.depends_on(*depends_on)
 
     # region: read input data into batch
     vcf_input = b.read_input_group(vcf=vcf_path, index=f'{vcf_path}.tbi')

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -28,7 +28,7 @@ from .. import get_batch
     analysis_type='custom',
     update_analysis_meta=_sg_vcf_meta,
     analysis_keys=['vcf'],
-    only_datasets=['validation']
+    only_datasets=['validation'],
 )
 class ValidationMtToVcf(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
@@ -50,7 +50,6 @@ class ValidationMtToVcf(SequencingGroupStage):
     def queue_jobs(
         self, sequencing_group: SequencingGroup, inputs: StageInput
     ) -> StageOutput | None:
-
         # only keep the sequencing groups with reference data
         if sequencing_group.external_id not in get_config()['references']:
             return None
@@ -66,7 +65,7 @@ class ValidationMtToVcf(SequencingGroupStage):
             mt_path=str(mt_path),
             sequencing_group_id=sequencing_group.id,
             out_vcf_path=str(exp_outputs['vcf']),
-            job_attrs=self.get_job_attrs(sequencing_group)
+            job_attrs=self.get_job_attrs(sequencing_group),
         )
 
         return self.make_outputs(sequencing_group, data=exp_outputs, jobs=job)
@@ -76,7 +75,7 @@ class ValidationMtToVcf(SequencingGroupStage):
     required_stages=ValidationMtToVcf,
     analysis_type='qc',
     analysis_keys=['happy_csv'],
-    only_datasets=['validation']
+    only_datasets=['validation'],
 )
 class ValidationHappyOnVcf(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
@@ -99,7 +98,6 @@ class ValidationHappyOnVcf(SequencingGroupStage):
     def queue_jobs(
         self, sequencing_group: SequencingGroup, inputs: StageInput
     ) -> StageOutput | None:
-
         # only keep the sequencing groups with reference data
         if sequencing_group.external_id not in get_config()['references']:
             logging.info(f'Skipping {sequencing_group.id}; not in the reference set')
@@ -132,7 +130,7 @@ class ValidationHappyOnVcf(SequencingGroupStage):
 
 @stage(
     required_stages=[ValidationMtToVcf, ValidationHappyOnVcf],
-    only_datasets=['validation']
+    only_datasets=['validation'],
 )
 class ValidationParseHappy(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
@@ -149,7 +147,6 @@ class ValidationParseHappy(SequencingGroupStage):
     def queue_jobs(
         self, sequencing_group: SequencingGroup, inputs: StageInput
     ) -> StageOutput | None:
-
         # only keep the sequencing groups with reference data
         if sequencing_group.external_id not in get_config()['references']:
             logging.info(f'Skipping {sequencing_group.id}; not in the reference set')

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -781,7 +781,7 @@ def stage(
     skipped: bool = False,
     assume_outputs_exist: bool = False,
     forced: bool = False,
-    only_datasets: list[str] | None = None
+    only_datasets: list[str] | None = None,
 ) -> Union[StageDecorator, Callable[..., StageDecorator]]:
     """
     Implements a standard class decorator pattern with optional arguments.
@@ -826,7 +826,7 @@ def stage(
                 skipped=skipped,
                 assume_outputs_exist=assume_outputs_exist,
                 forced=forced,
-                only_datasets=only_datasets
+                only_datasets=only_datasets,
             )
 
         return wrapper_stage
@@ -1247,9 +1247,11 @@ class SequencingGroupStage(Stage[SequencingGroup], ABC):
             return output_by_target
 
         for dataset in datasets:
-
             # allow full skipping if this stage isn't intended for this dataset
-            if self.only_datasets is not None and dataset.name not in self.only_datasets:
+            if (
+                self.only_datasets is not None
+                and dataset.name.lower() not in self.only_datasets
+            ):
                 logging.warning(
                     f'Skipping dataset {dataset} for Stage {self.name} '
                     f'as it is not in only_datasets'

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -1253,7 +1253,7 @@ class SequencingGroupStage(Stage[SequencingGroup], ABC):
                 and dataset.name.lower() not in self.only_datasets
             ):
                 logging.warning(
-                    f'Skipping dataset {dataset} for Stage {self.name} '
+                    f'Skipping dataset {dataset} for SequencinggGroupStage {self.name} '
                     f'as it is not in only_datasets'
                 )
                 continue
@@ -1326,7 +1326,18 @@ class DatasetStage(Stage, ABC):
                 f'via workflow.skip_datasets`'
             )
             return output_by_target
+
         for dataset_i, dataset in enumerate(datasets):
+            if (
+                self.only_datasets is not None
+                and dataset.name.lower() not in self.only_datasets
+            ):
+                logging.warning(
+                    f'Skipping dataset {dataset} for DatasetStage {self.name} '
+                    f'as it is not in only_datasets'
+                )
+                continue
+
             action = self._get_action(dataset)
             logging.info(f'{self.name}: #{dataset_i + 1}/{dataset} [{action.name}]')
             output_by_target[dataset.target_id] = self._queue_jobs_with_checks(


### PR DESCRIPTION
Proposal for another StageWrapper argument - only_datasets

This is an indication that the SequencingGroup/Dataset stage indicated should only run for the enumerated datasets. I think the syntax here would work, but this will all become outdated instantly once we move to custom cohorts, where we can't really target a named dataset in code.

Leaving this here as a proposal, but a better option will be to carve off the dataset stages into a completely separate workflow.