### PR TITLE
Correction to concordance output, latest docker images

### DIFF
--- a/configs/gatk_sv/use_for_all_workflows.toml
+++ b/configs/gatk_sv/use_for_all_workflows.toml
@@ -1,43 +1,33 @@
 [images]
 
-# built by the GATk-SV repo
-cnmops_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/cnmops:v0.27.0"
-cnmops_virtual_env = "australia-southeast1-docker.pkg.dev/cpg-common/images/cnmops-virtual-env:v0.27.0"
-samtools_cloud_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/samtools-cloud:v0.27.0"
-samtools_cloud_virtual_env = "australia-southeast1-docker.pkg.dev/cpg-common/images/samtools-cloud-virtual-env:v0.27.0"
-str = "australia-southeast1-docker.pkg.dev/cpg-common/images/str:v0.28.1"
-sv-pipeline-virtual-env = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline-virtual-env:v0.28.1"
-sv_base = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-base:v0.27.0"
-sv_base_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-base:v0.27.0"
-sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-base-mini:v0.27.0"
-sv_base_virtual_env = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-base-virtual-env:v0.27.0"
-sv_pipeline_base_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline:v0.28.1"
-sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline:v0.28.1"
-sv_pipeline_hail_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline:v0.28.1"
-sv_pipeline_qc_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline:v0.28.1"
-sv_pipeline_rdtest_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline:v0.28.1"
-sv_pipeline_updates_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline:v0.28.1"
-sv_pipeline_virtual_env = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-pipeline-virtual-env:v0.28.1"
-sv_utils = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-utils:v0.27.0"
-sv_utils_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-utils:v0.28.1"
-sv_utils_env = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv-utils-env:v0.27.0"
-wham_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/wham:v0.28.1"
-
-# external (not built by the gatk-sv repo)
+# cloned over from the GATK-SV config values
 cloud_sdk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/cloud-sdk"
+cnmops_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/cnmops:2023-07-28-v0.28.1-beta-e70dfbd7"
 condense_counts_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432"
 duphold_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/duphold:mw-xz-fixes-2-b1be6a9"
-gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432"
-gatk_docker_concordance = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:mw-sv-concordance-937c81"
+gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
 gatk_docker_pesr_override = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432"
 genomes_in_the_cloud_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/genomes-in-the-cloud:2.3.2-1510681135"
-gq_recalibrator_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:0a7e1d86f"
+gq_recalibrator_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:mw-tb-form-sv-filter-training-data-899360a"
 igv_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/igv:mw-xz-fixes-2-b1be6a9"
 manta_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/manta:5994670"
 pangenie_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/pangenie:vj-127571f"
+samtools_cloud_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/samtools-cloud:2023-07-28-v0.28.1-beta-e70dfbd7"
 scramble_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/scramble:1.0.2"
-vapor_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/vapor:header-hash-2fc8f12"
+str = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/str:2023-05-23-v0.27.3-beta-e537bdd6"
+sv-utils-env = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-utils-env:2023-02-01-v0.26.8-beta-9b25c72d"
+sv_base_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base:2023-07-28-v0.28.1-beta-e70dfbd7"
+sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
+sv_pipeline_base_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_pipeline_hail_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_pipeline_qc_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_pipeline_rdtest_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_pipeline_updates_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_utils_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-utils:2023-08-04-v0.28.1-beta-4959f62e"
+wham_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/wham:2023-07-28-v0.28.1-beta-e70dfbd7"
 linux_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/ubuntu1804"
