### PR TITLE
Fix source of input data for GATK-SV stage

### DIFF
--- a/configs/gatk_sv/all_batch_names.toml
+++ b/configs/gatk_sv/all_batch_names.toml
@@ -2,4 +2,13 @@
 # this will be used when running:
 # - MergeBatchSites (sandwich stage)
 # - MakeCohortVCF (multisample 2)
-batch_names = ['555b2843b7a3cfbdeb28c5cfbf7d2b3b1ca004_119', 'a5407cc508c8f25f960e1b52be1f31e740d289_119', '57970d24bdbea5ecd73d2bfb198561036db76b_161', 'fdbd58db0fd05246b40a530e2d357b6ca20065_197']
+batch_names = [
+    '555b2843b7a3cfbdeb28c5cfbf7d2b3b1ca004_119',
+    'a5407cc508c8f25f960e1b52be1f31e740d289_119',
+    '57970d24bdbea5ecd73d2bfb198561036db76b_161',
+    'fdbd58db0fd05246b40a530e2d357b6ca20065_197',
+    '53cc421fcfed5a57011666a55906f7980fa47d_249',
+    '37d60e139c4e9bf4e3afcf03e6d19f209b7c44_248',
+    '559487096cd14e497f2eb4e26fa1948a823eff_248',
+    '31dc2d5734b4bcfa023f8c681a72bb0ccbe8c9_248'
+]

--- a/configs/gatk_sv/genotypebatch.toml
+++ b/configs/gatk_sv/genotypebatch.toml
@@ -1,5 +1,5 @@
 [workflow]
 only_stages = ['GenotypeBatch']
 # this will be a single VCF, combined across multiple sub-cohort VCF outputs
-cohort_depth_vcf = 'gs://cpg-seqr-main/gatk_sv/31f10defa3d10298bc357a5d2f968ac729677a_595/MergeBatchSites/cohort_depth.vcf.gz'
-cohort_pesr_vcf = 'gs://cpg-seqr-main/gatk_sv/31f10defa3d10298bc357a5d2f968ac729677a_595/MergeBatchSites/cohort_pesr.vcf.gz'
+cohort_depth_vcf = 'gs://cpg-seqr-main/gatk_sv/147795b8125006e53b8f0a164f079f2efe2cd7_993/MergeBatchSites/cohort_depth.vcf.gz'
+cohort_pesr_vcf = 'gs://cpg-seqr-main/gatk_sv/147795b8125006e53b8f0a164f079f2efe2cd7_993/MergeBatchSites/cohort_pesr.vcf.gz'

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -557,7 +557,7 @@ class AnnotateVcf(CohortStage):
             batch=get_batch(),
             cohort=cohort,
             cohort_prefix=self.prefix,
-            input_vcf=inputs.as_dict(cohort, MakeCohortVcf)['vcf'],
+            input_vcf=inputs.as_dict(cohort, FilterGenotypes)['filtered_vcf'],
             outputs=expected_out,
             labels=billing_labels,
         )


### PR DESCRIPTION
See: https://batch.hail.populationgenomics.org.au/batches/431434/jobs/1

I'm not really sure how this crept in, this workflow has been run end-to-end previously. 

[This](https://github.com/populationgenomics/production-pipelines/commit/46c325f93f134f691ecf581f46ccb3d629ff77ee) might be the commit that did it - we introduced the FilterGenotypes workflow, then deactivated it due to a broken Docker image, then re-added it - that final re-addition may not have been done comprehensively

Changes to the config files here are done to stay up to date with all batches which have been run