### PR TITLE
Fix cpg-utils dependency

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.13
+current_version = 1.18.14
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.18.13
+  VERSION: 1.18.14
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'cpg-utils>=4.18.2',
+        'cpg-utils>=4.18.3',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.41.2',
         'hail!=0.2.120',  # Temporarily work around hail-is/hail#13337

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.13',
+    version='1.18.14',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
4.18.3 is the version with the fix for multiple configs, require this version when installing

see https://github.com/populationgenomics/cpg-utils/pull/149