### PR TITLE
Set thread count to core count

### DIFF
--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -475,7 +475,7 @@ def _align_one(
         {prepare_fastq_cmd}
         dragen-os -r {dragmap_index} {input_params} \\
             --RGID {sequencing_group_name} --RGSM {sequencing_group_name} \\
-            --num-threads {nthreads - 3}
+            --num-threads {nthreads - 1}
         """
 
     else:

--- a/cpg_workflows/resources.py
+++ b/cpg_workflows/resources.py
@@ -29,7 +29,7 @@ class MachineType:
     """
 
     min_cpu: int = 2
-    threads_on_cpu = 2  # hyper-threading
+    threads_on_cpu = 1  # GCP does not have hyper-threading
 
     def __init__(
         self,

--- a/cpg_workflows/resources.py
+++ b/cpg_workflows/resources.py
@@ -29,7 +29,9 @@ class MachineType:
     """
 
     min_cpu: int = 2
-    threads_on_cpu = 1  # GCP does not have hyper-threading
+    # GCP supports one active thread per vCPU.
+    # See https://cloud.google.com/compute/docs/instances/set-threads-per-core
+    threads_on_cpu = 1
 
     def __init__(
         self,


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1698721857838289

Production pipelines currently assumes that hyper-threading is enabled on workers so the number of compute threads should equal double core count. However, [on GCP](https://cloud.google.com/compute/docs/instances/set-threads-per-core) Compute Engine, each virtual CPU (vCPU) is implemented as a single hardware multithread, and two vCPUs share each physical CPU core by default.

This PR sets the thread count per CPU to 1 It also reverts a previous change to the dragmap command so that it will set the number of worker threads to one less than the core count.

