### PR TITLE
Update default variant sites table

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -74,4 +74,4 @@ delete_scratch_on_exit = false
 
 [references.gnomad]
 tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht"
-predetermined_qc_variants = "gs://cpg-hgdp-1kg-test/vds/pruned_variants.ht/"
+predetermined_qc_variants = "gs://cpg-hgdp-1kg-main/sites_table/v1-0/pruned_variants.ht/"


### PR DESCRIPTION
The default variants table was being pulled from `test`, rather than `main`.

For more context, this sites table has been chosen as a representative sample of variation across diverse cohorts after testing several sites tables. See slack thread here: https://centrepopgen.slack.com/archives/C04KZFM1TC7/p1679895423746189