### PR TITLE
Ref panel PED location moved

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -228,10 +228,11 @@ def make_combined_ped(cohort: Cohort, prefix: Path) -> Path:
     Concatenating all samples across all datasets with ref panel
     """
     combined_ped_path = prefix / 'ped_with_ref_panel.ped'
+    conf_ped_path = get_references(['ped_file'])['ped_file']
     with combined_ped_path.open('w') as out:
         with cohort.write_ped_file().open() as f:
             out.write(f.read())
         # The ref panel PED doesn't have any header, so can safely concatenate:
-        with reference_path('gatk_sv/ped_file').open() as f:
+        with to_path(conf_ped_path).open() as f:
             out.write(f.read())
     return combined_ped_path


### PR DESCRIPTION
I did a bit of work last week to add some new elements to our config/references repo [here](https://github.com/populationgenomics/references/pull/31) - this realigned a bunch of content between the `references.gatk_sv` and `references.broad` parts of the config file so as to accurately represent where that data is now available in the Broad's public buckets (i.e. should we wish to make new copies of this data, we would be able to. The previous state would have resulted in mass failure due to incorrect source paths).

A method call during the reference Pedigree generation is the only place in the GATK-SV process* where we explicitly search only one of these parts of the config file. Access is usually deferred to [this method](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gatk_sv/gatk_sv_common.py#L89) which searches both possible locations, and returns the first match.

This change corrects this behaviour so that the PED gathering step also uses the permissive config checking wrapper

*that I've found so far