### PR TITLE
Use federated identities to auth to GCP

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,6 +10,10 @@ on:
         description: 'Tag to use (defaults to "test")'
         default: "test"
 
+permissions:
+  id-token: write
+  contents: read
+  
 env:
   VERSION: 1.18.8
 
@@ -31,13 +35,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: gcloud auth
-        uses: google-github-actions/auth@v0
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: ${{ secrets.GH_IMAGES_DEPLOYER_JSON }}
-
+          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+  
       - name: set up gcloud sdk
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: cpg-common
 


### PR DESCRIPTION
Failed after I revoked all the service accounts for gh-images-deployer.
Successful run: https://github.com/populationgenomics/production-pipelines/actions/runs/6922877336/job/18830113488