### PR TITLE
Allow ES-Index name registration without file checks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.4
+current_version = 1.18.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ on:
         default: "test"
 
 env:
-  VERSION: 1.18.4
+  VERSION: 1.18.5
 
 jobs:
   docker:

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -44,18 +44,22 @@ def complete_analysis_job(
     assert isinstance(output, str)
     output_cloudpath = to_path(output)
 
-    if not output_cloudpath.exists():
-        if tolerate_missing:
-            print(f"Output {output} doesn't exist, allowing silent return")
-            return
-        raise ValueError(f"Output {output} doesn't exist")
-
     if update_analysis_meta is not None:
         meta | update_analysis_meta(output)
 
-    # pad meta with real file size
-    if not output_cloudpath.is_dir():
-        meta |= {'size': output_cloudpath.stat().st_size}
+    # we know that es indexes are registered names, not files/dirs
+    # skip all relevant checks for this output type
+    if analysis_type != 'es-index':
+
+        if not output_cloudpath.exists():
+            if tolerate_missing:
+                print(f"Output {output} doesn't exist, allowing silent return")
+                return
+            raise ValueError(f"Output {output} doesn't exist")
+
+        # add file size to meta
+        if not output_cloudpath.is_dir():
+            meta |= {'size': output_cloudpath.stat().st_size}
 
     this_analysis = Analysis(
         type=analysis_type,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.4',
+    version='1.18.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
ES Indexes are registered as names, not files. Skip pesky file checks (separate logic from the 'permit output to be missing')

As discussed on Slack