### PR TITLE
Ensure populated CramPaths have both path and index_path

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.12
+current_version = 1.18.13
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.18.12
+  VERSION: 1.18.13
 
 jobs:
   docker:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -156,7 +156,10 @@ def _populate_analysis(cohort: Cohort) -> None:
                     'cram file does not exist',
                     analysis.output,
                 )
-                sequencing_group.cram = CramPath(path=analysis.output)
+                crai_path = analysis.output.with_suffix('.cram.crai')
+                if not crai_path.exists():
+                    crai_path = None
+                sequencing_group.cram = CramPath(analysis.output, crai_path)
 
             elif sequencing_group.make_cram_path().exists():
                 logging.warning(

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -10,6 +10,7 @@ from cpg_workflows.filetypes import CramPath, GvcfPath
 
 from .metamist import AnalysisType, Assay, MetamistError, get_metamist, parse_reads
 from .targets import Cohort, PedigreeInfo, SequencingGroup, Sex
+from .utils import exists
 
 _cohort: Cohort | None = None
 
@@ -140,28 +141,28 @@ def _populate_analysis(cohort: Cohort) -> None:
         for sequencing_group in dataset.get_sequencing_groups():
             if (analysis := gvcf_by_sgid.get(sequencing_group.id)) and analysis.output:
                 # assert file exists
-                assert analysis.output.exists(), (
+                assert exists(analysis.output), (
                     'gvcf file does not exist',
                     analysis.output,
                 )
                 sequencing_group.gvcf = GvcfPath(path=analysis.output)
-            elif sequencing_group.make_gvcf_path().exists():
+            elif exists(sequencing_group.make_gvcf_path()):
                 logging.warning(
                     f'We found a gvcf file in the expected location {sequencing_group.make_gvcf_path()},'
                     'but it is not logged in metamist. Skipping. You may want to update the metadata and try again. '
                 )
             if (analysis := cram_by_sgid.get(sequencing_group.id)) and analysis.output:
                 # assert file exists
-                assert analysis.output.exists(), (
+                assert exists(analysis.output), (
                     'cram file does not exist',
                     analysis.output,
                 )
                 crai_path = analysis.output.with_suffix('.cram.crai')
-                if not crai_path.exists():
+                if not exists(crai_path):
                     crai_path = None
                 sequencing_group.cram = CramPath(analysis.output, crai_path)
 
-            elif sequencing_group.make_cram_path().exists():
+            elif exists(sequencing_group.make_cram_path()):
                 logging.warning(
                     f'We found a cram file in the expected location {sequencing_group.make_cram_path()},'
                     'but it is not logged in metamist. Skipping. You may want to update the metadata and try again. '

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.12',
+    version='1.18.13',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Followup to PR #537: We need `sequencing_group.cram` to be a CramPath as established by the previous PR, but we also need to ensure that `sequencing_group.cram.index_path` is also set (where applicable?), which requires a suitable value to be provided to the constructor call.

There are surely better ways to query or construct this value. Is it available perhaps via the same metamist call? Is it always available, or do we need to do an `.exists()` and leave this as None if not?