### PR TITLE
gCNV sub-pr 3

### DIFF
--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -8,4 +8,7 @@ ploidy_priors = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/re
 allosomal_contigs = ['chrX', 'chrY']
 
 [images]
+gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
 gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
+sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
+sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -12,3 +12,9 @@ gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:202
 gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
 sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+
+[references.gatk_sv]
+# a couple of annotation arguments are not files
+# github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
+external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
+external_af_ref_bed_prefix = 'gnomad_v2.1_sv'

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -359,3 +359,91 @@ def fix_intervals_vcf(
 
     return reheader_job
 
+
+def merge_calls(
+    b: hb.Batch, sg_vcfs: list[str], docker_image: str, job_attrs: dict[str, str], output_path: Path
+):
+    """
+    This job will run a fast simple merge on per-SGID call files
+    It then throws in a python script to add in two additional header lines
+    and edit the SVLEN and SVTYPE attributes into each row
+
+    Args:
+        b (batch):
+        sg_vcfs (list[str]): paths to all individual VCFs
+        docker_image (str): docker image to use
+        job_attrs (dict): any params to atach to the job
+        output_path (Path): path to the final merged VCF
+    """
+
+    if can_reuse(output_path):
+        return None
+
+    assert sg_vcfs, 'No VCFs to merge'
+
+    j = b.new_job('Merge gCNV calls', job_attrs | {'tool': 'bcftools'})
+    j.image(docker_image)
+
+    # this should be made reactive, in case we scale past 10GB
+    j.storage('10Gi')
+
+    batch_vcfs = []
+    for each_vcf in sg_vcfs:
+        batch_vcfs.append(
+            b.read_input_group(
+                **{
+                    'vcf.gz': each_vcf,
+                    'vcf.gz.tbi': f'{each_vcf}.tbi',
+                }
+            )['vcf.gz']
+        )
+
+    j.declare_resource_group(
+        output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
+    )
+
+    # option breakdown:
+    # -Oz: bgzip output
+    # -o: output file
+    # --threads: number of threads to use
+    # -m: merge strategy
+    # -0: compression level
+    j.command(
+        f'bcftools merge {" ".join(batch_vcfs)} -Oz -o temp.vcf.bgz --threads 4 -m all -0'
+    )
+    j.command(fr"""
+    python <<CODE
+import gzip
+headers = []
+others = []
+with gzip.open('temp.vcf.bgz', 'rt') as f:
+    for line in f:
+        if line.startswith('#'):
+            headers.append(line)
+            if line.startswith('##INFO=<ID=EN'):
+                headers.extend([
+                    '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="SV Type">\n',
+                    '##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="SV Length">\n']
+                )
+        else:
+            l_split = line.split('\t')
+            original_end = l_split[7]
+            end_int = int(l_split[7].removeprefix('END='))
+            l_split[7] = 'SVTYPE=CNV;SVLEN={{length}};{{end}}'.format(
+                length=str(end_int - int(l_split[1])),
+                end=original_end
+            )
+            line = '\t'.join(l_split)
+            others.append(line)
+with open('temp.vcf', 'w') as f:
+    f.writelines(headers)
+    f.writelines(others)
+CODE
+    """)
+    j.command(f'bgzip -c temp.vcf > {j.output["vcf.bgz"]}')
+    j.command(f'tabix {j.output["vcf.bgz"]}')
+
+    # get the output root to write to
+    output_no_suffix = str(output_path).removesuffix('.vcf.bgz')
+    b.write_output(j.output, output_no_suffix)
+    return j

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -429,7 +429,9 @@ with gzip.open('temp.vcf.bgz', 'rt') as f:
             l_split = line.split('\t')
             original_end = l_split[7]
             end_int = int(l_split[7].removeprefix('END='))
-            l_split[7] = 'SVTYPE=CNV;SVLEN={{length}};{{end}}'.format(
+            alt_allele = l_split[4][1:-1]
+            l_split[7] = 'SVTYPE={{alt}};SVLEN={{length}};{{end}}'.format(
+                alt=alt_allele,
                 length=str(end_int - int(l_split[1])),
                 end=original_end
             )

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -239,3 +239,57 @@ def make_combined_ped(cohort: Cohort, prefix: Path) -> Path:
         with to_path(conf_ped_path).open() as f:
             out.write(f.read())
     return combined_ped_path
+
+
+def queue_annotate_sv_jobs(
+    batch,
+    cohort,
+    cohort_prefix: Path,
+    input_vcf: Path,
+    outputs: dict,
+    labels: dict[str, str] | None = None,
+) -> list[Job] | Job | None:
+    """
+    Helper function to queue jobs for SV annotation
+    Enables common access to the same Annotation WDL for CNV & SV
+    """
+    input_dict: dict[str, Any] = {
+        'vcf': input_vcf,
+        'prefix': cohort.name,
+        'ped_file': make_combined_ped(cohort, cohort_prefix),
+        'sv_per_shard': 5000,
+        'population': get_config()['references']['gatk_sv'].get(
+            'external_af_population'
+        ),
+        'ref_prefix': get_config()['references']['gatk_sv'].get(
+            'external_af_ref_bed_prefix'
+        ),
+        'use_hail': False,
+    }
+
+    input_dict |= get_references(
+        [
+            'noncoding_bed',
+            'protein_coding_gtf',
+            {'ref_bed': 'external_af_ref_bed'},
+            {'contig_list': 'primary_contigs_list'},
+        ]
+    )
+
+    # images!
+    input_dict |= get_images(
+        [
+            'sv_pipeline_docker',
+            'sv_base_mini_docker',
+            'gatk_docker',
+        ]
+    )
+    jobs = add_gatk_sv_jobs(
+        batch=batch,
+        dataset=cohort.analysis_dataset,
+        wfl_name='AnnotateVcf',
+        input_dict=input_dict,
+        expected_out_dict=outputs,
+        labels=labels,
+    )
+    return jobs

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -24,6 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     get_images,
     get_references,
     make_combined_ped,
+    queue_annotate_sv_jobs,
 )
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.workflow import (
@@ -547,46 +548,20 @@ class AnnotateVcf(CohortStage):
         configure and queue jobs for SV annotation
         passing the VCF Index has become implicit, which may be a problem for us
         """
-        input_dict: dict[str, Any] = {
-            'vcf': inputs.as_dict(cohort, FilterGenotypes)['filtered_vcf'],
-            'prefix': cohort.name,
-            'ped_file': make_combined_ped(cohort, self.prefix),
-            'sv_per_shard': 5000,
-            'population': get_config()['references']['gatk_sv'].get(
-                'external_af_population'
-            ),
-            'ref_prefix': get_config()['references']['gatk_sv'].get(
-                'external_af_ref_bed_prefix'
-            ),
-            'use_hail': False,
+        expected_out = self.expected_outputs(cohort)
+        billing_labels = {
+            'stage': self.name.lower(),
+            AR_GUID_NAME: try_get_ar_guid(),
         }
-
-        input_dict |= get_references(
-            [
-                'noncoding_bed',
-                'protein_coding_gtf',
-                {'ref_bed': 'external_af_ref_bed'},
-                {'contig_list': 'primary_contigs_list'},
-            ]
-        )
-
-        # images!
-        input_dict |= get_images(
-            ['sv_pipeline_docker', 'sv_base_mini_docker', 'gatk_docker']
-        )
-        expected_d = self.expected_outputs(cohort)
-
-        billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
-
-        jobs = add_gatk_sv_jobs(
+        job_or_none = queue_annotate_sv_jobs(
             batch=get_batch(),
-            dataset=cohort.analysis_dataset,
-            wfl_name=self.name,
-            input_dict=input_dict,
-            expected_out_dict=expected_d,
+            cohort=cohort,
+            cohort_prefix=self.prefix,
+            input_vcf=inputs.as_dict(cohort, MakeCohortVcf)['vcf'],
+            outputs=expected_out,
             labels=billing_labels,
         )
-        return self.make_outputs(cohort, data=expected_d, jobs=jobs)
+        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
 
 
 @stage(required_stages=AnnotateVcf)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -3,18 +3,31 @@ Stages that implement GATK-gCNV.
 """
 
 from cpg_utils import Path
-from cpg_utils.config import get_config
-from cpg_utils.hail_batch import get_batch
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_images
+from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
+from cpg_utils.hail_batch import get_batch, image_path
 from cpg_workflows.jobs import gcnv
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
+    get_images,
+    get_references,
+    queue_annotate_sv_jobs,
+)
 from cpg_workflows.targets import SequencingGroup, Cohort
 from cpg_workflows.workflow import (
     stage,
     CohortStage,
     SequencingGroupStage,
     StageInput,
-    StageOutput
+    StageOutput,
 )
+
+
+def _gcnv_annotated_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, str]:
+    """
+    Callable, adds custom analysis object meta attribute
+    """
+    return {'type': 'gCNV-annotated'}
 
 
 @stage
