### PR TITLE
Pass a single file to the pythonJob

### DIFF
--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -173,7 +173,7 @@ def parse_and_post_results(
     vcf_path: str,
     sequencing_group_id: str,
     sequencing_group_ext_id: str,
-    happy_results: dict,
+    happy_csv: str,
     out_file: str,
 ):
     """
@@ -184,14 +184,17 @@ def parse_and_post_results(
         vcf_path (str): path to the single-sample VCF
         sequencing_group_id (str): the SG ID
         sequencing_group_ext_id (str): the SG external ID
-        happy_results (dict): all results from the hap.py stage
+        happy_csv (str): CSV results from Hap.py
         out_file (str): where to write the JSON file
 
     Returns:
         this job
     """
+
+    # handler for the CSV file
+    happy_csv = to_path(happy_csv)
+
     ref_data = get_sample_truth_data(sequencing_group_id=sequencing_group_ext_id)
-    happy_csv = happy_results['happy_csv']
 
     # populate a dictionary of results for this sequencing group
     summary_data = {
@@ -218,7 +221,6 @@ def parse_and_post_results(
     with to_path(out_file).open('w', encoding='utf-8') as handle:
         json.dump(summary_data, handle)
 
-    # NOTE: This change is untested.
     get_metamist().create_analysis(
         dataset=get_config()['workflow']['dataset'],
         status=AnalysisStatus('completed'),

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -192,7 +192,7 @@ def parse_and_post_results(
     """
 
     # handler for the CSV file
-    happy_csv = to_path(happy_csv)
+    happy_handle = to_path(happy_csv)
 
     ref_data = get_sample_truth_data(sequencing_group_id=sequencing_group_ext_id)
 
@@ -208,7 +208,7 @@ def parse_and_post_results(
         summary_data['stratified'] = stratification
 
     # read in the summary CSV file
-    with happy_csv.open() as handle:
+    with happy_handle.open() as handle:
         summary_reader = DictReader(handle)
         for line in summary_reader:
             if line['Filter'] != 'PASS' or line['Subtype'] != '*':
@@ -226,6 +226,6 @@ def parse_and_post_results(
         status=AnalysisStatus('completed'),
         sequencing_group_ids=[sequencing_group_id],
         type_='qc',
-        output=str(happy_csv.parent),
+        output=str(happy_handle.parent),
         meta=summary_data,
     )

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -56,9 +56,9 @@ class ValidationMtToVcf(SequencingGroupStage):
         # generate the MT path from config
         input_hash = get_config()['inputs']['sample_hash']
         mt_path = (
-            sequencing_group.dataset.prefix() /
-            'mt' /
-            f'{input_hash}-{sequencing_group.dataset.name}.mt'
+            sequencing_group.dataset.prefix()
+            / 'mt'
+            / f'{input_hash}-{sequencing_group.dataset.name}.mt'
         )
 
         exp_outputs = self.expected_outputs(sequencing_group)
@@ -68,7 +68,7 @@ class ValidationMtToVcf(SequencingGroupStage):
             mt_path=str(mt_path),
             sequencing_group_id=sequencing_group.id,
             out_vcf_path=str(exp_outputs['vcf']),
-            job_attrs=self.get_job_attrs(sequencing_group)
+            job_attrs=self.get_job_attrs(sequencing_group),
         )
 
         return self.make_outputs(sequencing_group, data=exp_outputs, jobs=job)
@@ -125,7 +125,7 @@ class ValidationHappyOnVcf(SequencingGroupStage):
             vcf_path=str(input_vcf),
             sequencing_group_ext_id=sequencing_group.external_id,
             out_prefix=str(output_prefix),
-            job_attrs=self.get_job_attrs(sequencing_group)
+            job_attrs=self.get_job_attrs(sequencing_group),
         )
 
         return self.make_outputs(sequencing_group, data=exp_outputs, jobs=job)
@@ -157,9 +157,11 @@ class ValidationParseHappy(SequencingGroupStage):
         input_vcf = inputs.as_path(
             target=sequencing_group, stage=ValidationMtToVcf, key='vcf'
         )
-        happy_results = inputs.as_dict_by_target(stage=ValidationHappyOnVcf)[
-            sequencing_group.id
-        ]
+        happy_csv = str(
+            inputs.as_dict_by_target(stage=ValidationHappyOnVcf)[sequencing_group.id][
+                'happy_csv'
+            ]
+        )
 
         exp_outputs = self.expected_outputs(sequencing_group)
 
@@ -173,7 +175,7 @@ class ValidationParseHappy(SequencingGroupStage):
             vcf_path=str(input_vcf),
             sequencing_group_id=sequencing_group.id,
             sequencing_group_ext_id=sequencing_group.external_id,
-            happy_results=happy_results,
+            happy_results=happy_csv,
             out_file=str(exp_outputs['json_summary']),
         )
 


### PR DESCRIPTION
I am really bad at this...

The workflow builder is still exploding with the same `ValueError: too many values to unpack (expected 2)` issue. Excluding this final stage it all works correctly. 

I've realised that I'm only using one path from this dictionary anyway, so there's no need to pass as a dictionary. 
