### PR TITLE
Update SNV es-index analysis meta with seqr data type

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -112,9 +112,7 @@ def annotate_cohort(
     rg37 = hl.get_reference('GRCh37')
     rg38 = hl.get_reference('GRCh38')
     rg38.add_liftover(str(liftover_path), rg37)
-    mt = mt.annotate_rows(
-        rg37_locus=hl.liftover(mt.locus, 'GRCh37')
-    )
+    mt = mt.annotate_rows(rg37_locus=hl.liftover(mt.locus, 'GRCh37'))
 
     # only remove if present
     if 'InbreedingCoeff' in mt.info:
@@ -169,6 +167,9 @@ def annotate_cohort(
         sourceFilePath=vcf_path,
         genomeVersion=genome_build().replace('GRCh', ''),
         hail_version=hl.version(),
+        # Broad seqr uses a new datasetType string for SNV index https://github.com/broadinstitute/seqr/blob/master/seqr/models.py#L642
+        # populationgenomics seqr fork still uses the original datasetType string 'VARIANTS' ~ EddieLF 2023-10-23
+        datasetType='VARIANTS',
     )
     if sequencing_type := get_config()['workflow'].get('sequencing_type'):
         # Map to Seqr-style string

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -112,7 +112,9 @@ def annotate_cohort(
     rg37 = hl.get_reference('GRCh37')
     rg38 = hl.get_reference('GRCh38')
     rg38.add_liftover(str(liftover_path), rg37)
-    mt = mt.annotate_rows(rg37_locus=hl.liftover(mt.locus, 'GRCh37'))
+    mt = mt.annotate_rows(
+        rg37_locus=hl.liftover(mt.locus, 'GRCh37')
+    )
 
     # only remove if present
     if 'InbreedingCoeff' in mt.info:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -169,9 +169,6 @@ def annotate_cohort(
         sourceFilePath=vcf_path,
         genomeVersion=genome_build().replace('GRCh', ''),
         hail_version=hl.version(),
-        # Broad seqr uses a new datasetType string for SNV index https://github.com/broadinstitute/seqr/blob/master/seqr/models.py#L642
-        # populationgenomics seqr fork still uses the original datasetType string 'VARIANTS' ~ EddieLF 2023-10-23
-        datasetType='VARIANTS',
     )
     if sequencing_type := get_config()['workflow'].get('sequencing_type'):
         # Map to Seqr-style string

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -654,7 +654,7 @@ def _gatk_sv_index_meta(
     Add meta.type to custom analysis object
     https://github.com/populationgenomics/metamist/issues/539
     """
-    return {'seqr-data-type': 'gatk-sv'}
+    return {'seqr-dataset-type': 'SV'}
 
 
 @stage(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -654,7 +654,7 @@ def _gatk_sv_index_meta(
     Add meta.type to custom analysis object
     https://github.com/populationgenomics/metamist/issues/539
     """
-    return {'type': 'gatk-sv-index', 'seqr-data-type': 'gatk-sv'}
+    return {'seqr-data-type': 'gatk-sv'}
 
 
 @stage(

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -119,7 +119,7 @@ def _snv_es_index_meta(
     Add meta.type to es-index analysis object
     https://github.com/populationgenomics/metamist/issues/539
     """
-    return {'type': 'snv-es-index', 'seqr-data-type': 'snv'}
+    return {'seqr-data-type': 'snv'}
 
 
 @stage(

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -119,7 +119,7 @@ def _snv_es_index_meta(
     Add meta.type to es-index analysis object
     https://github.com/populationgenomics/metamist/issues/539
     """
-    return {'seqr-data-type': 'snv'}
+    return {'seqr-dataset-type': 'VARIANTS'}
 
 
 @stage(

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -112,6 +112,16 @@ def _sg_vcf_meta(
     return {'type': 'dataset-vcf'}
 
 
+def _snv_es_index_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, Any]:
+    """
+    Add meta.type to es-index analysis object
+    https://github.com/populationgenomics/metamist/issues/539
+    """
+    return {'type': 'snv-es-index', 'seqr-data-type': 'snv'}
+
+
 @stage(
     required_stages=[AnnotateCohort],
     analysis_type='custom',
@@ -232,6 +242,7 @@ def es_password() -> str:
     required_stages=[AnnotateDataset],
     analysis_type='es-index',
     analysis_keys=['index_name'],
+    update_analysis_meta=_snv_es_index_meta,
 )
 class MtToEs(DatasetStage):
     """


### PR DESCRIPTION
A small change to add the `seqr-data-type` field to the es-index `meta` for SNV indexes. Relates to https://github.com/populationgenomics/metamist/issues/539. 