### PR TITLE
Batch ID list correction

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -116,7 +116,7 @@ class MakeCohortVcf(CohortStage):
 
         input_dict: dict[str, Any] = {
             'cohort_name': cohort.name,
-            'batches': [batch_names],
+            'batches': batch_names,
             'ped_file': make_combined_ped(cohort, self.prefix),
             'ref_dict': str(get_fasta().with_suffix('.dict')),
             'chr_x': 'chrX',


### PR DESCRIPTION
I was sending the batch names as a list within a list - the workflow couldn't iterate over this as expected causing the error here
https://batch.hail.populationgenomics.org.au/batches/425694