### PR TITLE
Silence some mypy diagnostics

### DIFF
--- a/cpg_workflows/dataproc_scripts/mt_to_es.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es.py
@@ -119,7 +119,7 @@ def main(
     mt_path: str,
     es_index: str,
     done_flag_path: str,
-    password: str = None,
+    password: str | None = None,
 ):
     """
     Entry point.

--- a/cpg_workflows/filetypes.py
+++ b/cpg_workflows/filetypes.py
@@ -33,7 +33,7 @@ class CramOrBamPath(AlignmentInput, ABC):
         self,
         path: str | Path,
         index_path: str | Path | None = None,
-        reference_assembly: str = None,
+        reference_assembly: str | None = None,
     ):
         self.path = to_path(path)
         self.index_path: Path | None = None

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -91,7 +91,7 @@ def haplotype_caller(
         logging.info(f'Reusing HaplotypeCaller {output_path}, job attrs: {job_attrs}')
         return [None]
 
-    jobs: list[Job] = []
+    jobs: list[Job | None] = []
 
     if scatter_count > 1:
         global intervals
@@ -257,7 +257,7 @@ def _haplotype_caller_one(
 def merge_gvcfs_job(
     b: hb.Batch,
     sequencing_group_name: str,
-    gvcf_groups: list[str | hb.Resource],
+    gvcf_groups: list[str | hb.ResourceGroup],
     job_attrs: dict | None = None,
     out_gvcf_path: Path | None = None,
     overwrite: bool = False,

--- a/cpg_workflows/large_cohort/dataproc_utils.py
+++ b/cpg_workflows/large_cohort/dataproc_utils.py
@@ -34,7 +34,7 @@ def dataproc_job(
     function_str_args: list[str] | None = None,
     preemptible: bool = True,
     num_workers: int | None = None,
-    depends_on: list[Job | None] = None,
+    depends_on: list[Job | None] | None = None,
     autoscaling_policy: str | None = None,
     long: bool = False,
     worker_boot_disk_size: int | None = None,

--- a/cpg_workflows/large_cohort/dataproc_utils.py
+++ b/cpg_workflows/large_cohort/dataproc_utils.py
@@ -3,6 +3,8 @@ Utils for submitting the workflow to a Dataproc cluster.
 """
 
 import math
+from typing import Sequence
+
 from analysis_runner import dataproc
 from hailtop.batch.job import Job
 
@@ -34,7 +36,7 @@ def dataproc_job(
     function_str_args: list[str] | None = None,
     preemptible: bool = True,
     num_workers: int | None = None,
-    depends_on: list[Job | None] | None = None,
+    depends_on: Sequence[Job | None] | None = None,
     autoscaling_policy: str | None = None,
     long: bool = False,
     worker_boot_disk_size: int | None = None,

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -48,7 +48,7 @@ class StatusReporter(ABC):
         analysis_status: str,
         target: Target,
         meta: dict | None = None,
-        project_name: str = None,
+        project_name: str | None = None,
     ) -> int | None:
         """
         Record analysis entry.
@@ -184,7 +184,7 @@ class MetamistStatusReporter(StatusReporter):
         analysis_status: str,
         target: Target,
         meta: dict | None = None,
-        project_name: str = None,
+        project_name: str | None = None,
     ) -> int | None:
         """Record analysis entry"""
         return get_metamist().create_analysis(

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -836,7 +836,7 @@ def stage(
 def skip(
     _fun: Optional[StageDecorator] = None,
     *,
-    reason: str = None,
+    reason: str | None = None,
     assume_outputs_exist: bool = False,
 ) -> Union[StageDecorator, Callable[..., StageDecorator]]:
     """

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -202,6 +202,7 @@ def test_attributes(mocker: MockFixture, tmp_path):
     ]
 
     for job in get_batch()._jobs:
+        assert job.attributes
         for key in job.attributes:
             assert key in expected_attrs
         assert job.attributes['stage'] in [s.__name__ for s in workflow_stages]
@@ -215,6 +216,7 @@ def test_attributes(mocker: MockFixture, tmp_path):
             or job.attributes['sequencing_groups'] == "['CPG02']"
         )
         # test job name
+        assert job.name
         assert job.name.startswith(
             f'{get_cohort().get_datasets()[0].name}/{job.attributes["sequencing_group"]}/{job.attributes["participant_id"]}'
         )


### PR DESCRIPTION
This gets rid of some existing trivia when you run

```
mypy .
```

looking for new diagnostics coming from your own changes.

The remaining messages are of two kinds:

```
note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs
error: Cannot instantiate abstract class "CloudPath" with abstract attributes "drive", "is_dir", "is_file", "mkdir" and "touch"  [abstract]
```

It might be worth running with `--check-untyped-defs` to see if there is further low-hanging trivia that can be cleared up.

The `CloudPath` problem is one that hopefully ought to be / could be fixed by cloudpathlib changes (see drivendataorg/cloudpathlib#328).