### PR TITLE
Pass specific dataset ID for the checkpoints

### DIFF
--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -231,6 +231,7 @@ class RunHailFiltering(DatasetStage):
             f'--panelapp "{panelapp_json}" '
             f'--pedigree "{local_ped}" '
             f'--vcf_out "{str(expected_out["labelled_vcf"])}" '
+            f'--dataset {dataset.name} '
         )
 
         return self.make_outputs(dataset, data=expected_out, jobs=job)


### PR DESCRIPTION
Complement to https://github.com/populationgenomics/automated-interpretation-pipeline/pull/326
We need to pass a specific dataset into this module to prevent checkpoints being made in `cpg-seqr-main-tmp`