### PR TITLE
Simplify Genotype.expected_outputs() GVCF path construction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.17
+current_version = 1.18.18
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.18.17
+  VERSION: 1.18.18
 
 jobs:
   docker:

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -33,15 +33,13 @@ class Genotype(SequencingGroupStage):
         Generate a GVCF and corresponding TBI index.
         """
         if sequencing_group.gvcf:
-            if sequencing_group.gvcf.tbi_path:
-                tbi_path = sequencing_group.gvcf.tbi_path
-            else:
-                tbi_path = None
+            gvcf_path = sequencing_group.gvcf
         else:
-            tbi_path = sequencing_group.make_gvcf_path().tbi_path
+            gvcf_path = sequencing_group.make_gvcf_path()
+
         return {
-            'gvcf': sequencing_group.gvcf or sequencing_group.make_gvcf_path().path,
-            'tbi': tbi_path,
+            'gvcf': gvcf_path.path,
+            'tbi': gvcf_path.tbi_path,
         }
 
     def queue_jobs(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.17',
+    version='1.18.18',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
We now have batches failing with:

```
  File "/production-pipelines/cpg_workflows/stages/gvcf_qc.py", line 53, in queue_jobs
    gvcf_path = inputs.as_path(sequencing_group, Genotype, 'gvcf')
  File "/production-pipelines/cpg_workflows/workflow.py", line 308, in as_path
    return res.as_path(key)
  File "/production-pipelines/cpg_workflows/workflow.py", line 177, in as_path
    raise ValueError(f'{res} is not a path object.')
ValueError: gs://cpg-tob-wgs-main/gvcf/nagim/CPG66902.g.vcf.gz is not a path object.
```

Messages like this are usually because `res` is a string rather than some kind of path object. However in this case (as revealed by studying the code or by mypy), the problem is that `sequencing_group.gvcf` is a `GvcfPath`, which — despite the name! — is not a `pathlib.Path`-like class.

So we can fix this similarly to what PR #552 did for CRAMs: We want `.path` and `.tbi_path` from `sequencing_group.gvcf` if it has been set; otherwise fall back to the generic `make_gvcf_path()`.