### PR TITLE
Reheader crams sg id fix

### DIFF
--- a/scripts/fix_rg_pg_header_sg_ids.py
+++ b/scripts/fix_rg_pg_header_sg_ids.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+
+import hashlib
+import os
+import subprocess as sb
+import sys
+
+import click
+
+from hailtop.batch.resource import JobResourceFile
+
+from cpg_utils import to_path
+from cpg_utils.hail_batch import get_batch, get_config, image_path
+from metamist import models
+from metamist.apis import AnalysisApi
+from metamist.graphql import query, gql
+
+FIND_CRAMS = gql("""
+query CramQuery($project: String!, $sequencing_groups: [String!]) {
+  project(name: $project) {
+    sequencingGroups(id: {in_:$sequencing_groups}) {
+      id
+      analyses(type: {eq: "cram"}) {
+        id
+        meta
+        output
+        active
+        type
+      }
+    }
+  }
+}
+""")
+
+
+def query_metamist(dataset: str, sequencing_groups: list[str]) -> dict[str, str]:
+    cram_list = {}
+
+    for seqgroup in query(FIND_CRAMS, {'project': dataset, 'sequencing_groups': sequencing_groups})['project']['sequencingGroups']:
+        sgid = seqgroup['id']
+        for analysis in seqgroup['analyses']:
+            fname = analysis['output']
+            if fname is not None and fname.endswith('.cram'):
+                cram_list[sgid] = fname
+            else:
+                anid = analysis['id']
+                print(f'Sequencing group {sgid} analysis {anid} is not CRAM: {fname}')
+
+    return cram_list
+
+
+def parse_one_header_line(line: str):
+    table = {}
+    for field in line.strip().split('\t')[1:]:
+        key, value = field.split(':', maxsplit=1)
+        table[key] = value
+    return table
+
+
+def extract_header_sgid(path: str):
+    """Reads the file's headers and finds the sequencing group IDs within"""
+    run = sb.run(['samtools', 'head', path], capture_output=True, text=True)
+    if run.returncode != 0:
+        return None  # Probably file not found
+
+    header_sgid = {}
+    for line in run.stdout.splitlines():
+        if line.startswith('@RG'):
+            rg_field = parse_one_header_line(line)
+            header_sgid['ID'] = rg_field['ID']
+            header_sgid['SM'] = rg_field['SM']
+            assert rg_field['ID'] == rg_field['SM']
+        if line.startswith('@PG'):
+            pg_field = parse_one_header_line(line)
+            cmd = pg_field['CL']
+            if cmd[:-4] == ['--RGID', header_sgid['ID'], '--RGSM', header_sgid['ID']]:
+                header_sgid['RGID'] = cmd[-3]
+                header_sgid['RGSM'] = cmd[-1]
+                assert header_sgid['RGID'] == header_sgid['RGSM']
+                assert header_sgid['RGID'] == header_sgid['ID']
+
+    return header_sgid
+
+
+def do_reheader(dry_run, sgid, incram, outcram, outcrai):
+    header = extract_header_sgid(incram)
+    # Check if any of the values in the header dict are not the sgid
+    if not any(header.get(key) != sgid for key in header):
+        raise ValueError(f'{incram}: headers already match {sgid}')
+
+    head_cmd = ['samtools', 'head', incram]
+    headers = sb.run(head_cmd, check=True, capture_output=True, text=True).stdout
+
+    newhdr_file = os.path.join(os.environ['BATCH_TMPDIR'], 'tmp.hdr')
+    with open(newhdr_file, 'w') as newhdr:
+        for line in headers.splitlines():
+            pg_line_count = 0
+            if line.startswith('@RG'):
+                new_line = line.replace(header['ID'], sgid)
+                print(new_line, file=newhdr)
+            elif line.startswith('@PG') and pg_line_count < 1:
+                new_line = line.replace(header['ID'], sgid)
+                print(line, file=newhdr)
+                pg_line_count += 1      
+            else:
+                print(line, file=newhdr)
+
+    if dry_run:
+        print(f'{incram} original header sequencing group ID: {header["ID"]}')
+        print(f'Would rewrite it to {outcram} with headers:')
+        with open(newhdr_file) as fp:
+            print(fp.read())
+        return {}
+
+    sb.run(['samtools', 'reheader', '--no-PG', '--in-place', newhdr_file, incram], check=True)
+    os.rename(incram, outcram)
+    sb.run(['samtools', 'index', '-o', outcrai, outcram], check=True)
+
+    new_header_sgid = extract_header_sgid(outcram)
+    print(f'{outcram}: reheadered: {new_header_sgid}')
+
+    return {
+        'cram_size': os.stat(outcram).st_size,
+    }
+
+
+def do_metamist_update(dataset, sequencing_type, seqgroup, oldpath, newpath, result):
+    aapi = AnalysisApi()
+
+    analysis = models.Analysis(
+        type='cram',
+        status=models.AnalysisStatus('completed'),
+        output=str(newpath),
+        sequencing_group_ids=[seqgroup],
+        meta={
+            'sequencing_type': sequencing_type,
+            'size': result['cram_size'],
+            'source': f'Reheadered from {oldpath}',
+        },
+    )
+    aid = aapi.create_analysis(dataset, analysis)
+    print(f'Created Analysis(id={aid}, output={newpath}) in {dataset}')
+
+
+@click.command()
+@click.option('--sequencing-groups', multiple=True, help='Sequencing group ID and name')
+@click.option('--dry-run', is_flag=True, help='Display information only without making changes')
+def main(
+    sequencing_groups: list[str],
+    dry_run: bool,
+):
+    """
+    This script uses the usual config entries (workflow.dataset, .access_level, .sequencing_type
+    and images.samtools) to check the CRAM headers for a list of sequencing groups, reheadering and
+    renaming the files with the correct sequencing group.
+    """
+    config = get_config(True)
+
+    dataset = config['workflow']['dataset']
+    if config['workflow']['access_level'] == 'test' and not dataset.endswith('-test'):
+        dataset = f'{dataset}-test'
+
+    print(f'Finding CRAMs for {len(sequencing_groups)} sequencing groups from {dataset} in database')
+    cram_list = query_metamist(dataset, sequencing_groups)
+
+    print(f'Total CRAM file entries found: {len(cram_list)}')
+
+    sequencing_type = config['workflow']['sequencing_type']
+
+    reheader_list = []
+    for sgid, fname in cram_list.items():
+        if fname.endswith(f'{sgid}.cram'):
+            continue
+        
+        path = to_path(fname)
+        reheadered_path = path.parent / f'{sgid}.cram'
+
+        if not path.exists():
+            print(f'{fname}: file does not exist')
+        elif reheadered_path.exists():
+            print(f'{reheadered_path}: reheadered file already exists')
+        else:
+            reheader_list.append((path, reheadered_path, path.stat().st_size))
+
+    if len(reheader_list) == 0:
+        sys.exit('No CRAMs to be reheadered!')
+
+    print(f'CRAM files to be reheadered: {len(reheader_list)}')
+
+    b = get_batch(f'Reheader CRAMs in {dataset}')
+
+    for path, newpath, filesize in reheader_list:
+        j = b.new_python_job(f'Reheader {path}')
+        j.image(image_path('samtools'))
+        j.storage(filesize * 1.2)  # Allow some extra space for index file, references, etc
+
+        j_result = j.call(do_reheader,
+                          dry_run, reheadered_path.stem,
+                          b.read_input(str(path)), j.out_cram, j.out_crai)
+
+        assert isinstance(j.out_cram, JobResourceFile)
+        assert isinstance(j.out_crai, JobResourceFile)
+        j.out_cram.add_extension('.cram')
+        j.out_crai.add_extension('.cram.crai')
+
+        if not dry_run:
+            b.write_output(j.out_cram, str(newpath))
+            b.write_output(j.out_crai, str(newpath.with_suffix('.cram.crai')))
+
+        print(f'Added reheader job for {path}')
+
+        if not dry_run:
+            db_j = b.new_python_job(f'Update metamist for {newpath}')
+            db_j.image(config['workflow']['driver_image'])
+
+            db_j.call(do_metamist_update,
+                      dataset, sequencing_type, reheadered_path.stem, str(path), str(newpath), j_result)
+
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter  # click will add the arguments