@@ -27,7 +40,7 @@ class PrepareIntervals(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
             'preprocessed': self.prefix / f'{cohort.name}.preprocessed.interval_list',
-            'annotated':    self.prefix / f'{cohort.name}.annotated.tsv',
+            'annotated': self.prefix / f'{cohort.name}.annotated.tsv',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -49,11 +62,17 @@ class CollectReadCounts(SequencingGroupStage):
 
     def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
         return {
-            'counts': seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.counts.tsv.gz',
-            'index':  seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.counts.tsv.gz.tbi',
+            'counts': seqgroup.dataset.prefix()
+            / 'gcnv'
+            / f'{seqgroup.id}.counts.tsv.gz',
+            'index': seqgroup.dataset.prefix()
+            / 'gcnv'
+            / f'{seqgroup.id}.counts.tsv.gz.tbi',
         }
 
-    def queue_jobs(self, seqgroup: SequencingGroup, inputs: StageInput) -> StageOutput | None:
+    def queue_jobs(
+        self, seqgroup: SequencingGroup, inputs: StageInput
+    ) -> StageOutput | None:
         outputs = self.expected_outputs(seqgroup)
 
         if seqgroup.cram is None:
@@ -80,8 +99,8 @@ class DeterminePloidy(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
             'filtered': self.tmp_prefix / f'{cohort.name}.filtered.interval_list',
-            'calls':    self.tmp_prefix / f'{cohort.name}-ploidy-calls.tar.gz',
-            'model':    self.tmp_prefix / f'{cohort.name}-ploidy-model.tar.gz',
+            'calls': self.tmp_prefix / f'{cohort.name}-ploidy-calls.tar.gz',
+            'model': self.tmp_prefix / f'{cohort.name}-ploidy-model.tar.gz',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -135,11 +154,19 @@ class GermlineCNVCalls(SequencingGroupStage):
 
     def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
         return {
-            'intervals': seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.intervals.vcf.gz',
-            'intervals_index': seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.intervals.vcf.gz.tbi',
-            'segments':  seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.segments.vcf.gz',
-            'segments_index':  seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.segments.vcf.gz.tbi',
-            'ratios':    seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.ratios.tsv',
+            'intervals': seqgroup.dataset.prefix()
+            / 'gcnv'
+            / f'{seqgroup.id}.intervals.vcf.gz',
+            'intervals_index': seqgroup.dataset.prefix()
+            / 'gcnv'
+            / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'segments': seqgroup.dataset.prefix()
+            / 'gcnv'
+            / f'{seqgroup.id}.segments.vcf.gz',
+            'segments_index': seqgroup.dataset.prefix()
+            / 'gcnv'
+            / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'ratios': seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.ratios.tsv',
         }
 
     def queue_jobs(self, seqgroup: SequencingGroup, inputs: StageInput) -> StageOutput:
@@ -170,7 +197,8 @@ class PrepareVcfsForMerge(SequencingGroupStage):
     def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
         return {
             'fixed_intervals': self.prefix / f'{seqgroup.id}.fixed_intervals.vcf.bgz',
-            'fixed_intervals_index': self.prefix / f'{seqgroup.id}.fixed_intervals.vcf.bgz.tbi'
+            'fixed_intervals_index': self.prefix
+            / f'{seqgroup.id}.fixed_intervals.vcf.bgz.tbi',
         }
 
     def queue_jobs(
@@ -182,7 +210,7 @@ class PrepareVcfsForMerge(SequencingGroupStage):
             get_batch(),
             inputs.as_path(seqgroup, GermlineCNVCalls, 'intervals'),
             self.get_job_attrs(seqgroup),
-            output_path=outputs['fixed_intervals']
+            output_path=outputs['fixed_intervals'],
         )
         return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
 
@@ -219,3 +247,105 @@ class FastCombineGCNVs(CohortStage):
             output_path=outputs['combined_calls'],
         )
         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
+
+
+@stage(
+    required_stages=FastCombineGCNVs,
+    analysis_type='sv',
+    analysis_keys=['annotated_vcf'],
+    update_analysis_meta=_gcnv_annotated_meta,
+)
+class AnnotateCNV(CohortStage):
+    """
+    Smaller, direct annotation using SvAnnotate
+    Add annotations, such as the inferred function and allele frequencies of variants,
+    to final VCF.
+
+    This is a full clone of the GATK-SV pipeline Cromwell stage, but use on a slightly
+    different output. Trying to work out the best way to handle this through inheritance
+
+    Annotations methods include:
+    * Functional annotation - annotate SVs with inferred functional consequence on
+      protein-coding regions, regulatory regions such as UTR and promoters, and other
+      non-coding elements.
+    * Allele frequency annotation - annotate SVs with their allele frequencies across
+      all samples, and samples of specific sex, as well as specific subpopulations.
+    * Allele Frequency annotation with external callset - annotate SVs with the allele
+      frequencies of their overlapping SVs in another callset, e.g. gnomad SV callset.
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> dict:
+        return {
+            'annotated_vcf': self.prefix / 'unfiltered_annotated.vcf.bgz',
+            'annotated_vcf_index': self.prefix / 'unfiltered_annotated.vcf.bgz.tbi',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        configure and queue jobs for SV annotation
+        passing the VCF Index has become implicit, which may be a problem for us
+        """
+        expected_out = self.expected_outputs(cohort)
+
+        billing_labels = {
+            'stage': self.name.lower(),
+            AR_GUID_NAME: try_get_ar_guid(),
+        }
+
+        job_or_none = queue_annotate_sv_jobs(
+            batch=get_batch(),
+            cohort=cohort,
+            cohort_prefix=self.prefix,
+            input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)['combined_calls'],
+            outputs=expected_out,
+            labels=billing_labels,
+        )
+        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
+
+
+@stage(required_stages=AnnotateCNV)
+class AnnotateCNVVcfWithStrvctvre(CohortStage):
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        return {
+            'strvctvre_vcf': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz',
+            'strvctvre_vcf_index': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz.tbi',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        strv_job = get_batch().new_job(
+            'StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'}
+        )
+
+        strv_job.image(image_path('strvctvre'))
+        strv_job.storage('20Gi')
+
+        strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
+        phylop_in_batch = get_batch().read_input(strvctvre_phylop)
+
+        input_dict = inputs.as_dict(cohort, AnnotateCNV)
+        expected_d = self.expected_outputs(cohort)
+
+        # read vcf and index into the batch
+        input_vcf = get_batch().read_input_group(
+            vcf=str(input_dict['annotated_vcf']),
+            vcf_index=str(input_dict['annotated_vcf_index']),
+        )['vcf']
+
+        strv_job.declare_resource_group(
+            output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
+        )
+
+        # run strvctvre
+        strv_job.command(
+            f'python StrVCTVRE.py '
+            f'-i {input_vcf} '
+            f'-o {strv_job.output_vcf["vcf.gz"]} '
+            f'-f vcf '
+            f'-p {phylop_in_batch}'
+        )
+        strv_job.command(f'tabix {strv_job.output_vcf["vcf.gz"]}')
+
+        get_batch().write_output(
+            strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.gz', '')
+        )
+        return self.make_outputs(cohort, data=expected_d, jobs=strv_job)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import GermlineCNVCalls
+from cpg_workflows.stages.gcnv import AnnotateCNV, AnnotateCNVVcfWithStrvctvre, GermlineCNVCalls, FastCombineGCNVs
 from cpg_workflows.stages.aip import GeneratePanelData, QueryPanelapp, RunHailFiltering, ValidateMOI, CreateAIPHTML
 from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.stages.happy_validation import (
@@ -55,7 +55,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
         MergeBatchSites
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
-    'gcnv': [GermlineCNVCalls],
+    'gcnv': [GermlineCNVCalls, FastCombineGCNVs, AnnotateCNV, AnnotateCNVVcfWithStrvctvre],
 }
 
 


### PR DESCRIPTION
Adds the step for combining all single-sample intervals VCFs into a single joint-call.

- Reads each VCF and corresponding index into the batch temp directory
- Runs a fast bcftools merge on the individual VCFs (these are all called at the same sites/intervals, to this works as a naive merge)
- Inserts a python code block to read the VCF, add 2 header lines for the SVTYPE and SVLEN attributes, then annotate these values into all variant rows. These are both required for StrVCTVRE and AnnotateVcf, but are omitted from the gCNV output

Operational image for this stage is borrowed from GATK-SV (bcftools, tabix, python)