### PR TITLE
Correction to Batch names

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -23,6 +23,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     make_combined_ped,
     SV_CALLERS,
 )
+from cpg_workflows.workflow import get_workflow
 
 
 @stage
@@ -89,7 +90,7 @@ class GatherBatchEvidence(CohortStage):
         sequencing_groups = cohort.get_sequencing_groups(only_active=True)
 
         input_dict: dict[str, Any] = {
-            'batch': cohort.name,
+            'batch': get_workflow().output_version,
             'samples': [sg.id for sg in sequencing_groups],
             'ped_file': str(make_combined_ped(cohort, self.prefix)),
             'counts': [
@@ -209,7 +210,7 @@ class ClusterBatch(CohortStage):
         batch_evidence_d = inputs.as_dict(cohort, GatherBatchEvidence)
 
         input_dict: dict[str, Any] = {
-            'batch': cohort.name,
+            'batch': get_workflow().output_version,
             'del_bed': str(batch_evidence_d['merged_dels']),
             'dup_bed': str(batch_evidence_d['merged_dups']),
             'ped_file': str(make_combined_ped(cohort, self.prefix)),
@@ -273,7 +274,7 @@ class GenerateBatchMetrics(CohortStage):
         gatherbatchevidence_d = inputs.as_dict(cohort, GatherBatchEvidence)
 
         input_dict: dict[str, Any] = {
-            'batch': cohort.name,
+            'batch': get_workflow().output_version,
             'baf_metrics': gatherbatchevidence_d['merged_BAF'],
             'discfile': gatherbatchevidence_d['merged_PE'],
             'coveragefile': gatherbatchevidence_d['merged_bincov'],
@@ -373,7 +374,7 @@ class FilterBatch(CohortStage):
         clusterbatch_d = inputs.as_dict(cohort, ClusterBatch)
 
         input_dict: dict[str, Any] = {
-            'batch': cohort.name,
+            'batch': get_workflow().output_version,
             'ped_file': make_combined_ped(cohort, self.prefix),
             'evidence_metrics': metrics_d['metrics'],
             'evidence_metrics_common': metrics_d['metrics_common'],
@@ -523,7 +524,7 @@ class GenotypeBatch(CohortStage):
         batchevidence_d = inputs.as_dict(cohort, GatherBatchEvidence)
 
         input_dict: dict[str, Any] = {
-            'batch': cohort.name,
+            'batch': get_workflow().output_version,
             'ped_file': make_combined_ped(cohort, self.prefix),
             'n_per_split': 5000,
             'n_RD_genotype_bins': 100000,


### PR DESCRIPTION
See https://github.com/broadinstitute/gatk-sv/issues/564

We have an issue whereby the merging of data from two separate runs is causing downstream duplication. With Emma's input I've tracked this back to the ClusterBatch step - 

- Each separate group of SGs being processed independently needs a distinct ID
- This ID is incorporated into the Variants identified as [part of a key](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/PESRClustering.wdl#L77)
- When I set up these jobs I was erroneously passing down the `cohort.name`, i.e. `seqr`, as the batch name for all batches
- `seqr` is then included into both sets of IDs, which leads to duplicated IDs when multiple VCFs are merged together (unique variants are determined by contig, start, end, DUP/DEL/etc., not by ID)

This change corrects this behaviour - for all stages processing sample batches in parallel, the hash of all relevant SGs is taken as the 'batch id' to be incorporated into the output files.