### PR TITLE
Extend minimum status polling interval

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.16
+current_version = 1.18.17
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.18.16
+  VERSION: 1.18.17
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -118,7 +118,8 @@ def add_gatk_sv_jobs(
     sequencing_group_id: str | None = None,
     driver_image: str | None = None,
     labels: dict[str, str] | None = None,
-    cromwell_status_poll_interval: int = 60,
+    cromwell_status_min_poll_interval: int = 30,
+    cromwell_status_max_poll_interval: int = 100,
 ) -> list[Job]:
     """
     Generic function to add a job that would run one GATK-SV workflow.
@@ -174,7 +175,8 @@ def add_gatk_sv_jobs(
         driver_image=driver_image,
         copy_outputs_to_gcp=copy_outputs,
         labels=labels,
-        max_watch_poll_interval=cromwell_status_poll_interval,
+        min_watch_poll_interval=cromwell_status_min_poll_interval,
+        max_watch_poll_interval=cromwell_status_max_poll_interval,
     )
 
     copy_j = batch.new_job(f'{job_prefix}: copy outputs')

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -152,7 +152,7 @@ class GatherSampleEvidence(SequencingGroupStage):
         # add some max-polling interval jitter for each sample
         # cromwell_status_poll_interval is a number (int, seconds)
         # this is used to determine how often to poll Cromwell for completion status
-        # we alter the per-sample maximum to be between 5 and 15 minutes for this
+        # we alter the per-sample maximum to be between 5 and 30 minutes for this
         # long running job, so samples poll on different intervals, spreading load
         jobs = add_gatk_sv_jobs(
             batch=get_batch(),
@@ -162,7 +162,8 @@ class GatherSampleEvidence(SequencingGroupStage):
             expected_out_dict=expected_d,
             sequencing_group_id=sequencing_group.id,
             labels=billing_labels,
-            cromwell_status_poll_interval=randint(300, 900),
+            cromwell_status_min_poll_interval=randint(30, 180),
+            cromwell_status_max_poll_interval=randint(300, 1800),
         )
         return self.make_outputs(sequencing_group, data=expected_d, jobs=jobs)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'cpg-utils>=4.18.3',
         'cyvcf2==0.30.18',
-        'analysis-runner>=2.41.2',
+        'analysis-runner>=2.43.3',
         'hail!=0.2.120',  # Temporarily work around hail-is/hail#13337
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.16',
+    version='1.18.17',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Updates the minimum frequency for polling the Cromwell API for success, which should lower the instant burden when firing off a large batch of samples

relates to https://github.com/populationgenomics/analysis-runner/pull/660