+vapor_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/vapor:header-hash-2fc8f12"
 
 [sv_ref_panel]
 ref_panel_samples = ['HG00096', 'HG00129', 'HG00140', 'HG00150', 'HG00187', 'HG00239', 'HG00277', 'HG00288', 'HG00337', 'HG00349', 'HG00375', 'HG00410', 'HG00457', 'HG00557', 'HG00599', 'HG00625', 'HG00701', 'HG00740', 'HG00844', 'HG01060', 'HG01085', 'HG01112', 'HG01275', 'HG01325', 'HG01344', 'HG01356', 'HG01384', 'HG01393', 'HG01396', 'HG01474', 'HG01507', 'HG01572', 'HG01607', 'HG01709', 'HG01747', 'HG01790', 'HG01794', 'HG01799', 'HG01861', 'HG01874', 'HG01880', 'HG01885', 'HG01958', 'HG01982', 'HG02002', 'HG02010', 'HG02019', 'HG02020', 'HG02069', 'HG02085', 'HG02186', 'HG02221', 'HG02235', 'HG02272', 'HG02275', 'HG02299', 'HG02332', 'HG02367', 'HG02374', 'HG02489', 'HG02490', 'HG02491', 'HG02586', 'HG02588', 'HG02611', 'HG02620', 'HG02642', 'HG02648', 'HG02658', 'HG02855', 'HG02953', 'HG03007', 'HG03009', 'HG03085', 'HG03099', 'HG03100', 'HG03111', 'HG03369', 'HG03370', 'HG03436', 'HG03449', 'HG03472', 'HG03476', 'HG03556', 'HG03604', 'HG03649', 'HG03684', 'HG03694', 'HG03709', 'HG03722', 'HG03727', 'HG03744', 'HG03756', 'HG03789', 'HG03850', 'HG03864', 'HG03872', 'HG03888', 'HG04118', 'HG04158', 'HG04161', 'HG04183', 'NA06984', 'NA10847', 'NA11894', 'NA12340', 'NA12489', 'NA12872', 'NA18499', 'NA18507', 'NA18530', 'NA18539', 'NA18549', 'NA18553', 'NA18560', 'NA18638', 'NA18923', 'NA18941', 'NA18945', 'NA18956', 'NA18995', 'NA19001', 'NA19035', 'NA19062', 'NA19102', 'NA19143', 'NA19184', 'NA19350', 'NA19351', 'NA19377', 'NA19443', 'NA19449', 'NA19661', 'NA19678', 'NA19679', 'NA19684', 'NA19746', 'NA19795', 'NA19818', 'NA19913', 'NA20126', 'NA20320', 'NA20321', 'NA20346', 'NA20509', 'NA20510', 'NA20522', 'NA20752', 'NA20764', 'NA20802', 'NA20845', 'NA20869', 'NA20895', 'NA21102', 'NA21122', 'NA21133']
@@ -46,5 +36,5 @@ model_tar_cnt = 285
 [workflow]
 status_reporter = 'metamist'
 # un-comment these to force stages to repeat
-check_intermediates = false
-check_expected_outputs = false
+#check_intermediates = false
+#check_expected_outputs = false

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -307,19 +307,13 @@ class SVConcordance(CohortStage):
         """
 
         return {
-            'gatk_formatted_vcf': self.prefix / 'gatk_formatted.vcf.gz',
-            'gatk_formatted_vcf_index': self.prefix / 'gatk_formatted.vcf.gz.tbi',
+            'concordance_vcf': self.prefix / 'sv_concordance.vcf.gz',
+            'concordance_vcf_index': self.prefix / 'sv_concordance.vcf.gz.tbi',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
         """
-
-        Args:
-            cohort ():
-            inputs ():
-
-        Returns:
-
+        configure and queue jobs for SV concordance
         """
         raw_calls = inputs.as_dict(cohort, JoinRawCalls)
         format_vcf = inputs.as_dict(cohort, FormatVcfForGatk)


### PR DESCRIPTION
Latest run [here](https://batch.hail.populationgenomics.org.au/batches/427281) failed

Reason: I made a copy-paste error when writing the new Stages, the expected output didn't have the correct name

Additional: Updates the committed config file to use the latest sync'd GATK images. The previous version of this config file contains docker images which are out of date (i.e. execution of the latest WDLs with those images will cause runtime failures). I've been using this latest edited TOML version during the latest GATK-SV run, but without being committed I'm worried it might vanish. Docker images to use based on [this](https://batch.hail.populationgenomics.org.au/batches/427117/jobs/1) GATK image sync script execution.