### PR TITLE
Correction to grammatical discrepancy

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -277,7 +277,7 @@ class JoinRawCalls(CohortStage):
                 / f'clustered-{caller}.vcf.gz'
                 for batch_name in batch_names
             ]
-            input_dict[f'clustered_{caller}_vcf_indices'] = [
+            input_dict[f'clustered_{caller}_vcf_indexes'] = [
                 batch_prefix
                 / batch_name
                 / 'ClusterBatch'


### PR DESCRIPTION
One of the stages requires a number of index files to be supplied.

I supplied this as 
`f'clustered_{caller}_vcf_indices'`

The WDL expected this as 
`f'clustered_{caller}_vcf_indexes'`

This change corrects the argument name to conform with the WDL expectation.

<img width="298" alt="Screenshot 2023-08-18 at 11 59 22 am" src="https://github.com/populationgenomics/production-pipelines/assets/5886855/65f521c0-009b-42ec-b9e4-b44841c9845a">