### PR TITLE
Script to find SGs needing SV calling

### DIFF
--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -48,7 +48,7 @@ def annotate_dataset_jobs_sv(
     out_mt_path: Path,
     tmp_prefix: Path,
     job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None,
+    depends_on: list[Job] | None = None
 ) -> list[Job]:
     """
     Split mt by dataset and annotate dataset-specific fields (only for those datasets

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -171,12 +171,19 @@ class GatherBatchEvidence(CohortStage):
         )
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -252,12 +259,19 @@ class ClusterBatch(CohortStage):
         )
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -323,12 +337,19 @@ class GenerateBatchMetrics(CohortStage):
         )
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -411,12 +432,19 @@ class FilterBatch(CohortStage):
         )
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -476,12 +504,19 @@ class MergeBatchSites(CohortStage):
         }
         input_dict |= get_images(['sv_pipeline_docker'])
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -580,11 +615,18 @@ class GenotypeBatch(CohortStage):
         # - sr_median_hom_ins
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -192,12 +192,19 @@ class MakeCohortVcf(CohortStage):
             ]
         )
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -234,12 +241,19 @@ class FormatVcfForGatk(CohortStage):
         input_dict |= get_references([{'contig_list': 'primary_contigs_list'}])
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -295,12 +309,19 @@ class JoinRawCalls(CohortStage):
                 for batch_name in batch_names
             ]
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -338,12 +359,19 @@ class SVConcordance(CohortStage):
         input_dict |= get_references([{'contig_list': 'primary_contigs_list'}])
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -449,12 +477,19 @@ class FilterGenotypes(CohortStage):
         )
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -528,12 +563,19 @@ class AnnotateVcf(CohortStage):
             ['sv_pipeline_docker', 'sv_base_mini_docker', 'gatk_docker']
         )
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -566,6 +608,11 @@ class AnnotateCohortSv(CohortStage):
         checkpoint_prefix = (
             to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
         )
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
 
         job = annotate_cohort_jobs_sv(
             b=get_batch(),
@@ -631,6 +678,11 @@ class AnnotateDatasetSv(DatasetStage):
         checkpoint_prefix = (
             to_path(self.expected_outputs(dataset)['tmp_prefix']) / 'checkpoints'
         )
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
 
         jobs = annotate_dataset_jobs_sv(
             b=get_batch(),

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -609,11 +609,6 @@ class AnnotateCohortSv(CohortStage):
             to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
         )
 
-        billing_labels = {
-            'stage': self.name.lower(),
-            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
-        }
-
         job = annotate_cohort_jobs_sv(
             b=get_batch(),
             vcf_path=vcf_path,
@@ -678,11 +673,6 @@ class AnnotateDatasetSv(DatasetStage):
         checkpoint_prefix = (
             to_path(self.expected_outputs(dataset)['tmp_prefix']) / 'checkpoints'
         )
-
-        billing_labels = {
-            'stage': self.name.lower(),
-            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
-        }
 
         jobs = annotate_dataset_jobs_sv(
             b=get_batch(),

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -142,7 +142,7 @@ class GatherSampleEvidence(SequencingGroupStage):
         # these must conform to the regex [a-z]([-a-z0-9]*[a-z0-9])?
         billing_labels = {
             'dataset': sequencing_group.dataset.name, # already lowercase
-            'sequencing_group': sequencing_group.id.lower(), # cpg123123
+            'sequencing-group': sequencing_group.id.lower(), # cpg123123
             'stage': self.name.lower(),
             'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
         }
@@ -213,12 +213,19 @@ class EvidenceQC(CohortStage):
         input_dict |= get_references(['genome_file', 'wgd_scoring_mask'])
 
         expected_d = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+        }
+
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
             expected_out_dict=expected_d,
+            labels=billing_labels
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -138,9 +138,13 @@ class GatherSampleEvidence(SequencingGroupStage):
         expected_d = self.expected_outputs(sequencing_group)
 
         # billing labels!
+        # https://cromwell.readthedocs.io/en/stable/wf_options/Google/
+        # these must conform to the regex [a-z]([-a-z0-9]*[a-z0-9])?
         billing_labels = {
-            'dataset': sequencing_group.dataset.name,
-            'sequencing_group': sequencing_group.id,
+            'dataset': sequencing_group.dataset.name, # already lowercase
+            'sequencing_group': sequencing_group.id.lower(), # cpg123123
+            'stage': self.name.lower(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
         }
 
         jobs = add_gatk_sv_jobs(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -141,8 +141,8 @@ class GatherSampleEvidence(SequencingGroupStage):
         # https://cromwell.readthedocs.io/en/stable/wf_options/Google/
         # these must conform to the regex [a-z]([-a-z0-9]*[a-z0-9])?
         billing_labels = {
-            'dataset': sequencing_group.dataset.name, # already lowercase
-            'sequencing-group': sequencing_group.id.lower(), # cpg123123
+            'dataset': sequencing_group.dataset.name,  # already lowercase
+            'sequencing-group': sequencing_group.id.lower(),  # cpg123123
             'stage': self.name.lower(),
             'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
         }

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -113,7 +113,7 @@ def main(
         additional (str | None): a json file containing sequencing groups to include specifically
     """
 
