### PR TITLE
Alter max polling interval for Cromwell

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -118,6 +118,7 @@ def add_gatk_sv_jobs(
     sequencing_group_id: str | None = None,
     driver_image: str | None = None,
     labels: dict[str, str] | None = None,
+    cromwell_status_poll_interval: int = 60,
 ) -> list[Job]:
     """
     Generic function to add a job that would run one GATK-SV workflow.
@@ -173,6 +174,7 @@ def add_gatk_sv_jobs(
         driver_image=driver_image,
         copy_outputs_to_gcp=copy_outputs,
         labels=labels,
+        max_watch_poll_interval=cromwell_status_poll_interval,
     )
 
     copy_j = batch.new_job(f'{job_prefix}: copy outputs')

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -2,6 +2,7 @@
 single-sample components of the GATK SV workflow
 """
 import logging
+from random import randint
 from typing import Any
 
 from cpg_utils import Path
@@ -148,6 +149,7 @@ class GatherSampleEvidence(SequencingGroupStage):
             AR_GUID_NAME: try_get_ar_guid()
         }
 
+        # add some max-polling interval jitter for each sample
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=sequencing_group.dataset,
@@ -156,6 +158,7 @@ class GatherSampleEvidence(SequencingGroupStage):
             expected_out_dict=expected_d,
             sequencing_group_id=sequencing_group.id,
             labels=billing_labels,
+            cromwell_status_poll_interval=randint(300, 500),
         )
         return self.make_outputs(sequencing_group, data=expected_d, jobs=jobs)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -150,6 +150,10 @@ class GatherSampleEvidence(SequencingGroupStage):
         }
 
         # add some max-polling interval jitter for each sample
+        # cromwell_status_poll_interval is a number (int, seconds)
+        # this is used to determine how often to poll Cromwell for completion status
+        # we alter the per-sample maximum to be between 5 and 15 minutes for this
+        # long running job, so samples poll on different intervals, spreading load
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
             dataset=sequencing_group.dataset,

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -158,7 +158,7 @@ class GatherSampleEvidence(SequencingGroupStage):
             expected_out_dict=expected_d,
             sequencing_group_id=sequencing_group.id,
             labels=billing_labels,
-            cromwell_status_poll_interval=randint(300, 500),
+            cromwell_status_poll_interval=randint(300, 900),
         )
         return self.make_outputs(sequencing_group, data=expected_d, jobs=jobs)
 


### PR DESCRIPTION
Allows for an extended polling interval for Cromwell watcher jobs
Adds some per-sample jitter to the max interval so that we spread out the API burden

This task is particularly long running (~days) so this could be extended even further