### PR TITLE
Omit samples_cn field from gatksv final MT

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -461,13 +461,17 @@ def annotate_dataset_sv(mt_path: str, out_mt_path: str):
                 for i in range(0, 90, 10)
             }
         ),
-        samples_cn=hl.struct(
-            **{
-                f'{i}': _genotype_filter_samples(_filter_sample_cn(i))
-                for i in range(0, 4, 1)
-            },
-            gte_4=_genotype_filter_samples(lambda g: g.cn >= 4),
-        ),
+
+        # As per `samples` field, I beleive CN stats should only be generated for gCNV only
+        # callsets. In particular samples_cn_2 is used to select ALT_ALT variants,
+        # presumably because this genotype is only asigned when this CN is alt (ie on chrX)
+        # samples_cn=hl.struct(
+        #     **{
+        #         f'{i}': _genotype_filter_samples(_filter_sample_cn(i))
+        #         for i in range(0, 4, 1)
+        #     },
+        #     gte_4=_genotype_filter_samples(lambda g: g.cn >= 4),
+        # ),
     )
 
     logging.info('Genotype fields annotated')


### PR DESCRIPTION
As per https://github.com/populationgenomics/production-pipelines/pull/506

samples_cn fields appear to be gCNV callset specific and have a non-intuative effect due to the nature of gCNV callsets. For example the samples_cn_2 field is  used to select ALT_ALT variants, presumably because this genotype is only asigned in a gCNV callset when this CN is alt (ie on chrX).

PR #506 resolved most seqr genotype query issues with SV call sets. This PR should resove the remaining problem causing default recessive filters to return all ref/ref calls.