### PR TITLE
Switch off the filtering workflow

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -476,8 +476,8 @@ class AnnotateVcf(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict:
         return {
-            'output_vcf': self.prefix / 'unfiltered_annotated.vcf.gz',
-            'output_vcf_idx': self.prefix / 'unfiltered_annotated.vcf.gz.tbi',
+            'output_vcf': self.prefix / 'unfiltered_annotated.vcf.bgz',
+            'output_vcf_idx': self.prefix / 'unfiltered_annotated.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:


### PR DESCRIPTION
Closes #452 

FilterGenotypes is not currently viable, so skip over those stages. This re-introduces the direct AnnotateVcf -> MakeCohortVcf sequence. 

The VCF output from AnnotateVcf is renamed `annotated.vcf.gz` ->  `unfiltered_annotated.vcf.bgz`

- `bgz` extension to gel neatly with the coming Hail Stages (file is Block GZipped, but Hail cares a lot about names)
- `unfiltered` to force the stage to repeat and to differentiate from when we hopefully get the filtering workflow in