### PR TITLE
gCNV sub-pr 4

### DIFF
--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -12,3 +12,9 @@ gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:202
 gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
 sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+
+[references.gatk_sv]
+# a couple of annotation arguments are not files
+# github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
+external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
+external_af_ref_bed_prefix = 'gnomad_v2.1_sv'

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -20,16 +20,22 @@ def prepare_intervals(
     job_attrs: dict[str, str],
     output_paths: dict[str, Path],
 ) -> list[Job]:
-    j = b.new_job('Prepare intervals', job_attrs | {
-        'tool': 'gatk PreprocessIntervals/AnnotateIntervals',
-    })
+    j = b.new_job(
+        'Prepare intervals',
+        job_attrs
+        | {
+            'tool': 'gatk PreprocessIntervals/AnnotateIntervals',
+        },
+    )
     j.image(image_path('gatk_gcnv'))
 
     sequencing_type = get_config()['workflow']['sequencing_type']
     reference = fasta_res_group(b)
 
     exclude_intervals = get_config()['workflow'].get('exclude_intervals', [])
-    exclude_intervals_args = ' '.join([f'--exclude-intervals {i}' for i in exclude_intervals])
+    exclude_intervals_args = ' '.join(
+        [f'--exclude-intervals {i}' for i in exclude_intervals]
+    )
 
     if sequencing_type == 'exome':
         intervals = b.read_input(get_config()['workflow'].get('intervals_path'))
@@ -77,15 +83,19 @@ def collect_read_counts(
     job_attrs: dict[str, str],
     output_base_path: Path,
 ) -> list[Job]:
-    j = b.new_job('Collect gCNV read counts', job_attrs | {'tool': 'gatk CollectReadCounts'})
+    j = b.new_job(
+        'Collect gCNV read counts', job_attrs | {'tool': 'gatk CollectReadCounts'}
+    )
     j.image(image_path('gatk_gcnv'))
 
     reference = fasta_res_group(b)
 
-    j.declare_resource_group(counts={
-        'counts.tsv.gz': '{root}.counts.tsv.gz',
-        'counts.tsv.gz.tbi': '{root}.counts.tsv.gz.tbi',
-    })
+    j.declare_resource_group(
+        counts={
+            'counts.tsv.gz': '{root}.counts.tsv.gz',
+            'counts.tsv.gz.tbi': '{root}.counts.tsv.gz.tbi',
+        }
+    )
     assert isinstance(j.counts, ResourceGroup)
 
     cmd = f"""
@@ -107,10 +117,12 @@ def collect_read_counts(
 def _counts_input_args(b: hb.Batch, counts_paths: Iterable[Path]) -> str:
     args = ''
     for f in counts_paths:
-        counts = b.read_input_group(**{
-            'counts.tsv.gz': str(f),
-            'counts.tsv.gz.tbi': str(f) + '.tbi',
-        })
+        counts = b.read_input_group(
+            **{
+                'counts.tsv.gz': str(f),
+                'counts.tsv.gz.tbi': str(f) + '.tbi',
+            }
+        )
         args += f' --input {counts["counts.tsv.gz"]}'
 
     return args
@@ -125,9 +137,13 @@ def filter_and_determine_ploidy(
     job_attrs: dict[str, str],
     output_paths: dict[str, Path],
 ) -> list[Job]:
-    j = b.new_job('Filter intervals and determine ploidy', job_attrs | {
-        'tool': 'gatk FilterIntervals/DetermineGermlineContigPloidy',
-    })
+    j = b.new_job(
+        'Filter intervals and determine ploidy',
+        job_attrs
+        | {
+            'tool': 'gatk FilterIntervals/DetermineGermlineContigPloidy',
+        },
+    )
     j.image(image_path('gatk_gcnv'))
 
     counts_input_args = _counts_input_args(b, counts_paths)
@@ -215,10 +231,14 @@ def shard_gcnv(
         if can_reuse(output_paths[name]):
             continue
 
-        j = b.new_job('Call germline CNVs', job_attrs | {
-            'tool': 'gatk GermlineCNVCaller',
-            'part': f'shard {i} of {n}',
-        })
+        j = b.new_job(
+            'Call germline CNVs',
+            job_attrs
+            | {
+                'tool': 'gatk GermlineCNVCaller',
+                'part': f'shard {i} of {n}',
+            },
+        )
         j.image(image_path('gatk_gcnv'))
         j.memory('16Gi')  # TODO revisit limits
 
@@ -257,9 +277,13 @@ def postprocess_calls(
     job_attrs: dict[str, str],
     output_prefix: str,
 ) -> list[Job]:
-    j = b.new_job('Postprocess gCNV calls', job_attrs | {
-        'tool': 'gatk PostprocessGermlineCNVCalls',
-    })
+    j = b.new_job(
+        'Postprocess gCNV calls',
+        job_attrs
+        | {
+            'tool': 'gatk PostprocessGermlineCNVCalls',
+        },
+    )
     j.image(image_path('gatk_gcnv'))
     j.storage('12Gi')  # TODO revisit limits
 
@@ -277,7 +301,9 @@ def postprocess_calls(
         calls_shard_args += f' --calls-shard-path $BATCH_TMPDIR/{name}-calls'
 
     allosomal_contigs = get_config()['workflow'].get('allosomal_contigs', [])
-    allosomal_contigs_args = ' '.join([f'--allosomal-contig {c}' for c in allosomal_contigs])
+    allosomal_contigs_args = ' '.join(
+        [f'--allosomal-contig {c}' for c in allosomal_contigs]
+    )
 
     # declare all output files in advance
     j.declare_resource_group(
@@ -361,7 +387,11 @@ def fix_intervals_vcf(
 
 
 def merge_calls(
-    b: hb.Batch, sg_vcfs: list[str], docker_image: str, job_attrs: dict[str, str], output_path: Path
+    b: hb.Batch,
+    sg_vcfs: list[str],
+    docker_image: str,
+    job_attrs: dict[str, str],
+    output_path: Path,
 ):
     """
     This job will run a fast simple merge on per-SGID call files
