### PR TITLE
AIP tweaks, Stage wrapper arg to allow-missing outputs

### DIFF
--- a/configs/defaults/aip.toml
+++ b/configs/defaults/aip.toml
@@ -35,7 +35,7 @@ gnomad_max_hemi = 1
 
 [csq]
 # variables affecting how the VCF variants are parsed, and AnalysisVariant objects are populated
-csq_string = ['allele', 'consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'amino_acids', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen']
+csq_string = ['allele', 'consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'amino_acids', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
 
 [filter]
 # variables for the hail operations, including CSQ sets and filter thresholds
@@ -59,6 +59,7 @@ spliceai = 0.5
 3 = 'High Impact Variant'
 4 = 'de Novo'
 5 = 'High SpliceAI Score'
+6 = 'AlphaMissense P/LP'
 pm5 = 'ACMG PM5 - missense in same residue as known pathogenic'
 support = 'High in Silico Scores'
 

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -401,6 +401,7 @@ class Stage(Generic[TargetT], ABC):
         analysis_type: str | None = None,
         analysis_keys: list[str] | None = None,
         update_analysis_meta: Callable[[str], dict] | None = None,
+        tolerate_missing_output: bool = False,
         skipped: bool = False,
         assume_outputs_exist: bool = False,
         forced: bool = False,
@@ -426,6 +427,8 @@ class Stage(Generic[TargetT], ABC):
         # if `update_analysis_meta` is defined, it is called on the `Analysis.output`
         # field, and result is merged into the `Analysis.meta` dictionary.
         self.update_analysis_meta = update_analysis_meta
+
+        self.tolerate_missing_output = tolerate_missing_output
 
         # Populated with the return value of `add_to_the_workflow()`
         self.output_by_target: dict[str, StageOutput | None] = dict()
@@ -621,6 +624,7 @@ class Stage(Generic[TargetT], ABC):
                     meta=outputs.meta,
                     job_attrs=self.get_job_attrs(target),
                     update_analysis_meta=self.update_analysis_meta,
+                    tolerate_missing_output=self.tolerate_missing_output,
                     project_name=project_name,
                 )
 
@@ -775,6 +779,7 @@ def stage(
     analysis_type: str | None = None,
     analysis_keys: list[str | Path] | None = None,
     update_analysis_meta: Callable[[str], dict] | None = None,
+    tolerate_missing_output: bool = False,
     required_stages: list[StageDecorator] | StageDecorator | None = None,
     skipped: bool = False,
     assume_outputs_exist: bool = False,
@@ -798,6 +803,8 @@ def stage(
         if the Stage.expected_outputs() returns a dict.
     @update_analysis_meta: if defined, this function is called on the `Analysis.output`
         field, and returns a dictionary to be merged into the `Analysis.meta`
+    @tolerate_missing_output: if True, when registering the output of this stage,
+        allow for the output file to be missing (only relevant for metamist entry)
     @required_stages: list of other stage classes that are required prerequisites
         for this stage. Outputs of those stages will be passed to
         `Stage.queue_jobs(... , inputs)` as `inputs`, and all required


### PR DESCRIPTION
Tweak to the AIP default config to include the new category (see https://github.com/populationgenomics/automated-interpretation-pipeline/pull/327)

Secondary item, up for discussion:

- AIP reports come in 2 flavours: **all variants**, and **new variants in this run only**
- It's possible for a run to discover 0 new variants. If this situation occurs, no 'latest' output is generated, causing failures [here](https://batch.hail.populationgenomics.org.au/batches/429252/jobs/11)
- AIP reports are aggregated into an index (http://popgen.rocks/aip_index) which is done by pulling from the analysis entries, so we need to keep registering all outputs which exist.

Situation:
We want to register outputs in metamist, but we are aware that not all outputs may be created. 

I've stuck a new attribute in the @stage wrapper - `tolerate_missing_output`. This cascades down to the metamist status updater, and if the output file doesn't exist, instead of updating its attributes & checking object size, the method called should silently quit. 

Q. Is this a rational thing to be doing?
Q2. Is this the best way to accomplish this change?
Q3. Should the `in-progress` analysis entry for an output that doesn't exist be deleted instead of left hanging
Q4. **BIG Q** What do we accomplish by registering an analysis output as pending or in progress - surely metamist should only care about extant analysis outputs, not just potential ones (e.g. analysis object created, but the run fails... we'll just have ghost entries in metamist)