### PR TITLE
Reduce Metamist logging

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.5
+current_version = 1.18.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ on:
         default: "test"
 
 env:
-  VERSION: 1.18.5
+  VERSION: 1.18.6
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -89,6 +89,7 @@ reblock_gq_bands = [20, 30, 40]
 # startup will be printed into the Hail Batch logs. These logs are substantial
 # blocks of text, and contain all query results in JSON format. By default the
 # behaviour is to hide this information from logging files.
+# This is relevant in cpg_workflows.metamist.gql_query_optional_logging
 #log_metamist = true
 
 # Map internally used validation sample external_id to truth sample names

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -85,6 +85,12 @@ reblock_gq_bands = [20, 30, 40]
 # the code can be run without permissions.
 #dry_run = true
 
+# if this argument is set to True, the GQL queries executed during pipeline
+# startup will be printed into the Hail Batch logs. These logs are substantial
+# blocks of text, and contain all query results in JSON format. By default the
+# behaviour is to hide this information from logging files.
+#log_metamist = true
+
 # Map internally used validation sample external_id to truth sample names
 [validation.sample_map]
 HG001_NA12878 = 'na12878'

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -14,7 +14,7 @@ from cpg_utils.config import get_config
 from metamist import models
 from metamist.apis import AnalysisApi
 from metamist.exceptions import ApiException
