### PR TITLE
Improve (remove) hard path building, assume metamist as source of truth. 

### DIFF
--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -140,21 +140,30 @@ def _populate_analysis(cohort: Cohort) -> None:
         # TODO: Review here
         for sequencing_group in dataset.get_sequencing_groups():
             if (analysis := gvcf_by_sgid.get(sequencing_group.id)) and analysis.output:
-                assert analysis.output == sequencing_group.make_gvcf_path().path, (
+                # assert file exists
+                assert analysis.output.exists(), (
+                    'gvcf file does not exist',
                     analysis.output,
-                    sequencing_group.make_gvcf_path().path,
                 )
-                sequencing_group.gvcf = sequencing_group.make_gvcf_path()
+                sequencing_group.gvcf = analysis.output
             elif sequencing_group.make_gvcf_path().exists():
-                sequencing_group.gvcf = sequencing_group.make_gvcf_path()
-            if (analysis := cram_by_sgid.get(sequencing_group.id)) and analysis.output:
-                assert analysis.output == sequencing_group.make_cram_path().path, (
-                    analysis.output,
-                    sequencing_group.make_cram_path().path,
+                logging.warning(
+                    f'We found a gvcf file in the expected location {sequencing_group.make_gvcf_path()},'
+                    'but it is not logged in metamist. Skipping. You may want to update the metadata and try again. '
                 )
-                sequencing_group.cram = sequencing_group.make_cram_path()
+            if (analysis := cram_by_sgid.get(sequencing_group.id)) and analysis.output:
+                # assert file exists
+                assert analysis.output.exists(), (
+                    'cram file does not exist',
+                    analysis.output,
+                )
+                sequencing_group.cram = analysis.output
+
             elif sequencing_group.make_cram_path().exists():
-                sequencing_group.cram = sequencing_group.make_cram_path()
+                logging.warning(
+                    f'We found a cram file in the expected location {sequencing_group.make_cram_path()},'
+                    'but it is not logged in metamist. Skipping. You may want to update the metadata and try again. '
+                )
 
 
 def _populate_pedigree(cohort: Cohort) -> None:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -135,9 +135,6 @@ def _populate_analysis(cohort: Cohort) -> None:
             dataset=dataset.name,
         )
 
-        # NOTE: This logic will be simplified to remove existence checks overwriting metamist
-        # in a later PR.
-        # TODO: Review here
         for sequencing_group in dataset.get_sequencing_groups():
             if (analysis := gvcf_by_sgid.get(sequencing_group.id)) and analysis.output:
                 # assert file exists

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -137,6 +137,7 @@ def _populate_analysis(cohort: Cohort) -> None:
 
         # NOTE: This logic will be simplified to remove existence checks overwriting metamist
         # in a later PR.
+        # TODO: Review here
         for sequencing_group in dataset.get_sequencing_groups():
             if (analysis := gvcf_by_sgid.get(sequencing_group.id)) and analysis.output:
                 assert analysis.output == sequencing_group.make_gvcf_path().path, (

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -16,9 +16,6 @@ def _check_gvcfs(sequencing_groups: list[SequencingGroup]) -> list[SequencingGro
     Making sure each sequencing group has a GVCF
     """
     for sequencing_group in sequencing_groups:
-        # TODO: Review this
-        if not sequencing_group.gvcf and exists(sequencing_group.make_gvcf_path().path):
-            sequencing_group.gvcf = sequencing_group.make_gvcf_path()
         if not sequencing_group.gvcf:
             if get_config()['workflow'].get('skip_sgs_with_missing_input', False):
                 logging.warning(f'Skipping {sequencing_group} which is missing GVCF')

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -1,10 +1,10 @@
 import collections
 import logging
 
+import hail as hl
 from cpg_utils import Path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import genome_build
-import hail as hl
 
 from cpg_workflows.inputs import get_cohort
 from cpg_workflows.targets import SequencingGroup
@@ -16,6 +16,7 @@ def _check_gvcfs(sequencing_groups: list[SequencingGroup]) -> list[SequencingGro
     Making sure each sequencing group has a GVCF
     """
     for sequencing_group in sequencing_groups:
+        # TODO: Review this
         if not sequencing_group.gvcf and exists(sequencing_group.make_gvcf_path().path):
             sequencing_group.gvcf = sequencing_group.make_gvcf_path()
         if not sequencing_group.gvcf:

--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -29,7 +29,6 @@ class Align(SequencingGroupStage):
         """
         Stage is expected to generate a CRAM file and a corresponding index.
         """
-        # TODO: Review here too
         return {
             'cram': sequencing_group.make_cram_path().path,
             'crai': sequencing_group.make_cram_path().index_path,
@@ -56,7 +55,6 @@ class Align(SequencingGroupStage):
         )
 
         try:
-            # TODO: Review this.
             jobs = align.align(
                 b=get_batch(),
                 sequencing_group=sequencing_group,

--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -2,19 +2,20 @@
 Stage that generates a CRAM file.
 """
 import logging
-from cloudpathlib import CloudPath
 
+from cloudpathlib import CloudPath
 from cpg_utils import Path
 from cpg_utils.config import get_config
+
 from cpg_workflows import get_batch
 from cpg_workflows.jobs import align
 from cpg_workflows.jobs.align import MissingAlignmentInputException
 from cpg_workflows.workflow import (
     SequencingGroup,
-    stage,
+    SequencingGroupStage,
     StageInput,
     StageOutput,
-    SequencingGroupStage,
+    stage,
 )
 
 
@@ -28,6 +29,7 @@ class Align(SequencingGroupStage):
         """
         Stage is expected to generate a CRAM file and a corresponding index.
         """
+        # TODO: Review here too
         return {
             'cram': sequencing_group.make_cram_path().path,
             'crai': sequencing_group.make_cram_path().index_path,
@@ -54,6 +56,7 @@ class Align(SequencingGroupStage):
         )
 
         try:
+            # TODO: Review this.
             jobs = align.align(
                 b=get_batch(),
                 sequencing_group=sequencing_group,

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -124,7 +124,7 @@ class CramQC(SequencingGroupStage):
         for qc in qc_functions():
             for key, out in qc.outs.items():
                 if key == 'somalier':
-                    # TODO: Review here
+                    # Somalier outputs will be written to self.dataset.prefix() / 'cram' / f'{self.id}.cram.somalier' regardless of input cram path.
                     outs[key] = sequencing_group.make_cram_path().somalier_path
                 elif out:
                     outs[key] = (

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -1,33 +1,34 @@
 """
 Stages that generates and summarises CRAM QC.
 """
-import logging
 import dataclasses
-from typing import Callable, Optional, Any
+import logging
+from typing import Any, Callable, Optional
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
+
 from cpg_workflows import get_batch
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.jobs import somalier
 from cpg_workflows.jobs.multiqc import multiqc
 from cpg_workflows.jobs.picard import (
-    picard_wgs_metrics,
     picard_collect_metrics,
     picard_hs_metrics,
+    picard_wgs_metrics,
 )
 from cpg_workflows.jobs.samtools import samtools_stats
 from cpg_workflows.jobs.verifybamid import verifybamid
 from cpg_workflows.stages.align import Align
-from cpg_workflows.targets import SequencingGroup, Dataset
+from cpg_workflows.targets import Dataset, SequencingGroup
 from cpg_workflows.utils import exists
 from cpg_workflows.workflow import (
-    stage,
-    StageInput,
-    StageOutput,
-    SequencingGroupStage,
     DatasetStage,
+    SequencingGroupStage,
+    StageInput,
     StageInputNotFoundError,
+    StageOutput,
+    stage,
 )
 
 
@@ -123,6 +124,7 @@ class CramQC(SequencingGroupStage):
         for qc in qc_functions():
             for key, out in qc.outs.items():
                 if key == 'somalier':
+                    # TODO: Review here
                     outs[key] = sequencing_group.make_cram_path().somalier_path
                 elif out:
                     outs[key] = (
@@ -180,7 +182,9 @@ class SomalierPedigree(DatasetStage):
         """
         if get_config()['workflow'].get('skip_qc', False) is True:
             return {}
-        prefix = dataset.prefix() / 'somalier' / 'cram' / dataset.alignment_inputs_hash()
+        prefix = (
+            dataset.prefix() / 'somalier' / 'cram' / dataset.alignment_inputs_hash()
+        )
         return {
             'samples': prefix / f'{dataset.name}.samples.tsv',
             'expected_ped': prefix / f'{dataset.name}.expected.ped',
@@ -246,8 +250,9 @@ class SomalierPedigree(DatasetStage):
 
 
 def _update_meta(output_path: str) -> dict[str, Any]:
-    from cloudpathlib import CloudPath
     import json
+
+    from cloudpathlib import CloudPath
 
     with CloudPath(output_path).open() as f:
         d = json.load(f)

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -32,7 +32,6 @@ class Genotype(SequencingGroupStage):
         """
         Generate a GVCF and corresponding TBI index.
         """
-        # TODO: Review this
         return {
             'gvcf': sequencing_group.make_gvcf_path().path,
             'tbi': sequencing_group.make_gvcf_path().tbi_path,

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -4,16 +4,18 @@ Stage that generates a GVCF file.
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
+
 from cpg_workflows.jobs import genotype
 from cpg_workflows.workflow import (
     SequencingGroup,
-    stage,
+    SequencingGroupStage,
     StageInput,
     StageOutput,
-    SequencingGroupStage,
+    stage,
 )
-from .align import Align
+
 from .. import get_batch
+from .align import Align
 
 
 @stage(
@@ -30,6 +32,7 @@ class Genotype(SequencingGroupStage):
         """
         Generate a GVCF and corresponding TBI index.
         """
+        # TODO: Review this
         return {
             'gvcf': sequencing_group.make_gvcf_path().path,
             'tbi': sequencing_group.make_gvcf_path().tbi_path,
@@ -41,6 +44,7 @@ class Genotype(SequencingGroupStage):
         """
         Use function from the jobs module
         """
+        # TODO: Review here
         jobs = genotype.genotype(
             b=get_batch(),
             output_path=self.expected_outputs(sequencing_group)['gvcf'],

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -45,15 +45,11 @@ class Genotype(SequencingGroupStage):
         Use function from the jobs module
         """
 
-        assert sequencing_group.cram, (
-            'CRAM file not found for genotyping',
-            sequencing_group.id,
-        )
         jobs = genotype.genotype(
             b=get_batch(),
             output_path=self.expected_outputs(sequencing_group)['gvcf'],
             sequencing_group_name=sequencing_group.id,
-            cram_path=sequencing_group.cram,
+            cram_path=sequencing_group.cram or sequencing_group.make_cram_path(),
             tmp_prefix=self.tmp_prefix / sequencing_group.id,
             overwrite=sequencing_group.forced,
             job_attrs=self.get_job_attrs(sequencing_group),

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -44,12 +44,16 @@ class Genotype(SequencingGroupStage):
         """
         Use function from the jobs module
         """
-        # TODO: Review here
+
+        assert sequencing_group.cram, (
+            'CRAM file not found for genotyping',
+            sequencing_group.id,
+        )
         jobs = genotype.genotype(
             b=get_batch(),
             output_path=self.expected_outputs(sequencing_group)['gvcf'],
             sequencing_group_name=sequencing_group.id,
-            cram_path=sequencing_group.make_cram_path(),
+            cram_path=sequencing_group.cram,
             tmp_prefix=self.tmp_prefix / sequencing_group.id,
             overwrite=sequencing_group.forced,
             job_attrs=self.get_job_attrs(sequencing_group),

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -605,7 +605,6 @@ class SequencingGroup(Target):
         """
         return self.pedigree.get_ped_dict(use_participant_id)
 
-    # TODO: Review here
     def make_cram_path(self) -> CramPath:
         """
         Path to a CRAM file. Not checking its existence here.
@@ -617,7 +616,6 @@ class SequencingGroup(Target):
             reference_assembly=reference_path('broad/ref_fasta'),
         )
 
-    # TODO: Review here
     def make_gvcf_path(self) -> GvcfPath:
         """
         Path to a GVCF file. Not checking its existence here.

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -7,19 +7,13 @@ import logging
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
+
 import pandas as pd
-
-from cpg_utils.hail_batch import dataset_path, web_url, reference_path
-from cpg_utils.config import get_config
 from cpg_utils import Path, to_path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import dataset_path, reference_path, web_url
 
-from .filetypes import (
-    AlignmentInput,
-    CramPath,
-    BamPath,
-    GvcfPath,
-    FastqPairs,
-)
+from .filetypes import AlignmentInput, BamPath, CramPath, FastqPairs, GvcfPath
 from .metamist import Assay
 
 
@@ -611,6 +605,7 @@ class SequencingGroup(Target):
         """
         return self.pedigree.get_ped_dict(use_participant_id)
 
+    # TODO: Review here
     def make_cram_path(self) -> CramPath:
         """
         Path to a CRAM file. Not checking its existence here.
@@ -622,6 +617,7 @@ class SequencingGroup(Target):
             reference_assembly=reference_path('broad/ref_fasta'),
         )
 
+    # TODO: Review here
     def make_gvcf_path(self) -> GvcfPath:
         """
         Path to a GVCF file. Not checking its existence here.

--- a/misc/benchmark_combiner.py
+++ b/misc/benchmark_combiner.py
@@ -9,12 +9,11 @@ analysis-runner --dataset thousand-genomes --access-level standard <script>
 import logging
 
 import pandas as pd
-
 from cpg_utils import to_path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import output_path, dataset_path
-from cpg_workflows import get_cohort, get_batch
+from cpg_utils.hail_batch import dataset_path, output_path
 
+from cpg_workflows import get_batch, get_cohort
 
 # benchmark matrix:
 N_WORKERS = [10, 30, 20, 40, 50]
@@ -22,6 +21,7 @@ N_SEQUENCING_GROUPS = [100, 200, 300, 400, 500]
 
 
 def main():
+    # TODO: Review this
     df = pd.DataFrame(
         [
             {'s': s.id, 'gvcf': s.make_gvcf_path()}
@@ -45,8 +45,8 @@ def main():
                 :n_sequencing_groups
             ]
 
-            from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
             from cpg_workflows.large_cohort.combiner import run
+            from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
 
             dataproc_job(
                 job_name=f'Combine {n_sequencing_groups} GVCFs on {n_workers} workers',

--- a/misc/benchmark_combiner.py
+++ b/misc/benchmark_combiner.py
@@ -21,12 +21,11 @@ N_SEQUENCING_GROUPS = [100, 200, 300, 400, 500]
 
 
 def main():
-    # TODO: Review this
     df = pd.DataFrame(
         [
-            {'s': s.id, 'gvcf': s.make_gvcf_path()}
+            {'s': s.id, 'gvcf': s.gvcf}
             for s in get_cohort().get_sequencing_groups()
-            if s.make_gvcf_path().exists()
+            if s.gvcf.exists()
         ]
     )
     logging.info(


### PR DESCRIPTION
Within production pipelines there is an assumption that all gvcf and cram paths adhere to the following format: 
`self.dataset.prefix() / 'gvcf' / f'{self.id}.g.vcf.gz'` 
`self.dataset.prefix() / 'cram' / f'{self.id}.cram'` 

However, not all paths from all projects will follow this format. This is creating issues ([failing job](https://batch.hail.populationgenomics.org.au/batches/430408/jobs/1)). 

We should rely on metamist as the source of truth for these output paths (when the outputs already exist before the run is kicked off). Though, historically this has been a challenge. 

This PR aims to remove the reliance on 'hardcoded' path checking for crams and gvcfs and instead use sg.cram or sg.gvcf which are defined for each sequencing group. 

