### PR TITLE
Avoid hail 0.2.120, which breaks test/test_large_cohort.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'cpg-utils',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.41.2',
-        'hail',
+        'hail!=0.2.120',  # Temporarily work around hail-is/hail#13337
         'networkx',
         'metamist>=6.0.4',
         'pandas',


### PR DESCRIPTION
Downgrade to 0.2.119 to avoid apparent Hail bug causing #424.

Using `!=` means this will choose an upcoming 0.2.121 when that is released, at which point we can remove this (if the problem is fixed) or widen it (if the problem persists). The available version comparison operators are [documented here](https://peps.python.org/pep-0440/#version-specifiers).