### PR TITLE
Copy GATK-SV nightly image

### DIFF
--- a/scripts/copy_gatk_sv_nightly.sh
+++ b/scripts/copy_gatk_sv_nightly.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+skopeo copy docker://us.gcr.io/broad-dsde-methods/markw/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT docker://australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT


### PR DESCRIPTION
Adds a quick Skopeo copy script to bring in a specific nightly build used in the Broad GATK-SV pipeline