-    collected_sgs = set()
+    collected_sgs: set[str] = set()
 
     # get excluded SGs if that's valid
     if exclude is not None:

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+"""
+a script to find samples that need to be run through the structural variant pipeline
+(i.e. are not present yet in any extant callsets)
+
+usage:
+    python3 find_samples_needing_sv.py
+    -n <min_#_samples>
+    -o <output_path>
+    <projects in order of preference>
+"""
+
+from argparse import ArgumentParser
+import json
+from metamist.graphql import query, gql
+
+
+QUERY_STRING = f"""
+"""
+
+
+def main(min_samples: int, output_path: str, projects: list[str]):
+    """
+
+    Args:
+        min_samples ():
+        output_path ():
+        projects ():
+
+    Returns:
+
+    """
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('-n', '--min_samples', type=int, default=200)
+    parser.add_argument('-o', '--output_path', default='samples_needing_sv.json')
+    parser.add_argument('projects', nargs='+')
+    args = parser.parse_args()
+    main(args.min_samples, args.output_path, args.projects)

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -12,6 +12,7 @@ usage:
 
 optional argument:
     -e <path to json file containing sequencing groups to exclude from search>
+    -a <path to json file containing sequencing groups to include specifically>
 """
 from argparse import ArgumentParser
 from random import sample
@@ -21,7 +22,8 @@ import json
 from metamist.graphql import query, gql
 
 
-FIND_ANALYSES = gql("""
+FIND_ANALYSES = gql(
+    """
 query MyQuery ($project: String!) {
   project(name: $project) {
     analyses(
@@ -33,9 +35,11 @@ query MyQuery ($project: String!) {
     }
   }
 }
-""")
+"""
+)
 
-GENOME_SGS = gql("""
+GENOME_SGS = gql(
+    """
 query SG_Query($project: String!) {
   project(name: $project) {
     sequencingGroups(activeOnly: {eq: true}, type: {eq: "genome"}) {
@@ -43,7 +47,8 @@ query SG_Query($project: String!) {
       type
     }
   }
-}""")
+}"""
+)
 
 
 def get_all_sgs(project: str, exclude_sgs: set[str] | None = None) -> set[str]:
@@ -91,7 +96,13 @@ def get_called_sgs(project: str) -> set[str]:
     return sgs
 
 
-def main(min_samples: int, output_path: str, projects: list[str], exclude: str = None, additional: str| None = None):
+def main(
+    min_samples: int,
+    output_path: str,
+    projects: list[str],
+    exclude: str = None,
+    additional: str | None = None,
+):
     """
 
     Args:
@@ -152,4 +163,10 @@ if __name__ == '__main__':
     parser.add_argument('-a', '--additional', required=False, default=None)
     parser.add_argument('projects', nargs='+')
     args = parser.parse_args()
-    main(args.min_samples, args.output_path, args.projects, exclude=args.exclude, additional=args.additional)
+    main(
+        args.min_samples,
+        args.output_path,
+        args.projects,
+        exclude=args.exclude,
+        additional=args.additional,
+    )

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -6,13 +6,17 @@ a script to find samples that need to be run through the structural variant pipe
 
 usage:
     python3 find_samples_needing_sv.py
