### PR TITLE
Incorporate sample hash into multiQC input file

### DIFF
--- a/cpg_workflows/jobs/multiqc.py
+++ b/cpg_workflows/jobs/multiqc.py
@@ -61,7 +61,7 @@ def multiqc(
     mqc_j.image(image_path('multiqc'))
     STANDARD.set_resources(mqc_j, ncpu=16)
 
-    file_list_path = tmp_prefix / 'multiqc-file-list.txt'
+    file_list_path = tmp_prefix / f'{dataset.alignment_inputs_hash()}_multiqc-file-list.txt'
     if not get_config()['workflow'].get('dry_run', False):
         with file_list_path.open('w') as f:
             f.writelines([f'{p}\n' for p in paths])
@@ -73,7 +73,7 @@ def multiqc(
     )
 
     if sequencing_group_id_map:
-        sample_map_path = tmp_prefix / 'rename-sample-map.tsv'
+        sample_map_path = tmp_prefix / f'{dataset.alignment_inputs_hash()}_rename-sample-map.tsv'
         if not get_config()['workflow'].get('dry_run', False):
             _write_sg_id_map(sequencing_group_id_map, sample_map_path)
         sample_map_file = b.read_input(str(sample_map_path))

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -277,7 +277,7 @@ class CramMultiQC(DatasetStage):
             return {}
         h = dataset.alignment_inputs_hash()
         return {
-            'html': dataset.web_prefix() / 'qc' / 'cram' / 'multiqc.html',
+            'html': dataset.web_prefix() / 'qc' / 'cram' / h / 'multiqc.html',
             'json': dataset.prefix() / 'qc' / 'cram' / h / 'multiqc_data.json',
             'checks': dataset.prefix() / 'qc' / 'cram' / h / '.checks',
         }

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -275,11 +275,13 @@ class CramMultiQC(DatasetStage):
         """
         if get_config()['workflow'].get('skip_qc', False) is True:
             return {}
-        h = dataset.alignment_inputs_hash()
+
+        # get the unique hash for these Sequencing Groups
+        sg_hash = dataset.alignment_inputs_hash()
         return {
-            'html': dataset.web_prefix() / 'qc' / 'cram' / h / 'multiqc.html',
-            'json': dataset.prefix() / 'qc' / 'cram' / h / 'multiqc_data.json',
-            'checks': dataset.prefix() / 'qc' / 'cram' / h / '.checks',
+            'html': dataset.web_prefix() / 'qc' / 'cram' / sg_hash / 'multiqc.html',
+            'json': dataset.prefix() / 'qc' / 'cram' / sg_hash / 'multiqc_data.json',
+            'checks': dataset.prefix() / 'qc' / 'cram' / sg_hash / '.checks',
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -180,8 +180,7 @@ class SomalierPedigree(DatasetStage):
         """
         if get_config()['workflow'].get('skip_qc', False) is True:
             return {}
-        h = dataset.alignment_inputs_hash()
-        prefix = dataset.prefix() / 'somalier' / 'cram' / h
+        prefix = dataset.prefix() / 'somalier' / 'cram' / dataset.alignment_inputs_hash()
         return {
             'samples': prefix / f'{dataset.name}.samples.tsv',
             'expected_ped': prefix / f'{dataset.name}.expected.ped',

--- a/cpg_workflows/stages/fastqc.py
+++ b/cpg_workflows/stages/fastqc.py
@@ -130,7 +130,7 @@ class FastQCMultiQC(DatasetStage):
             return {}
         h = dataset.alignment_inputs_hash()
         return {
-            'html': dataset.web_prefix() / 'qc' / 'fastqc' / 'multiqc.html',
+            'html': dataset.web_prefix() / 'qc' / 'fastqc' / h / 'multiqc.html',
             'json': dataset.prefix() / 'qc' / 'fastqc' / h / 'multiqc_data.json',
         }
 

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -144,7 +144,7 @@ class GvcfMultiQC(DatasetStage):
 
         h = dataset.alignment_inputs_hash()
         return {
-            'html': dataset.web_prefix() / 'qc' / 'gvcf' / 'multiqc.html',
+            'html': dataset.web_prefix() / 'qc' / 'gvcf' / h / 'multiqc.html',
             'json': dataset.prefix() / 'qc' / 'gvcf' / h / 'multiqc_data.json',
             'checks': dataset.prefix() / 'qc' / 'gvcf' / h / '.checks',
         }

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -142,11 +142,12 @@ class GvcfMultiQC(DatasetStage):
         if get_config()['workflow'].get('skip_qc', False) is True:
             return {}
 
-        h = dataset.alignment_inputs_hash()
+        # get the unique hash for these Sequencing Groups
+        sg_hash = dataset.alignment_inputs_hash()
         return {
-            'html': dataset.web_prefix() / 'qc' / 'gvcf' / h / 'multiqc.html',
-            'json': dataset.prefix() / 'qc' / 'gvcf' / h / 'multiqc_data.json',
-            'checks': dataset.prefix() / 'qc' / 'gvcf' / h / '.checks',
+            'html': dataset.web_prefix() / 'qc' / 'gvcf' / sg_hash / 'multiqc.html',
+            'json': dataset.prefix() / 'qc' / 'gvcf' / sg_hash / 'multiqc_data.json',
+            'checks': dataset.prefix() / 'qc' / 'gvcf' / sg_hash / '.checks',
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/joint_genotyping_qc.py
+++ b/cpg_workflows/stages/joint_genotyping_qc.py
@@ -151,19 +151,19 @@ class JointVcfMultiQC(CohortStage):
         """
         if get_config()['workflow'].get('skip_qc', False) is True:
             return {}
-
+        h = get_workflow().output_version
         return {
-            'html': cohort.analysis_dataset.web_prefix() / 'qc' / 'jc' / 'multiqc.html',
+            'html': cohort.analysis_dataset.web_prefix()
+            / 'qc'
+            / 'jc'
+            / h
+            / 'multiqc.html',
             'json': cohort.analysis_dataset.prefix()
             / 'qc'
             / 'jc'
-            / get_workflow().output_version
+            / h
             / 'multiqc_data.json',
-            'checks': cohort.analysis_dataset.prefix()
-            / 'qc'
-            / 'jc'
-            / get_workflow().output_version
-            / '.checks',
+            'checks': cohort.analysis_dataset.prefix() / 'qc' / 'jc' / h / '.checks',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:

--- a/scripts/find_samples_needing_sv.py
+++ b/scripts/find_samples_needing_sv.py
@@ -95,11 +95,11 @@ def get_called_sgs(project: str) -> set[str]:
     sgs = set()
 
     for analysis in query(FIND_ANALYSES, {'project': project, 'type': 'sv'})['project']['analyses']:
-        if analysis['meta'].get('type') != 'annotated-sv-dataset-callset':
+        if analysis['meta'].get('stage') != 'AnnotateDatasetSv':
             continue
-        assert analysis['meta'].get('stage') == 'AnnotateDatasetSv'
 
         sgs.update(analysis['meta']['sequencing_groups'])
+
     return sgs
 
 


### PR DESCRIPTION
Closes #532

Incorporates the hash of the collected samples into the file name written/read for multiQC. This should permit multiple overlapping batches