### PR TITLE
Annotate sex fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.18
+current_version = 1.18.19
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.18.18
+  VERSION: 1.18.19
 
 jobs:
   docker:

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -104,7 +104,7 @@ def impute_sex(
     calling_intervals_ht.describe()
 
     # clunky import due to dataproc execution
-    from hail.vds import VariantDataset
+    from hail.vds.variant_dataset import VariantDataset
 
     # Pre-filter here and setting `variants_filter_lcr` and `variants_filter_segdup`
     # below to `False` to avoid the function calling gnomAD's `resources` module:

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -103,12 +103,22 @@ def impute_sex(
     logging.info('Calling intervals table:')
     calling_intervals_ht.describe()
 
+    # clunky import due to dataproc execution
+    from hail.vds import VariantDataset
+
     # Pre-filter here and setting `variants_filter_lcr` and `variants_filter_segdup`
     # below to `False` to avoid the function calling gnomAD's `resources` module:
     for name in ['lcr_intervals_ht', 'seg_dup_intervals_ht']:
-        ht = hl.read_table(str(reference_path(f'gnomad/{name}')))
-        if ht.count() > 0:
-            vds = hl.vds.filter_intervals(vds, ht, keep=False)
+        interval_table = hl.read_table(str(reference_path(f'gnomad/{name}')))
+        if interval_table.count() > 0:
+            # remove all rows where the locus falls within a defined interval
+            tmp_variant_data = vds.variant_data.filter_rows(
+                hl.is_defined(interval_table[vds.variant_data.locus]), keep=False
+            )
+            vds = VariantDataset(
+                reference_data=vds.reference_data, variant_data=tmp_variant_data
+            ).checkpoint(str(tmp_prefix / f'{name}_checkpoint.vds'))
+            logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 
     # Infer sex (adds row fields: is_female, var_data_chr20_mean_dp, sex_karyotype)
     sex_ht = annotate_sex(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.18',
+    version='1.18.19',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
See https://centrepopgen.slack.com/archives/C030X7WGFCL/p1702345700581549

Test run https://batch.hail.populationgenomics.org.au/batches/431057

We were seeing failures in annotate_sex in the large-cohort pipeline's SampleQC stage. We originally traced these errors to the `gnomad-methods` submodule, but after an extensive debugging operation the point of failure looks to be the filter_intervals operation - this op is not designed for massive numbers of intervals, and was failing repeatedly when we tried to apply a filter table with ~2M rows.

@cassimons redesigned the syntax around this operation, and combining the new filter syntax with checkpointing, we can successfully complete SampleQC, at the expense of creating a few more checkpoints in tmp (these checkpoints may not be necessary given the new syntax/operations, but it's working and I'm too scared to change it now)

Debugging credit to @michael-harper @jmarshall @KatalinaBobowik @illusional 