### PR TITLE
Remove absent output

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -405,7 +405,7 @@ class FilterGenotypes(CohortStage):
             / 'unfiltered_recalibrated.vcf.gz',
             'unfiltered_recalibrated_vcf_index': self.prefix
             / 'unfiltered_recalibrated.vcf.gz.tbi',
-            'vcf_optimization_table': self.prefix / 'vcf_optimization_table.tsv.gz',
+            # 'vcf_optimization_table': self.prefix / 'vcf_optimization_table.tsv.gz',
             'sl_cutoff_qc_tarball': self.prefix / 'sl_cutoff_SV_VCF_QC_output.tar.gz',
         }
 


### PR DESCRIPTION
The WDL for FilterGenotypes contains an un-implemented input, which would cause a table to be created.
https://github.com/broadinstitute/gatk-sv/blob/main/wdl/FilterGenotypes.wdl#L22
It's not implemented, so don't expect it as an output