### PR TITLE
Bump version: 1.15.3 → 1.16.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.15.3
+current_version = 1.16.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ on:
         default: "test"
 
 env:
-  VERSION: 1.15.3
+  VERSION: 1.16.0
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.15.3',
+    version='1.16.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
TL; DR, I've failed to add bump2version commits to a couple of recent changes on main. This has lead to the `cpg_workflows` version in main and in PyPi becoming out of step. This has caused a recent pipeline failure.

Breakdown:
[Main Pipeline Run](https://batch.hail.populationgenomics.org.au/batches/427930)
[Failing MtToEs Run](https://batch.hail.populationgenomics.org.au/batches/427940)

Issue:
- I moved a method from MtToEs -> AnnotateCohort, so that MtToEs would be generalisable to both small variants and SVs
- I failed to bump the version in cpg-workflows so the version in PyPi doesn't include those changes
- When running AnnotateCohort and MtToEs (both stages use Dataproc), AnnotateCohort uses the version from PyPi, MtToEs uses the version from main
- This causes a failure as the method required for Seqr loading is absent from both locations in that configuration

Details:
The difference between the two dataproc startups is the use of pyfiles
[MtToEs](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/seqr_loader.py#L287)
[AnnotateCohort](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/jobs/seqr_loader.py#L45)

- I messed up by moving the rg37_locus/InbreedingCoeff method but not issuing a new production-pipelines/cpg_workflows version number. That means that the version of cpg-workflows in pypi is a few commits behind what we have in main. 
- The job that starts a Dataproc cluster and submits a job to it runs using the dataproc image, with an init script that installs cpg-workflows (due to the missed version tag, this is the PyPi version a few commits behind main)
- The submit to dataproc runs in this image, so the use of pyfiles takes the cpg_workflows code that is installed by pip but not current, and makes that available in the dataproc instance.
- This means that AnnotateCohort is using non-current code
- MtToEs is not passed cpg_workflows pyfiles, so it uses the latest version of the code on main (as copied in using prepare_git_job)