### PR TITLE
Bump Scramble part 1 RAM

### DIFF
--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -6,5 +6,5 @@
 
 # resource overrides for the GatherSampleEvidence stage
 
-[resource_overrides.GatherSampleEvidence.runtime_attr_wham]
+[resource_overrides.GatherSampleEvidence.runtime_attr_scramble_part2]
 mem_gb = 7.5

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -96,16 +96,17 @@ class GatherSampleEvidence(SequencingGroupStage):
         """
         assert sequencing_group.cram, sequencing_group
 
-        input_dict: dict[str, Any] = {
-            'bam_or_cram_file': str(sequencing_group.cram),
-            'bam_or_cram_index': str(sequencing_group.cram) + '.crai',
-            'sample_id': sequencing_group.id,
-            'reference_fasta': str(get_fasta()),
-            'reference_index': str(get_fasta()) + '.fai',
-            'reference_dict': str(get_fasta().with_suffix('.dict')),
-            'reference_version': '38',
-            # 'scramble_part2_threads': 4,  # default = 7
-        }
+        input_dict: dict[str, Any] = dict(
+            bam_or_cram_file=str(sequencing_group.cram),
+            bam_or_cram_index=str(sequencing_group.cram) + '.crai',
+            sample_id=sequencing_group.id,
+            reference_fasta=str(get_fasta()),
+            reference_index=str(get_fasta()) + '.fai',
+            reference_dict=str(get_fasta().with_suffix('.dict')),
+            reference_version='38',
+            runtime_attr_scramble_part2= {"mem_gb": 8}
+        )
+
 
         input_dict |= get_images(
             [

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -103,10 +103,14 @@ class GatherSampleEvidence(SequencingGroupStage):
             reference_fasta=str(get_fasta()),
             reference_index=str(get_fasta()) + '.fai',
             reference_dict=str(get_fasta().with_suffix('.dict')),
-            reference_version='38',
-            runtime_attr_scramble_part2= {"mem_gb": 8}
+            reference_version='38'
         )
 
+        # runtime_attr_scramble_part2 = {"mem_gb": 8}
+        # optional override:
+        if (overrides := get_config().get('resource_overrides')) and 'GatherSampleEvidence' in overrides:
+            for key, value in overrides['GatherSampleEvidence'].items():
+                input_dict[key] = value
 
         input_dict |= get_images(
             [


### PR DESCRIPTION
Seeing some consistent failures in Scramble, possibly RAM related?

https://github.com/broadinstitute/gatk-sv/blob/main/wdl/Scramble.wdl#L21
-> 
https://github.com/broadinstitute/gatk-sv/blob/main/wdl/Scramble.wdl#L83C15-L83C27
->
https://github.com/broadinstitute/gatk-sv/blob/main/wdl/Scramble.wdl#L98

I _think_ this would override the RAM setting, and everything else would still pull from the default attributes?