### PR TITLE
Set dragmap threads to nthreads -1

### DIFF
--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -469,10 +469,13 @@ def _align_one(
             input_params = f'--interleaved=1 -b {r1_param}'
         else:
             input_params = f'-1 {r1_param} -2 {r2_param}'
+        # TODO: consider reverting to use of all threads if node capacity
+        # issue is resolved: https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/Job.20becomes.20unresponsive
         cmd = f"""\
         {prepare_fastq_cmd}
         dragen-os -r {dragmap_index} {input_params} \\
-            --RGID {sequencing_group_name} --RGSM {sequencing_group_name}
+            --RGID {sequencing_group_name} --RGSM {sequencing_group_name} \\
+            --num-threads {nthreads - 1}
         """
 
     else:

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -397,7 +397,7 @@ class TestDragmap:
         )
 
         cmd = get_command_str(align_jobs[0])
-        assert re.search(pattern, cmd)
+        assert re.search(pattern, cmd, flags=re.DOTALL)
 
     def test_dragmap_aligner_reads_dragmap_reference_resource(
         self, mocker: MockFixture, tmp_path: Path

--- a/test/jobs/test_align/test_fastq.py
+++ b/test/jobs/test_align/test_fastq.py
@@ -119,7 +119,7 @@ class TestDragmap:
             r'dragen-os -r \${BATCH_TMPDIR}/inputs/\w+'
             r' -1 \$BATCH_TMPDIR/R1\.fq\.gz -2 \$BATCH_TMPDIR/R2\.fq\.gz'
             fr'.*--RGID {sg.id} --RGSM {sg.id}'
-            r' \| samtools sort .* -Obam -o \${BATCH_TMPDIR}/.*/sorted_bam'
+            r'.* \| samtools sort .* -Obam -o \${BATCH_TMPDIR}/.*/sorted_bam'
         )
 
         for job in align_jobs:


### PR DESCRIPTION
Background: [here](https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/Job.20becomes.20unresponsive) and [here](https://centrepopgen.slack.com/archives/C030X7WGFCL/p1698189973862839)

Short-term fix for batch resource over allocation issue. Sets command argument so dragmap uses one thread less than requested for the job. 