### PR TITLE
AnnotateVcf without Hail

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -497,6 +497,7 @@ class AnnotateVcf(CohortStage):
             'ref_prefix': get_config()['references']['gatk_sv'].get(
                 'external_af_ref_bed_prefix'
             ),
+            'use_hail': False
         }
 
         input_dict |= get_references(


### PR DESCRIPTION
Since the last time this was run successfully, the annotation process supports both Hail and non-Hail merging workflows. I'll add an issue to the board to consider whether the Hail version is right for us.

Adds `use_hail=False` for now, mirroring the default setting in the GATK-SV repository.