### PR TITLE
Vep and ar-guid fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.2
+current_version = 1.18.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ on:
         default: "test"
 
 env:
-  VERSION: 1.18.2
+  VERSION: 1.18.3
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:a15ed15c0ca0b7304e0ceca1b873d734720c5d7a-hail-abaf45c99b32250dfc55a1b26a6a0635760e0a99
-# this pinned image is a temporary workaround for production-pipelines/issues/477
+FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
 RUN pip install metamist 
 COPY README.md .

--- a/cpg_workflows/jobs/vep.py
+++ b/cpg_workflows/jobs/vep.py
@@ -275,7 +275,6 @@ def vep_one(
     -i {vcf} \\
     --everything \\
     --mane_select \\
-    --no_stats \\
     --allele_number \\
     --minimal \\
     --species homo_sapiens \\

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -141,12 +141,11 @@ class GatherSampleEvidence(SequencingGroupStage):
         # billing labels!
         # https://cromwell.readthedocs.io/en/stable/wf_options/Google/
         # these must conform to the regex [a-z]([-a-z0-9]*[a-z0-9])?
-
         billing_labels = {
             'dataset': sequencing_group.dataset.name,  # already lowercase
             'sequencing-group': sequencing_group.id.lower(),  # cpg123123
             'stage': self.name.lower(),
-            AR_GUID_NAME: try_get_ar_guid(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
         }
 
         jobs = add_gatk_sv_jobs(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -145,7 +145,7 @@ class GatherSampleEvidence(SequencingGroupStage):
             'dataset': sequencing_group.dataset.name,  # already lowercase
             'sequencing-group': sequencing_group.id.lower(),  # cpg123123
             'stage': self.name.lower(),
-            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+            AR_GUID_NAME: try_get_ar_guid()
         }
 
         jobs = add_gatk_sv_jobs(
@@ -217,7 +217,7 @@ class EvidenceQC(CohortStage):
 
         billing_labels = {
             'stage': self.name.lower(),
-            AR_GUID_NAME: try_get_ar_guid(),
+            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
         }
 
         jobs = add_gatk_sv_jobs(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -217,7 +217,7 @@ class EvidenceQC(CohortStage):
 
         billing_labels = {
             'stage': self.name.lower(),
-            'ar-guid': f'ar-{get_config()["workflow"]["ar_guid"]}',
+            AR_GUID_NAME: try_get_ar_guid()
         }
 
         jobs = add_gatk_sv_jobs(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.2',
+    version='1.18.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'cloudpathlib>=0.16.0',
-        'cpg-utils',
+        'cpg-utils>=4.17.0',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.41.2',
         'hail!=0.2.120',  # Temporarily work around hail-is/hail#13337


### PR DESCRIPTION
- Pins the cpg-utils requirement to a point post `ar-guid` (currently at 4.15.1 in the driver image, so is not updated and is broken relative to code on main)
- removes the no-stats VEP flag (see [issue](https://github.com/Ensembl/ensembl-vep/issues/1013#issuecomment-867595782) affecting [batch](https://batch.hail.populationgenomics.org.au/batches/429519/jobs/3772))