### PR TITLE
Update kinship threshold

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -29,9 +29,10 @@ num_pcs = 4
 # demanding higher resources for all operations as standard. Examples below
 
 [large_cohort]
-# Parameters for reladness inference
-max_kin = 0.2  # maximum kin threshold to be considered unrelated in relatedness check (second degree)
-# As in hail docs https://hail.is/docs/0.2/methods/relatedness.html, 0.25
+# Kinship threshold to consider two samples as related.
+# the default threshold for second degree relatives in gnomAD is 0.1:
+# https://github.com/broadinstitute/gnomad_methods/blob/382fc2c7976d58cc8983cc4c9f0df5d8d5f9fae3/gnomad/sample_qc/relatedness.py#L195
+max_kin = 0.1  
 # Parameters for population inference
 n_pcs = 16  # number of principal components for PCA analysis
 min_pop_prob = 0.5  # minimum random forest probability for population assignment


### PR DESCRIPTION
Update kinship threshold from 0.2 to 0.1

This threshold represents the 'kinship threshold to consider two samples as related', as stated in the [gnomAD QC function](https://broadinstitute.github.io/gnomad_methods/_modules/gnomad/sample_qc/relatedness.html#compute_related_samples_to_drop) it's being pulled from. Currently, the wording makes it confusing as to what this threshold is doing. 

Under the PC-Relate model, kinship ranges from 0 to 0.5, where 0.5 = identical (i.e., identical twins, or the same individual), parent-child and sibling pairs have a kinship of 0.25, and uncle/aunt/grand-parent/-child pairs have a kinship of 0.125. In gnomAD, they filter out samples related at the 2nd degree or closer, however the current threshold is set to 0.2. Keeping this threshold would leave in samples at a kinship threshold above 0.2, meaning individuals related at the second-degree (e.g., uncle/aunt/grand-parent/-child pairs). 