--- a/scripts/fix_rg_pg_header_sg_ids.py
+++ b/scripts/fix_rg_pg_header_sg_ids.py
@@ -159,8 +159,7 @@ def main(
         dataset = f'{dataset}-test'
 
     print(f'Finding CRAMs for {len(sequencing_groups)} sequencing groups from {dataset} in database')
-    # cram_list = query_metamist(dataset, sequencing_groups)
-    cram_list = {'CPG296947': 'gs://cpg-flinders-ophthal-test/exome/cram/CPG270371.cram'}
+    cram_list = query_metamist(dataset, sequencing_groups)
 
     print(f'Total CRAM file entries found: {len(cram_list)}')
 
@@ -208,12 +207,12 @@ def main(
 
         print(f'Added reheader job for {path}')
 
-        # if not dry_run:
-        #     db_j = b.new_python_job(f'Update metamist for {newpath}')
-        #     db_j.image(config['workflow']['driver_image'])
+        if not dry_run:
+            db_j = b.new_python_job(f'Update metamist for {newpath}')
+            db_j.image(config['workflow']['driver_image'])
 
-        #     db_j.call(do_metamist_update,
-        #               dataset, sequencing_type, reheadered_path.stem, str(path), str(newpath), j_result)
+            db_j.call(do_metamist_update,
+                      dataset, sequencing_type, reheadered_path.stem, str(path), str(newpath), j_result)
 
     b.run(wait=False)
 

--- a/scripts/fix_rg_pg_header_sg_ids.py
+++ b/scripts/fix_rg_pg_header_sg_ids.py
@@ -161,7 +161,8 @@ def main(
         dataset = f'{dataset}-test'
 
     print(f'Finding CRAMs for {len(sequencing_groups)} sequencing groups from {dataset} in database')
-    cram_list = query_metamist(dataset, sequencing_groups)
+    # cram_list = query_metamist(dataset, sequencing_groups)
+    cram_list = {'CPG296947': 'gs://cpg-flinders-ophthal-test/exome/cram/CPG270371.cram'}
 
     print(f'Total CRAM file entries found: {len(cram_list)}')
 
@@ -195,7 +196,7 @@ def main(
         j.storage(filesize * 1.2)  # Allow some extra space for index file, references, etc
 
         j_result = j.call(do_reheader,
-                          dry_run, reheadered_path.stem,
+                          dry_run, newpath.stem,
                           b.read_input(str(path)), j.out_cram, j.out_crai)
 
         assert isinstance(j.out_cram, JobResourceFile)
@@ -209,12 +210,12 @@ def main(
 
         print(f'Added reheader job for {path}')
 
-        if not dry_run:
-            db_j = b.new_python_job(f'Update metamist for {newpath}')
-            db_j.image(config['workflow']['driver_image'])
+        # if not dry_run:
+        #     db_j = b.new_python_job(f'Update metamist for {newpath}')
+        #     db_j.image(config['workflow']['driver_image'])
 
-            db_j.call(do_metamist_update,
-                      dataset, sequencing_type, reheadered_path.stem, str(path), str(newpath), j_result)
+        #     db_j.call(do_metamist_update,
+        #               dataset, sequencing_type, reheadered_path.stem, str(path), str(newpath), j_result)
 
     b.run(wait=False)
 

--- a/scripts/fix_rg_pg_header_sg_ids.py
+++ b/scripts/fix_rg_pg_header_sg_ids.py
@@ -93,15 +93,15 @@ def do_reheader(dry_run, sgid, incram, outcram, outcrai):
 
     newhdr_file = os.path.join(os.environ['BATCH_TMPDIR'], 'tmp.hdr')
     with open(newhdr_file, 'w') as newhdr:
+        pg_line_count = 0
         for line in headers.splitlines():
-            pg_line_count = 0
             if line.startswith('@RG'):
                 new_line = line.replace(header['ID'], sgid)
                 print(new_line, file=newhdr)
             elif line.startswith('@PG') and pg_line_count < 1:
                 new_line = line.replace(header['ID'], sgid)
                 print(line, file=newhdr)
-                pg_line_count += 1      
+                pg_line_count += 1
             else:
                 print(line, file=newhdr)
 

--- a/scripts/fix_rg_pg_header_sg_ids.py
+++ b/scripts/fix_rg_pg_header_sg_ids.py
@@ -93,15 +93,13 @@ def do_reheader(dry_run, sgid, incram, outcram, outcrai):
 
     newhdr_file = os.path.join(os.environ['BATCH_TMPDIR'], 'tmp.hdr')
     with open(newhdr_file, 'w') as newhdr:
-        pg_line_count = 0
         for line in headers.splitlines():
             if line.startswith('@RG'):
                 new_line = line.replace(header['ID'], sgid)
                 print(new_line, file=newhdr)
-            elif line.startswith('@PG') and pg_line_count < 1:
+            elif line.startswith('@PG'):
                 new_line = line.replace(header['ID'], sgid)
-                print(line, file=newhdr)
-                pg_line_count += 1
+                print(new_line, file=newhdr)
             else:
                 print(line, file=newhdr)
 


### PR DESCRIPTION
This script heavily adapts the other re-headering script in this directory: https://github.com/populationgenomics/production-pipelines/blob/main/scripts/fix_sq_headers.py 

The goal of this script is to address the discrepancy between the Metamist sequencing group IDs and the IDs found in the headers for the CRAMs of those sequencing groups. See [this seqr-private issue](https://github.com/populationgenomics/seqr-private/issues/120) for some examples.

Consider the second last entry from the table in the issue linked above. It's SG ID is CPG29XXXX, but it's CRAM analysis has `output = "gs://cpg-dataset-main/exome/cram/CPG27XXXX.cram"`. I've copied the CRAM into the test bucket for ease of access and testing. 

We can see the incorrect sequencing group ID is used in the filename, and checking the CRAM headers we see it's there too:
`samtools view -H gs://cpg-dataset-test/exome/cram/CPG27XXXX.cram`
```
...
@SQ	SN:HLA-DRB1*16:02:01	LN:11005	M5:c3ea0b1e57d95699eb3e5fa5185a3ded	UR:/io/batch/04c297/inputs/6sCPR/Homo_sapiens_assembly38_masked.fasta
@RG	ID:CPG27XXXX	LB:LB0	PL:PL0	PU:PU0	SM:CPG27XXXX
@PG	ID: DRAGEN-OS	VN:0.2020.08.19	CL:dragen-os -r /io/batch/04c297/inputs/7vssB -1 /io/batch/04c297/R1.fq.gz -2 /io/batch/04c297/R2.fq.gz --RGID CPG27XXXX --RGSM CPG27XXXX
@PG	ID:samtools	PN:samtools	PP: DRAGEN-OS	VN:1.16.1	CL:samtools sort -@5 -T /io/batch/04c297/samtools-sort-tmp -Obam
...
```

The incorrect SG ID can be seen on the `@RG` line and the first `@PG` line. This script finds these lines, validates they are all the same incorrect ID, and writes a new cram with the IDs replaced in these lines of the header.

The re-headered CRAM is saved with the correct SG ID as its filename, and the related Metamist analysis entry will be updated with the new path and meta field noting the reheader activity. 
`samtools view -H gs://cpg-dataset-test/exome/cram/CPG29XXXX.cram`
```
...
@SQ	SN:HLA-DRB1*16:02:01	LN:11005	M5:c3ea0b1e57d95699eb3e5fa5185a3ded	UR:/io/batch/04c297/inputs/6sCPR/Homo_sapiens_assembly38_masked.fasta
@RG	ID:CPG29XXXX	LB:LB0	PL:PL0	PU:PU0	SM:CPG29XXXX
@PG	ID: DRAGEN-OS	VN:0.2020.08.19	CL:dragen-os -r /io/batch/04c297/inputs/7vssB -1 /io/batch/04c297/R1.fq.gz -2 /io/batch/04c297/R2.fq.gz --RGID CPG29XXXX --RGSM CPG29XXXX
@PG	ID:samtools	PN:samtools	PP: DRAGEN-OS	VN:1.16.1	CL:samtools sort -@5 -T /io/batch/04c297/samtools-sort-tmp -Obam
...
```

The re-headered CRAM seems consistent with the old one:
`gsutil ls -l gs://cpg-dataset-test/exome/cram/CPG27XXXX.cram`
```
 846060145  2023-12-13T01:00:52Z  gs://cpg-dataset-test/exome/cram/CPG27XXXX.cram
TOTAL: 1 objects, 846060145 bytes (806.87 MiB)
```
`gsutil ls -l gs://cpg-dataset-test/exome/cram/CPG29XXXX.cram`
```
 846060145  2023-12-13T01:29:13Z  gs://cpg-dataset-test/exome/cram/CPG29XXXX.cram
TOTAL: 1 objects, 846060145 bytes (806.87 MiB)
```

Currently the conditions are quite rigid, the CRAM analysis `output` filename must not match the SG ID, and the incorrect SG ID in the header must be consistently incorrect across the 4 locations it's found in the header. 

I've also not tested this extensively. I copied the above cram into the test bucket and tested the script by setting the variable `cram_list = {'CPG29XXXX': 'gs://cpg-dataset-test/exome/cram/CPG27XXXX.cram'}`. I also commented out the Metamist update since this was a dummy example without a real analysis behind it. 