### PR TITLE
Omit samples field for GATKSV callsets

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -438,7 +438,11 @@ def annotate_dataset_sv(mt_path: str, out_mt_path: str):
     # github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/lib/model/sv_mt_schema.py#L221
     # github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/lib/model/seqr_mt_schema.py#L251
     mt = mt.annotate_rows(
-        samples=_genotype_filter_samples(lambda g: True),
+
+        # omit samples field for GATKSV callsets. Leaving this here as likely needed
+        # for gCNV specific callsets (maybe)
+        # samples=_genotype_filter_samples(lambda g: True),
+
         samples_new_alt=_genotype_filter_samples(
             lambda g: g.new_call | hl.is_defined(g.prev_num_alt)
         ),


### PR DESCRIPTION
Final gatk sv mt currently contains a `samples` field that lists all samples in the call set. This results in variants always being returned in seqr searches reguardless of genotype filter settings.  Removing the field should result in proper search results being returned.