-    -n <min_#_samples>
+    -n <max_#_samples>
     -o <output_path>
     <projects in order of preference>
 
-optional argument:
-    -e <path to json file containing sequencing groups to exclude from search>
-    -a <path to json file containing sequencing groups to include specifically>
+The integer argument -n will be the maximum number of samples to return
+If all eligible SG IDs in all listed projects are not enough to reach this number,
+the samples that were successfully collected will be returned
+
+optional arguments:
+    -e <path to json list containing sequencing groups to exclude from search>
+    -a <path to json list containing sequencing groups to include specifically>
 """
 from argparse import ArgumentParser
 from random import sample
@@ -119,7 +123,7 @@ def get_project_crams(project: str) -> set[str]:
 
 
 def main(
-    min_samples: int,
+    max_samples: int,
     output_path: str,
     projects: list[str],
     exclude: str = None,
@@ -128,7 +132,7 @@ def main(
     """
 
     Args:
-        min_samples ():
+        max_samples ():
         output_path ():
         projects ():
         exclude (str | None): a json file containing sequencing groups to exclude from search
@@ -148,7 +152,7 @@ def main(
     for project in projects:
 
         # decide if its time to stop
-        if len(collected_sgs) >= min_samples:
+        if len(collected_sgs) >= max_samples:
             break
 
         # find all SGs with a registered ready CRAM
@@ -164,8 +168,8 @@ def main(
         project_samples_to_call = project_crams.intersection(all_eligible_sgs) - called_sgs
         print(f'{project}: {len(project_samples_to_call)} samples to call')
 
-        if len(project_samples_to_call) + len(collected_sgs) > min_samples:
-            more_samples = min_samples - len(collected_sgs)
+        if len(project_samples_to_call) + len(collected_sgs) > max_samples:
+            more_samples = max_samples - len(collected_sgs)
             collected_sgs.update(sample(list(project_samples_to_call), more_samples))
             print(f'Only added {more_samples} samples from {project}')
 

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -127,8 +127,8 @@ def main(min_samples: int, output_path: str, projects: list[str], exclude: str =
         project_samples_to_call = all_eligible_sgs - called_sgs
         print(f'{project}: {len(project_samples_to_call)} samples to call')
 
-        if len(project_samples_to_call) + len(called_sgs) > min_samples:
-            more_samples = min_samples - len(called_sgs)
+        if len(project_samples_to_call) + len(collected_sgs) > min_samples:
+            more_samples = min_samples - len(collected_sgs)
             collected_sgs.update(sample(list(project_samples_to_call), more_samples))
             print(f'Only added {more_samples} samples from {project}')
 

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -9,34 +9,147 @@ usage:
     -n <min_#_samples>
     -o <output_path>
     <projects in order of preference>
-"""
 
+optional argument:
+    -e <path to json file containing sequencing groups to exclude from search>
+"""
 from argparse import ArgumentParser
+from random import sample
+
 import json
+
 from metamist.graphql import query, gql
 
 
-QUERY_STRING = f"""
-"""
+FIND_ANALYSES = gql("""
+query MyQuery ($project: String!) {
+  project(name: $project) {
+    analyses(
+      status: {eq: COMPLETED}
+      type: {eq: "sv"}
+      active: {eq: true}
+    ) {
+      meta
+    }
+  }
+}
+""")
+
+GENOME_SGS = gql("""
+query SG_Query($project: String!) {
+  project(name: $project) {
+    sequencingGroups(activeOnly: {eq: true}, type: {eq: "genome"}) {
+      id
+      type
+    }
+  }
+}""")
 
 
-def main(min_samples: int, output_path: str, projects: list[str]):
+def get_all_sgs(project: str, exclude_sgs: set[str] | None = None) -> set[str]:
+    """
+    find all sgs in the project
+
+    Args:
+        project ():
+        exclude_sgs ():
+
+    Returns:
+
+    """
+
+    if exclude_sgs is None:
+        exclude_sgs = set()
+
+    sgs = set()
+
+    for sg in query(GENOME_SGS, {'project': project})['project']['sequencingGroups']:
+        if sg['id'] not in exclude_sgs:
+            sgs.add(sg['id'])
+    return sgs
+
+
+def get_called_sgs(project: str) -> set[str]:
+    """
+    find all sequencing groups in the project with SV calls
+
+    Args:
+        project (str): the project ID to use
+
+    Returns:
+        a set of all sequencing groups in the project
+    """
+
+    sgs = set()
+
+    for analysis in query(FIND_ANALYSES, {'project': project})['project']['analyses']:
+        if analysis['meta'].get('type') != 'annotated-sv-dataset-callset':
+            continue
+        assert analysis['meta'].get('stage') == 'AnnotateDatasetSv'
+
+        sgs.update(analysis['meta']['sequencing_groups'])
+    return sgs
+
+
+def main(min_samples: int, output_path: str, projects: list[str], exclude: str = None, additional: str| None = None):
     """
 
     Args:
         min_samples ():
         output_path ():
         projects ():
-
-    Returns:
-
+        exclude (str | None): a json file containing sequencing groups to exclude from search
+        additional (str | None): a json file containing sequencing groups to include specifically
     """
+
+    collected_sgs = set()
+
+    # get excluded SGs if that's valid
+    if exclude is not None:
+        with open(exclude) as f:
+            exclude_sgs = set(json.load(f))
+    else:
+        exclude_sgs = set()
+
+    # iterate over projects in order
+    for project in projects:
+
+        if len(collected_sgs) >= min_samples:
+            break
+
+        # find all SGs
+        all_eligible_sgs = get_all_sgs(project=project, exclude_sgs=exclude_sgs)
+
+        # find all SGs with SV calls
+        called_sgs = get_called_sgs(project=project)
+
+        # find all SGs without SV calls
+        project_samples_to_call = all_eligible_sgs - called_sgs
+        print(f'{project}: {len(project_samples_to_call)} samples to call')
+
+        if len(project_samples_to_call) + len(called_sgs) > min_samples:
+            more_samples = min_samples - len(called_sgs)
+            collected_sgs.update(sample(list(project_samples_to_call), more_samples))
+            print(f'Only added {more_samples} samples from {project}')
+
+        else:
+            collected_sgs.update(project_samples_to_call)
+
+    if additional is not None:
+        with open(additional) as f:
+            collected_sgs.update(json.load(f))
+
+    # write out the results
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(list(collected_sgs), f, indent=4)
 
 
 if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('-n', '--min_samples', type=int, default=200)
     parser.add_argument('-o', '--output_path', default='samples_needing_sv.json')
+    parser.add_argument('-e', '--exclude', required=False, default=None)
+    parser.add_argument('-a', '--additional', required=False, default=None)
     parser.add_argument('projects', nargs='+')
     args = parser.parse_args()
-    main(args.min_samples, args.output_path, args.projects)
+    main(args.min_samples, args.output_path, args.projects, exclude=args.exclude, additional=args.additional)


### PR DESCRIPTION
Candidate script to generate a list of samples to start off a fresh GATK-SV batch

- give it a number of samples to aim for, and a list of projects in order of priority
- iterate through projects
  - find all samples in the project (remove excluded samples, if exclusion file is added)
  - find subset of samples with SV calls already, remove from consideration
  - add all samples in the subset yet to be called (unless that would exceed the number specified, in which case add a subset using random.sample)
- if a file of 'additional' samples is specified, add all of those too
- write to output file

Completely functionally unrelated change crowbar'd in here to ride the wave of an approved PR: Labels!

There is an issue whereby Cromwell implements strict RegEx limitations on GCP labels, which we are relying on for billing auditability. This PR:

- updates the billing labels to conform to `[a-z]([-a-z0-9]*[a-z0-9])?`
- adds the `ar-guid` label
- prefixes `ar-guid`'s value with `ar-` to prevent failure when the first digit happens to be a number
- adds the Cromwell Stage (lowercase) as a label
- lowercases the CPG ID
- sequencing_group -> `sequencing-group`