### PR TITLE
SV Filtering Workflow corrections

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -377,7 +377,12 @@ class GeneratePloidyTable(CohortStage):
         return self.make_outputs(cohort, data=expected_d, jobs=py_job)
 
 
-@stage(required_stages=[GeneratePloidyTable,SVConcordance])
+@stage(
+    required_stages=[GeneratePloidyTable, SVConcordance],
+    analysis_type='sv',
+    analysis_keys=['filtered_vcf'],
+    update_analysis_meta=_sv_filtered_meta,
+)
 class FilterGenotypes(CohortStage):
     """
     Steps required to post-filter called genotypes


### PR DESCRIPTION
1. The PythonJob in the middle tries to access reference data in the wrong location
2. The job dependencies weren't quite right, so the required input files couldn't be accessed
3. The filteredGenotypes task wasn't registering outputs in metamist