### PR TITLE
Interim quick fix: Account for GB vs MiB in JobResource.get_java_mem_mb()

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.6
+current_version = 1.18.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ on:
         default: "test"
 
 env:
-  VERSION: 1.18.6
+  VERSION: 1.18.7
 
 jobs:
   docker:

--- a/cpg_workflows/resources.py
+++ b/cpg_workflows/resources.py
@@ -257,7 +257,8 @@ class JobResource:
         Subtracts 1G to start a java VM, and converts to MB as the option doesn't
         support fractions of GB.
         """
-        return int(math.floor((self.get_mem_gb() - 1) * 1000))
+        # get_mem_gb() is usually decimal GB, but our value is used as binary MiB
+        return int(math.floor((self.get_mem_gb() - 1) * 953.6))
 
     def get_ncpu(self) -> int:
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.6',
+    version='1.18.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
We will soon rewrite this Java option facility to be more flexible, but in the interim let's correct the mathematics. While `get_mem_gb()` is measured in decimal GB, `-Xms` uses `get_java_mem_mb()` as binary MiB. Hence the correct multiplier is 1000<sup>3</sup> / 1024<sup>2</sup> rather than 1000. (At present, the JVM is sometimes being told to use more memory than Hail has allocated to the job, leading to intermittent failures and a need to use the big hammer of the `picard_mem_gb` override.)

Context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1698815009640079?thread_ts=1698788154.906359&cid=C018KFBCR1C and the surrounding thread.