### PR TITLE
Dont copy cromwell outputs twice

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.14.1
+current_version = 1.14.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.14.1
+  VERSION: 1.14.2
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -160,6 +160,7 @@ def add_gatk_sv_jobs(
         input_dict=paths_as_strings,
         outputs_to_collect=outputs_to_collect,
         driver_image=driver_image,
+        copy_outputs_to_gcp=False
     )
 
     copy_j = batch.new_job(f'{job_prefix}: copy outputs')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.14.1',
+    version='1.14.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'cpg-utils',
         'cyvcf2==0.30.18',
-        'analysis-runner>=2.40.7',
+        'analysis-runner>=2.41.2',
         'hail',
         'networkx',
         'metamist>=6.0.4',


### PR DESCRIPTION
Closes #388

Analysis-Runner has a boolean argument to deactivate the standard copy from tmp for all Cromwell outputs. 

This change sets that Bool to False as standard. 

This does not impact the specific copying of output files into the `expected_outputs` paths - those jobs also copy from tmp directly.