@@ -411,7 +441,8 @@ def merge_calls(
     j.command(
         f'bcftools merge {" ".join(batch_vcfs)} -Oz -o temp.vcf.bgz --threads 4 -m all -0'
     )
-    j.command(fr"""
+    j.command(
+        fr"""
     python <<CODE
 import gzip
 headers = []
@@ -439,7 +470,8 @@ with open('temp.vcf', 'w') as f:
     f.writelines(headers)
     f.writelines(others)
 CODE
-    """)
+    """
+    )
     j.command(f'bgzip -c temp.vcf > {j.output["vcf.bgz"]}')
     j.command(f'tabix {j.output["vcf.bgz"]}')
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -239,3 +239,57 @@ def make_combined_ped(cohort: Cohort, prefix: Path) -> Path:
         with to_path(conf_ped_path).open() as f:
             out.write(f.read())
     return combined_ped_path
+
+
+def queue_annotate_sv_jobs(
+    batch,
+    cohort,
+    cohort_prefix: Path,
+    input_vcf: Path,
+    outputs: dict,
+    labels: dict[str, str] | None = None,
+) -> list[Job] | Job | None:
+    """
+    Helper function to queue jobs for SV annotation
+    Enables common access to the same Annotation WDL for CNV & SV
+    """
+    input_dict: dict[str, Any] = {
+        'vcf': input_vcf,
+        'prefix': cohort.name,
+        'ped_file': make_combined_ped(cohort, cohort_prefix),
+        'sv_per_shard': 5000,
+        'population': get_config()['references']['gatk_sv'].get(
+            'external_af_population'
+        ),
+        'ref_prefix': get_config()['references']['gatk_sv'].get(
+            'external_af_ref_bed_prefix'
+        ),
+        'use_hail': False,
+    }
+
+    input_dict |= get_references(
+        [
+            'noncoding_bed',
+            'protein_coding_gtf',
+            {'ref_bed': 'external_af_ref_bed'},
+            {'contig_list': 'primary_contigs_list'},
+        ]
+    )
+
+    # images!
+    input_dict |= get_images(
+        [
+            'sv_pipeline_docker',
+            'sv_base_mini_docker',
+            'gatk_docker',
+        ]
+    )
+    jobs = add_gatk_sv_jobs(
+        batch=batch,
+        dataset=cohort.analysis_dataset,
+        wfl_name='AnnotateVcf',
+        input_dict=input_dict,
+        expected_out_dict=outputs,
+        labels=labels,
+    )
+    return jobs

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -24,6 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     get_images,
     get_references,
     make_combined_ped,
+    queue_annotate_sv_jobs
 )
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.workflow import (
@@ -547,46 +548,20 @@ class AnnotateVcf(CohortStage):
         configure and queue jobs for SV annotation
         passing the VCF Index has become implicit, which may be a problem for us
         """
-        input_dict: dict[str, Any] = {
-            'vcf': inputs.as_dict(cohort, FilterGenotypes)['filtered_vcf'],
-            'prefix': cohort.name,
-            'ped_file': make_combined_ped(cohort, self.prefix),
-            'sv_per_shard': 5000,
-            'population': get_config()['references']['gatk_sv'].get(
-                'external_af_population'
-            ),
-            'ref_prefix': get_config()['references']['gatk_sv'].get(
-                'external_af_ref_bed_prefix'
-            ),
-            'use_hail': False,
+        expected_out = self.expected_outputs(cohort)
+        billing_labels = {
+            'stage': self.name.lower(),
+            AR_GUID_NAME: try_get_ar_guid(),
         }
-
-        input_dict |= get_references(
-            [
-                'noncoding_bed',
-                'protein_coding_gtf',
-                {'ref_bed': 'external_af_ref_bed'},
-                {'contig_list': 'primary_contigs_list'},
-            ]
-        )
-
-        # images!
-        input_dict |= get_images(
-            ['sv_pipeline_docker', 'sv_base_mini_docker', 'gatk_docker']
-        )
-        expected_d = self.expected_outputs(cohort)
-
-        billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
-
-        jobs = add_gatk_sv_jobs(
+        job_or_none = queue_annotate_sv_jobs(
             batch=get_batch(),
-            dataset=cohort.analysis_dataset,
-            wfl_name=self.name,
-            input_dict=input_dict,
-            expected_out_dict=expected_d,
+            cohort=cohort,
+            cohort_prefix=self.prefix,
+            input_vcf=inputs.as_dict(cohort, MakeCohortVcf)['vcf'],
+            outputs=expected_out,
             labels=billing_labels,
         )
-        return self.make_outputs(cohort, data=expected_d, jobs=jobs)
+        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
 
 
 @stage(required_stages=AnnotateVcf)

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     get_images,
     get_references,
     make_combined_ped,
-    queue_annotate_sv_jobs
+    queue_annotate_sv_jobs,
 )
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.workflow import (

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -232,6 +232,7 @@ class FastCombineGCNVs(CohortStage):
         )
         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
 
+
 @stage(
     required_stages=FastCombineGCNVs,
     analysis_type='sv',

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -3,10 +3,13 @@ Stages that implement GATK-gCNV.
 """
 
 from cpg_utils import Path
-from cpg_utils.config import get_config
+from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_images
 from cpg_workflows.jobs import gcnv
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
+    get_images,
+    queue_annotate_sv_jobs
+)
 from cpg_workflows.targets import SequencingGroup, Cohort
 from cpg_workflows.workflow import (
     stage,
@@ -15,6 +18,15 @@ from cpg_workflows.workflow import (
     StageInput,
     StageOutput
 )
+
+
+def _gcnv_annotated_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, str]:
+    """
+    Callable, adds custom analysis object meta attribute
+    """
+    return {'type': 'gCNV-annotated'}
 
 
 @stage
