### PR TITLE
Fixes to get things running with Analysis runner.

### DIFF
--- a/cpg_workflows/jobs/trim.py
+++ b/cpg_workflows/jobs/trim.py
@@ -222,10 +222,7 @@ def trim(
     trim_j_name = base_job_name
     trim_j_attrs = (job_attrs or {}) | dict(label=base_job_name, tool=trim_tool)
     trim_j = b.new_job(trim_j_name, trim_j_attrs)
-    # trim_j.image(image_path('fastp'))  # PRODUCTION
-    trim_j.image(
-        'australia-southeast1-docker.pkg.dev/cpg-common/images/fastp:0.23.4'
-    )  # DEV
+    trim_j.image(image_path('fastp'))
 
     # Set resource requirements
     res = STANDARD.set_resources(

--- a/cpg_workflows/jobs/trim.py
+++ b/cpg_workflows/jobs/trim.py
@@ -4,6 +4,7 @@ Trim raw FASTQ reads using cutadapt
 
 import hailtop.batch as hb
 from hailtop.batch.job import Job
+from hailtop.batch import ResourceFile, ResourceGroup
 from cpg_utils.hail_batch import command, image_path
 from cpg_utils.config import get_config
 from cpg_workflows.utils import can_reuse
@@ -21,11 +22,13 @@ from enum import Enum
 
 class MissingFastqInputException(Exception):
     """Raise if alignment input is missing"""
+
     pass
 
 
 class InvalidSequencingTypeException(Exception):
     """Raise if alignment type is not 'rna'"""
+
     pass
 
 
@@ -88,14 +91,20 @@ class Cutadapt:
             raise ValueError(f'Invalid adapter type: {adapter_type}')
         self.command = [
             'cutadapt',
-            '-o', str(output_fastq_pair.r1),
-            '-a', adapters.r1.sequence,
+            '-o',
+            str(output_fastq_pair.r1),
+            '-a',
+            adapters.r1.sequence,
         ]
         if paired:
-            self.command.extend([
-                '-p', str(output_fastq_pair.r2),
-                '-A', adapters.r2.sequence,
-            ])
+            self.command.extend(
+                [
+                    '-p',
+                    str(output_fastq_pair.r2),
+                    '-A',
+                    adapters.r2.sequence,
+                ]
+            )
         if quality_trim:
             if two_colour:
                 self.command.append(f'--nextseq-trim={quality_trim}')
@@ -111,7 +120,7 @@ class Cutadapt:
 
     def __str__(self) -> str:
         return ' '.join(self.command)
-    
+
     def __repr__(self) -> str:
         return str(self)
 
@@ -138,18 +147,28 @@ class Fastp:
             raise ValueError(f'Invalid adapter type: {adapter_type}')
         self.command = [
             'fastp',
-            '--in1', str(input_fastq_pair.r1),
-            '--out1', str(output_fastq_pair.r1),
-            '--length_required', str(min_length),
-            '--adapter_sequence', adapters.r1.sequence,
-            '--thread', str(nthreads),
+            '--in1',
+            str(input_fastq_pair.r1),
+            '--out1',
+            str(output_fastq_pair.r1),
+            '--length_required',
+            str(min_length),
+            '--adapter_sequence',
+            adapters.r1.sequence,
+            '--thread',
+            str(nthreads),
         ]
         if paired:
-            self.command.extend([
-                '--in2', str(input_fastq_pair.r2),
-                '--out2', str(output_fastq_pair.r2),
-                '--adapter_sequence_r2', adapters.r2.sequence,
-            ])
+            self.command.extend(
+                [
+                    '--in2',
+                    str(input_fastq_pair.r2),
+                    '--out2',
+                    str(output_fastq_pair.r2),
+                    '--adapter_sequence_r2',
+                    adapters.r2.sequence,
+                ]
+            )
         if not polyG:
             self.command.append('--disable_trim_poly_g')
         if polyX:
@@ -157,7 +176,7 @@ class Fastp:
 
     def __str__(self) -> str:
         return ' '.join(self.command)
-    
+
     def __repr__(self) -> str:
         return str(self)
 
@@ -171,61 +190,67 @@ def trim(
     extra_label: str | None = None,
     overwrite: bool = False,
     requested_nthreads: int | None = None,
-) -> Job:
+) -> Job | None:
     """
     Takes an input FastqPair object, and creates a job to trim the FASTQs using cutadapt.
     """
     # Don't run if all output files exist and can be reused
     if (
-        output_fq_pair and
-        can_reuse(output_fq_pair.r1, overwrite) and
-        can_reuse(output_fq_pair.r2, overwrite)
+        output_fq_pair
+        and can_reuse(output_fq_pair.r1, overwrite)
+        and can_reuse(output_fq_pair.r2, overwrite)
     ):
         return None
-    
+
     base_job_name = 'TrimFastqs'
     if extra_label:
         base_job_name += f' {extra_label}'
-    
+
     if not get_config()['workflow']['sequencing_type'] == 'transcriptome':
         raise InvalidSequencingTypeException(
-            f"Invalid sequencing type '{get_config()['workflow']['sequencing_type']}'" +
-            f" for job type '{base_job_name}'; sequencing type must be 'transcriptome'"
+            f"Invalid sequencing type '{get_config()['workflow']['sequencing_type']}'"
+            + f" for job type '{base_job_name}'; sequencing type must be 'transcriptome'"
         )
-    
+
     try:
         adapter_type = get_config()['trim']['adapter_type']
     except KeyError:
         raise ValueError('No adapter type specified in config file')
-    
+
     trim_tool = 'fastp'
 
     trim_j_name = base_job_name
     trim_j_attrs = (job_attrs or {}) | dict(label=base_job_name, tool=trim_tool)
     trim_j = b.new_job(trim_j_name, trim_j_attrs)
     # trim_j.image(image_path('fastp'))  # PRODUCTION
-    trim_j.image('australia-southeast1-docker.pkg.dev/cpg-common/images/fastp:0.23.4')  # DEV
-    
+    trim_j.image(
+        'australia-southeast1-docker.pkg.dev/cpg-common/images/fastp:0.23.4'
+    )  # DEV
+
     # Set resource requirements
-    requested_nthreads = requested_nthreads or 8
     res = STANDARD.set_resources(
         trim_j,
-        ncpu=requested_nthreads,
+        ncpu=8,
         storage_gb=50,  # TODO: make configurable
     )
 
     fastq_pair = input_fq_pair.as_resources(b)
 
+    trim_j.declare_resource_group(output_r1={'fastq.gz': '{root}.fastq.gz'})
+    trim_j.declare_resource_group(output_r2={'fastq.gz': '{root}.fastq.gz'})
+    assert isinstance(trim_j.output_r1, ResourceGroup)
+    assert isinstance(trim_j.output_r2, ResourceGroup)
+
     trim_cmd = Fastp(
         input_fastq_pair=fastq_pair,
         output_fastq_pair=FastqPair(
-            r1=trim_j.output_r1,
-            r2=trim_j.output_r2,
+            r1=trim_j.output_r1['fastq.gz'],
+            r2=trim_j.output_r2['fastq.gz'],
         ),
         adapter_type=adapter_type,
         paired=True,
         min_length=50,
-        nthreads=requested_nthreads,
+        nthreads=res.get_nthreads(),
         polyG=True,
         polyX=True,
     )
@@ -233,7 +258,7 @@ def trim(
 
     # Write output to file
     if output_fq_pair:
-        b.write_output(trim_j.output_r1, str(output_fq_pair.r1))
-        b.write_output(trim_j.output_r2, str(output_fq_pair.r2))
+        b.write_output(trim_j.output_r1['fastq.gz'], str(output_fq_pair.r1))
+        b.write_output(trim_j.output_r2['fastq.gz'], str(output_fq_pair.r2))
 
     return trim_j

--- a/cpg_workflows/stages/trim.py
+++ b/cpg_workflows/stages/trim.py
@@ -65,7 +65,7 @@ def get_input_output_pairs(sequencing_group: SequencingGroup) -> list[InOutFastq
     i = 1
     for pair in inputs:
         input_r1_bn = str(pair.r1.name).replace('.fastq.gz', '')
-        input_r2_bn = str(pair.r1.name).replace('.fastq.gz', '')
+        input_r2_bn = str(pair.r2.name).replace('.fastq.gz', '')
         output_r1 = prefix / f'{input_r1_bn}{trim_suffix}'
         output_r2 = prefix / f'{input_r2_bn}{trim_suffix}'
         input_output_pairs.append(InOutFastqPair(

--- a/cpg_workflows/stages/trim.py
+++ b/cpg_workflows/stages/trim.py
@@ -62,8 +62,7 @@ def get_input_output_pairs(sequencing_group: SequencingGroup) -> list[InOutFastq
     prefix = sequencing_group.dataset.tmp_prefix() / 'trim'
     trim_suffix = '.trimmed.fastq.gz'
     input_output_pairs = []
-    i = 1
-    for pair in inputs:
+    for i, pair in enumerate(inputs, 1):
         input_r1_bn = str(pair.r1.name).replace('.fastq.gz', '')
         input_r2_bn = str(pair.r2.name).replace('.fastq.gz', '')
         output_r1 = prefix / f'{input_r1_bn}{trim_suffix}'
@@ -73,7 +72,6 @@ def get_input_output_pairs(sequencing_group: SequencingGroup) -> list[InOutFastq
             pair,  # input FASTQ pair
             FastqPair(output_r1, output_r2),  # output FASTQ pair
         ))
-        i += 1
     return input_output_pairs
 
 

--- a/cpg_workflows/stages/trim.py
+++ b/cpg_workflows/stages/trim.py
@@ -30,9 +30,12 @@ def get_trim_inputs(sequencing_group: SequencingGroup) -> FastqPairs | None:
     sequencing_type = get_config()['workflow']['sequencing_type']
     alignment_input = sequencing_group.alignment_input_by_seq_type.get(sequencing_type)
     if (
-        not alignment_input or
-        (get_config()['workflow'].get('check_inputs', True) and not alignment_input.exists()) or
-        not isinstance(alignment_input, (FastqPair, FastqPairs))
+        not alignment_input
+        or (
+            get_config()['workflow'].get('check_inputs', True)
+            and not alignment_input.exists()
+        )
+        or not isinstance(alignment_input, (FastqPair, FastqPairs))
     ):
         return None
     if isinstance(alignment_input, FastqPair):
@@ -63,15 +66,19 @@ def get_input_output_pairs(sequencing_group: SequencingGroup) -> list[InOutFastq
     trim_suffix = '.trimmed.fastq.gz'
     input_output_pairs = []
     for i, pair in enumerate(inputs, 1):
+        assert isinstance(pair.r1, Path)
+        assert isinstance(pair.r2, Path)
         input_r1_bn = str(pair.r1.name).replace('.fastq.gz', '')
         input_r2_bn = str(pair.r2.name).replace('.fastq.gz', '')
         output_r1 = prefix / f'{input_r1_bn}{trim_suffix}'
         output_r2 = prefix / f'{input_r2_bn}{trim_suffix}'
-        input_output_pairs.append(InOutFastqPair(
-            str(i),  # ID
-            pair,  # input FASTQ pair
-            FastqPair(output_r1, output_r2),  # output FASTQ pair
-        ))
+        input_output_pairs.append(
+            InOutFastqPair(
+                str(i),  # ID
+                pair,  # input FASTQ pair
+                FastqPair(output_r1, output_r2),  # output FASTQ pair
+            )
+        )
     return input_output_pairs
 
 
@@ -86,10 +93,12 @@ def get_output_dict(sequencing_group: SequencingGroup) -> dict[str, Path]:
     for io_pair in input_output_pairs:
         r1_id = f'{io_pair.id}_R1'
         r2_id = f'{io_pair.id}_R2'
-        out_dict.update({
-            f'fastq_{r1_id}': io_pair.output_pair.r1,
-            f'fastq_{r2_id}': io_pair.output_pair.r2,
-        })
+        out_dict.update(
+            {
+                f'fastq_{r1_id}': io_pair.output_pair.r1,
+                f'fastq_{r2_id}': io_pair.output_pair.r2,
+            }
+        )
     return out_dict
 
 
@@ -105,7 +114,9 @@ class Trim(SequencingGroupStage):
         """
         return get_output_dict(sequencing_group)
 
-    def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
+    def queue_jobs(
+        self, sequencing_group: SequencingGroup, inputs: StageInput
+    ) -> StageOutput | None:
         """
         Queue a cutadapt job for each FASTQ file
         """
@@ -120,15 +131,19 @@ class Trim(SequencingGroupStage):
                     output_fq_pair=io_pair.output_pair,
                     job_attrs=self.get_job_attrs(sequencing_group),
                     overwrite=sequencing_group.forced,
-                    extra_label=f'fastq_pair_{io_pair.id}'
+                    extra_label=f'fastq_pair_{io_pair.id}',
                 )
                 if j:
                     jobs.append(j)
             except trim.MissingFastqInputException:
                 if get_config()['workflow'].get('skip_sgs_with_missing_input'):
-                    logging.error(f'No FASTQ inputs, skipping sample {sequencing_group}')
+                    logging.error(
+                        f'No FASTQ inputs, skipping sample {sequencing_group}'
+                    )
                     sequencing_group.active = False
-                    return self.make_outputs(sequencing_group, skipped=True)  # return empty output
+                    return self.make_outputs(
+                        sequencing_group, skipped=True
+                    )  # return empty output
                 else:
                     return self.make_outputs(
                         target=sequencing_group, error_msg=f'No FASTQ input found'

--- a/cpg_workflows/stages/trim.py
+++ b/cpg_workflows/stages/trim.py
@@ -59,13 +59,13 @@ def get_input_output_pairs(sequencing_group: SequencingGroup) -> list[InOutFastq
     inputs = get_trim_inputs(sequencing_group)
     if not inputs or not isinstance(inputs, FastqPairs):
         return []
-    prefix = sequencing_group.dataset.prefix() / 'trim'
+    prefix = sequencing_group.dataset.tmp_prefix() / 'trim'
     trim_suffix = '.trimmed.fastq.gz'
     input_output_pairs = []
     i = 1
     for pair in inputs:
-        input_r1_bn = re.sub(re.escape('.fastq.gz'), '', basename(pair.r1))
-        input_r2_bn = re.sub(re.escape('.fastq.gz'), '', basename(pair.r2))
+        input_r1_bn = str(pair.r1.name).replace('.fastq.gz', '')
+        input_r2_bn = str(pair.r1.name).replace('.fastq.gz', '')
         output_r1 = prefix / f'{input_r1_bn}{trim_suffix}'
         output_r2 = prefix / f'{input_r2_bn}{trim_suffix}'
         input_output_pairs.append(InOutFastqPair(
@@ -76,7 +76,7 @@ def get_input_output_pairs(sequencing_group: SequencingGroup) -> list[InOutFastq
         i += 1
     return input_output_pairs
 
-    
+
 def get_output_dict(sequencing_group: SequencingGroup) -> dict[str, Path]:
     """
     Return a flat dictionary of output files
@@ -106,7 +106,7 @@ class Trim(SequencingGroupStage):
         Expect a series of trimmed FASTQ files
         """
         return get_output_dict(sequencing_group)
-    
+
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
         """
         Queue a cutadapt job for each FASTQ file


### PR DESCRIPTION
This adds a few fixes to get the stage running successfully (eg [job](https://batch.hail.populationgenomics.org.au/batches/426223/jobs/1)). Costs about 8c per fastq to run ✅

- Fixes weird error when generating expected outputs that was causing the input fastq to be localised to the driver job (🤷‍♂️).
- Changes outputs to from ResourceFiles to ResourceGroups with a defined .gz suffix. Without this fastp was outputting unzipped fastqs.
-  Uses prod Fastp image that has now been deployed
- Changes output to tmp_prefix (deleted after 8 days) 
- Applied black formatting