### PR TITLE
WDL Memory Override for WhamG

### DIFF
--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -1,0 +1,10 @@
+[resource_overrides]
+
+# location for any required resource overrides
+
+[resource_overrides.GatherSampleEvidence]
+
+# resource overrides for the GatherSampleEvidence stage
+
+[resource_overrides.GatherSampleEvidence.runtime_attr_wham]
+mem_gb = 7

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -125,6 +125,10 @@ class GatherSampleEvidence(SequencingGroupStage):
             ]
         )
 
+        # find any additional arguments to pass to Cromwell
+        if override := get_config()['resource_overrides'].get('GatherSampleEvidence'):
+            input_dict |= override
+
         expected_d = self.expected_outputs(sequencing_group)
 
         jobs = add_gatk_sv_jobs(


### PR DESCRIPTION
Now this is a story, all about how 
My GATK-SV run got flip turned upside down
And I'd like to take a minute
Just sit right there
I'll tell you how I'm trying to override the default memory setting used [here](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/Whamg.wdl#L135-L150)

---

See https://batch.hail.populationgenomics.org.au/batches/425063/jobs/2 - OOM error running WHAMg on CPG264531 (This sample doesn't seem to be a particular outlier size-wise, but has failed ~3 times on the bounce so this appears deterministic)

Since #383 a canonical place for "I want this default setting to behave differently" is get_config()['resource_overrides']

Failing Stage starts [here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py#L32)

- I'd like to shove a new setting into the input dictionary, here that's [runtime_attr_wham](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/GatherSampleEvidence.wdl#L109)
- this be passed to the [Wham WDL](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/Whamg.wdl#L26)
- [the name changes](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/Whamg.wdl#L90) (because who cares about consistency)
- memory is automatically determined here based on [various metrics](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/Whamg.wdl#L135-L150)
- that can be overridden by passing [mem_gb](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/Whamg.wdl#L222) through in the override dict

Looks plausible to me, I'm not super familiar with RuntimeAttr and whether it needs a spicy 🌶️ structure above + beyond a dictionary.

From the Cromwell metadata on the failed run I see the current params as

```
"runtime_attr": {
    "cpu_cores": 1,
    "max_retries": 1,
    "boot_disk_gb": 10,
    "disk_gb": 100,
    "mem_gb": 3.75,
    "preemptible_tries": 3
},
```

So I'll probably poke this in a single-SG run with 7.5GB just to try and get this one sample through 🗿 