### PR TITLE
Add storage override for markdups job

### DIFF
--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -28,8 +28,9 @@ write_vcf = ["udn-aus"]
 # Override default resource requirements for unusually large seq data without
 # demanding higher resources for all operations as standard. Examples below
 
-# picard override (int), GB to use in MarkDuplicates
-#picard = 100
+# picard MarkDuplicates overrides for unreasnobly large sequnce groups
+#picard_mem_gb = 100
+#picard_storage_gb = 350
 
 # haplotype caller overrides, see production-pipelines PR#381
 # defaults in code are 40 for genomes, none for exomes
@@ -37,7 +38,7 @@ write_vcf = ["udn-aus"]
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level
-# sensitivities. The tool matches them internally to a VQSLOD score cutoff 
+# sensitivities. The tool matches them internally to a VQSLOD score cutoff
 # based on the model's estimated sensitivity to a set of true variants.
 snp_filter_level = 99.7
 indel_filter_level = 99.0
@@ -72,7 +73,7 @@ password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
 
 [stripy]
-# Analysis_type can be "standard" (fast) or "extended" (marginally slower 
+# Analysis_type can be "standard" (fast) or "extended" (marginally slower
 # but also uses unmapped reads for genotying)
 analysis_type = "extended"
 # See https://gitlab.com/andreassh/stripy-pipeline#list-of-loci

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -40,7 +40,7 @@
 # Description of the workflow (to display in the Batch GUI)
 #description =
 
-# Suffix the workflow outputs location (`get_workflow().prefix`) with this string. 
+# Suffix the workflow outputs location (`get_workflow().prefix`) with this string.
 # By default, the hash of all input paths will be used.
 #output_version = "0.1"
 
@@ -60,7 +60,7 @@ skip_sgs_with_missing_input = false
 # If set to False, will overwrite all intermediates. Used by `utils.can_reuse(path)`.
 check_intermediates = true
 
-# Before running a stage, check if input (i.e. expected outputs from required stages) 
+# Before running a stage, check if input (i.e. expected outputs from required stages)
 # already exist. If it exists, do not submit stage jobs.
 check_expected_outputs = true
 
@@ -81,7 +81,7 @@ check_expected_outputs = true
 reblock_gq_bands = [20, 30, 40]
 
 # Only print the final merged config and a list of stages to be submitted.
-# Will skip any communication with Metamist, Hail Batch, and Cloud Storage, so 
+# Will skip any communication with Metamist, Hail Batch, and Cloud Storage, so
 # the code can be run without permissions.
 #dry_run = true
 
@@ -92,3 +92,15 @@ SYNDIP = 'syndip'
 
 [hail]
 delete_scratch_on_exit = false
+
+[resource_overrides]
+# Override default resource requirements for unusually large seq data without
+# demanding higher resources for all operations as standard. Examples below
+
+# picard MarkDuplicates overrides for unreasnobly large sequnce groups
+#picard_mem_gb = 100
+#picard_storage_gb = 350
+
+# haplotype caller overrides, see production-pipelines PR#381
+# defaults in code are 40 for genomes, none for exomes
+#haplotypecaller_storage = 80

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -130,13 +130,19 @@ def markdup(
 
     j.image(image_path('picard'))
     resource = HIGHMEM.request_resources(ncpu=4)
-    # enough for input BAM and output CRAM
-    resource.attach_disk_storage_gb = 250
+
+    # check for a storage override for unreasonably large sequencing groups
+    if (storage_override := get_config()['resource_overrides'].get('picard_storage_gb')) is not None:
+        assert isinstance(storage_override, int)
+        resource.attach_disk_storage_gb = storage_override
+    else:
+        # enough for input BAM and output CRAM
+        resource.attach_disk_storage_gb = 250
     resource.set_to_job(j)
 
     # check for a memory override for impossible sequencing groups
     # if RAM is overridden, update the memory resource setting
-    if (memory_override := get_config()['resource_overrides'].get('picard')) is not None:
+    if (memory_override := get_config()['resource_overrides'].get('picard_mem_gb')) is not None:
         assert isinstance(memory_override, int)
         # Hail will select the right number of CPUs based on RAM request
         j.memory(f'{memory_override}G')


### PR DESCRIPTION
Default local storage is insufficnet for very large crams mkduplicates job. This PR adds a configerable overide to be used in when needed for very large crams.

eg https://batch.hail.populationgenomics.org.au/batches/425798/jobs/2