### PR TITLE
Cromwell job wrapper doesn't take access level any more

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -163,7 +163,6 @@ def add_gatk_sv_jobs(
         b=batch,
         job_prefix=job_prefix,
         dataset=get_config()['workflow']['dataset'],
-        access_level=get_config()['workflow']['access_level'],
         repo='gatk-sv',
         commit=GATK_SV_COMMIT,
         cwd='wdl',


### PR DESCRIPTION
In a recent change `access_level` stopped being an argument