-from metamist.graphql import gql, query, validate
+from metamist.graphql import gql, query
 
 from cpg_workflows.filetypes import (
     AlignmentInput,
@@ -24,6 +24,7 @@ from cpg_workflows.filetypes import (
     FastqPairs,
 )
 from cpg_workflows.utils import exists
+
 
 GET_SEQUENCING_GROUPS_QUERY = gql(
     """

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -93,7 +93,17 @@ def silent_query(query_to_run, query_params: dict | None = None):
     """
     Run a query, but don't log the results to the console
     Ref: https://github.com/populationgenomics/metamist/issues/540
+    Allow for a config override to log the results to the console
+
+    Args:
+        query_to_run (gql DocumentNode): Query String
+        query_params (dict): Query Parameters or None
+
+    Returns:
+        query result, with or without logging
     """
+    if get_config()['workflow'].get('log_metamist', False):
+        return query(query_to_run, variables=query_params)
 
     curr_level = logging.root.level
     logging.getLogger().setLevel(logging.WARN)

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -89,9 +89,12 @@ GET_PEDIGREE_QUERY = gql(
 _metamist: Optional['Metamist'] = None
 
 
-def silent_query(query_to_run, query_params: dict | None = None):
+def gql_query_optional_logging(query_to_run, query_params: dict | None = None):
     """
     Run a query, but don't log the results to the console
+    This is done by setting the global logger level to WARN
+    for the duration of the query exectution, then returning to
+    whichever state it was previously in
     Ref: https://github.com/populationgenomics/metamist/issues/540
     Allow for a config override to log the results to the console
 
@@ -249,7 +252,7 @@ class Metamist:
         if only_sgs and skip_sgs:
             raise MetamistError('Cannot specify both only_sgs and skip_sgs in config')
 
-        sequencing_group_entries = silent_query(
+        sequencing_group_entries = gql_query_optional_logging(
             GET_SEQUENCING_GROUPS_QUERY,
             {
                 'metamist_proj': metamist_proj,
@@ -321,7 +324,7 @@ class Metamist:
         if get_config()['workflow']['access_level'] == 'test':
             metamist_proj += '-test'
 
-        analyses = silent_query(
+        analyses = gql_query_optional_logging(
             GET_ANALYSES_QUERY,
             {
                 'metamist_proj': metamist_proj,
@@ -496,7 +499,7 @@ class Metamist:
         if get_config()['workflow']['access_level'] == 'test':
             metamist_proj += '-test'
 
-        entries = silent_query(GET_PEDIGREE_QUERY, {'metamist_proj': metamist_proj})
+        entries = gql_query_optional_logging(GET_PEDIGREE_QUERY, {'metamist_proj': metamist_proj})
 
         pedigree_entries = entries['project']['pedigree']
 

--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -71,7 +71,7 @@ from cpg_workflows.workflow import (
     StageInput,
 )
 from cpg_workflows.resources import STANDARD
-from cpg_workflows.metamist import silent_query
+from cpg_workflows.metamist import gql_query_optional_logging
 
 
 CHUNKY_DATE = datetime.now().strftime('%Y-%m-%d')
@@ -173,7 +173,7 @@ def query_for_latest_mt(dataset: str) -> str:
     query_dataset = dataset
     if get_config()['workflow'].get('access_level') == 'test' and 'test' not in query_dataset:
         query_dataset += '-test'
-    result = silent_query(MTA_QUERY, query_params={'dataset': query_dataset})
+    result = gql_query_optional_logging(MTA_QUERY, query_params={'dataset': query_dataset})
     mt_by_date = {}
     seq_type_exome = get_config()['workflow'].get('sequencing_type') == 'exome'
     for analysis in result['project']['analyses']:

--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -60,7 +60,7 @@ from cpg_utils.hail_batch import (
     copy_common_env,
     image_path,
 )
-from metamist.graphql import gql, query
+from metamist.graphql import gql
 
 from cpg_workflows.batch import get_batch
 from cpg_workflows.workflow import (
@@ -71,6 +71,7 @@ from cpg_workflows.workflow import (
     StageInput,
 )
 from cpg_workflows.resources import STANDARD
+from cpg_workflows.metamist import silent_query
 
 
 CHUNKY_DATE = datetime.now().strftime('%Y-%m-%d')
@@ -172,7 +173,7 @@ def query_for_latest_mt(dataset: str) -> str:
     query_dataset = dataset
     if get_config()['workflow'].get('access_level') == 'test' and 'test' not in query_dataset:
         query_dataset += '-test'
-    result = query(MTA_QUERY, variables={'dataset': query_dataset})
+    result = silent_query(MTA_QUERY, query_params={'dataset': query_dataset})
     mt_by_date = {}
     seq_type_exome = get_config()['workflow'].get('sequencing_type') == 'exome'
     for analysis in result['project']['analyses']:

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -924,14 +924,16 @@ class Workflow:
         stages: list[StageDecorator] | None = None,
         dry_run: bool | None = None,
     ):
+        # always print the first config call, even if dry_run
+        _config = get_config(True)
         if _workflow is not None:
             raise ValueError(
                 'Workflow already initialised. Use get_workflow() to get the instance'
             )
 
-        self.dry_run = dry_run or get_config(True)['workflow'].get('dry_run')
+        self.dry_run = dry_run or get_config()['workflow'].get('dry_run')
 
-        analysis_dataset = get_config(True)['workflow']['dataset']
+        analysis_dataset = get_config()['workflow']['dataset']
         name = get_config()['workflow'].get('name', analysis_dataset)
         description = get_config()['workflow'].get('description', name)
         self.name = slugify(name)

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -929,7 +929,7 @@ class Workflow:
                 'Workflow already initialised. Use get_workflow() to get the instance'
             )
 
-        self.dry_run = dry_run or get_config()['workflow'].get('dry_run')
+        self.dry_run = dry_run or get_config(True)['workflow'].get('dry_run')
 
         analysis_dataset = get_config()['workflow']['dataset']
         name = get_config()['workflow'].get('name', analysis_dataset)

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -931,7 +931,7 @@ class Workflow:
 
         self.dry_run = dry_run or get_config(True)['workflow'].get('dry_run')
 
-        analysis_dataset = get_config()['workflow']['dataset']
+        analysis_dataset = get_config(True)['workflow']['dataset']
         name = get_config()['workflow'].get('name', analysis_dataset)
         description = get_config()['workflow'].get('description', name)
         self.name = slugify(name)

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -924,16 +924,14 @@ class Workflow:
         stages: list[StageDecorator] | None = None,
         dry_run: bool | None = None,
     ):
-        # always print the first config call, even if dry_run
-        _config = get_config(True)
         if _workflow is not None:
             raise ValueError(
                 'Workflow already initialised. Use get_workflow() to get the instance'
             )
 
-        self.dry_run = dry_run or get_config()['workflow'].get('dry_run')
+        self.dry_run = dry_run or get_config(True)['workflow'].get('dry_run')
 
-        analysis_dataset = get_config()['workflow']['dataset']
+        analysis_dataset = get_config(True)['workflow']['dataset']
         name = get_config()['workflow'].get('name', analysis_dataset)
         description = get_config()['workflow'].get('description', name)
         self.name = slugify(name)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.5',
+    version='1.18.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Wraps the metamist GQL query calls with a reduced-granularity logging profile. Prevents the full un-parsed metamist query response being printed into Hail logs (often a multi-MB text dump)

First (?) get_config call is set to 'print result to log', in case https://github.com/populationgenomics/cpg-utils/pull/146 is merged