@@ -219,3 +231,58 @@ class FastCombineGCNVs(CohortStage):
             output_path=outputs['combined_calls'],
         )
         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
+
+@stage(
+    required_stages=FastCombineGCNVs,
+    analysis_type='sv',
+    analysis_keys=['annotated_vcf'],
+    update_analysis_meta=_gcnv_annotated_meta,
+)
+class AnnotateCNV(CohortStage):
+    """
+    Smaller, direct annotation using SvAnnotate
+    Add annotations, such as the inferred function and allele frequencies of variants,
+    to final VCF.
+
+    This is a full clone of the GATK-SV pipeline Cromwell stage, but use on a slightly
+    different output. Trying to work out the best way to handle this through inheritance
+
+    Annotations methods include:
+    * Functional annotation - annotate SVs with inferred functional consequence on
+      protein-coding regions, regulatory regions such as UTR and promoters, and other
+      non-coding elements.
+    * Allele frequency annotation - annotate SVs with their allele frequencies across
+      all samples, and samples of specific sex, as well as specific subpopulations.
+    * Allele Frequency annotation with external callset - annotate SVs with the allele
+      frequencies of their overlapping SVs in another callset, e.g. gnomad SV callset.
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> dict:
+        return {
+            'annotated_vcf': self.prefix / 'unfiltered_annotated.vcf.bgz',
+            'annotated_vcf_index': self.prefix / 'unfiltered_annotated.vcf.bgz.tbi',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        configure and queue jobs for SV annotation
+        passing the VCF Index has become implicit, which may be a problem for us
+        """
+        expected_out = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            AR_GUID_NAME: try_get_ar_guid(),
+        }
+
+        job_or_none = queue_annotate_sv_jobs(
+            batch=get_batch(),
+            cohort=cohort,
+            cohort_prefix=self.prefix,
+            input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)[
+                'combined_calls'
+            ],
+            outputs=expected_out,
+            labels=billing_labels,
+        )
+        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import GermlineCNVCalls
+from cpg_workflows.stages.gcnv import AnnotateCNV, AnnotateCNVVcfWithStrvctvre, GermlineCNVCalls, FastCombineGCNVs
 from cpg_workflows.stages.aip import GeneratePanelData, QueryPanelapp, RunHailFiltering, ValidateMOI, CreateAIPHTML
 from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.stages.happy_validation import (
@@ -55,7 +55,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
         MergeBatchSites
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
-    'gcnv': [GermlineCNVCalls],
+    'gcnv': [GermlineCNVCalls, FastCombineGCNVs, AnnotateCNV, AnnotateCNVVcfWithStrvctvre],
 }
 
 


### PR DESCRIPTION
Adds the AnnotateVcf stage into the gCNV pipeline

- Pulls out the GATK-SV call to `AnnotateVcf.wdl` and places it in gatk_sv_common
- Replaces the GATK-SV call with a call on the common method
- Adds a gCNV call to the common method
- Adds required elements to the gCNV workflow configuration file
- Tags the annotation run with the relevant AR-GUID for billing purposes