### PR TITLE
Simplify Align.expected_outputs() CRAM path construction

### DIFF
--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -29,16 +29,13 @@ class Align(SequencingGroupStage):
         Stage is expected to generate a CRAM file and a corresponding index.
         """
         if sequencing_group.cram:
-            if sequencing_group.cram.index_path:
-                crai_path = sequencing_group.cram.index_path
-            else:
-                crai_path = None
+            cram_path = sequencing_group.cram
         else:
-            crai_path = sequencing_group.make_cram_path().index_path
+            cram_path = sequencing_group.make_cram_path()
 
         return {
-            'cram': sequencing_group.cram or sequencing_group.make_cram_path().path,
-            'crai': crai_path,
+            'cram': cram_path.path,
+            'crai': cram_path.index_path,
         }
 
     def queue_jobs(


### PR DESCRIPTION
Reported in #543, and in a similar `Align` inputs context from elsewhere, is the following failure:

```
  File "/production-pipelines/cpg_workflows/stages/stripy.py", line 76, in queue_jobs
    cram_path = inputs.as_path(sequencing_group, Align, 'cram')
  File "/production-pipelines/cpg_workflows/workflow.py", line 309, in as_path
    return res.as_path(key)
  File "/production-pipelines/cpg_workflows/workflow.py", line 178, in as_path
    raise ValueError(f'{res} is not a path object.')
ValueError: gs://cpg-perth-neuro-main/cram/CPG297432.cram is not a path object.
```

Messages like this are usually because `res` is a string rather than some kind of path object. However in this case (as revealed by studying the code or by `mypy`), the problem is that `sequencing_group.cram` is a `CramPath`, which — despite the name! — is not a `pathlib.Path`-like class.

Hence the minimal change to make this work would be:

```diff
-            'cram': sequencing_group.cram      or sequencing_group.make_cram_path().path,
+            'cram': sequencing_group.cram.path or sequencing_group.make_cram_path().path,
```

However in this PR I've instead taken the opportunity to refactor this to treat `cram` and `crai` together and only check whether `sg.cram` is present once, which is hopefully clearer.

We want `.path` and `.index_path` from `sequencing_group.cram` if it has been set; otherwise fall back to the generic `make_cram_path()`. Fixes #543.