### PR TITLE
Typo correction in GATK-SV

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -234,13 +234,6 @@ def annotate_cohort_sv(
             }.get(sequencing_type, ''),
         )
 
-    # github.com/broadinstitute/seqr-loading-pipelines..luigi_pipeline/lib/hail_tasks.py#L212
-    mt = mt.annotate_rows(
-        gt_stats=hl.agg.call_stats(mt.GT, mt.alleles),
-        aIndex=mt.a_index,
-        wasSplit=mt.was_split,
-    )
-
     # reimplementation of
     # github.com/populationgenomics/seqr-loading-pipelines..luigi_pipeline/lib/model/sv_mt_schema.py
     mt = mt.annotate_rows(


### PR DESCRIPTION
https://github.com/broadinstitute/seqr-loading-pipelines/blob/d336b00143f531734a0769b3a5b26666ee1fd981/luigi_pipeline/seqr_sv_loading.py#L40

key input VCF by rsid (unique per-variant ID within this callset)

correction of syType -> svType (🙄)

reorders some fields to match the order they're applied in seqr-loading-pipelines