### PR TITLE
Further reduce dragmap threads

### DIFF
--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -475,7 +475,7 @@ def _align_one(
         {prepare_fastq_cmd}
         dragen-os -r {dragmap_index} {input_params} \\
             --RGID {sequencing_group_name} --RGSM {sequencing_group_name} \\
-            --num-threads {nthreads - 1}
+            --num-threads {nthreads - 3}
         """
 
     else:


### PR DESCRIPTION
Follows #494.

n_threads on a 16 core machine == 32. Reducing this to 31 did not alter CPU load and alignment jobs still failed after ~ an hour. This reduces the request to n_threads -3 == ~31~ 29 threads, hopefully enough to give some head room.