### PR TITLE
Insert T-Shirt job sizing for Cromwell and config overrides

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -50,7 +50,6 @@ def create_polling_intervals() -> dict:
     [cromwell_polling_intervals.medium]
     min = 69
     max = 420
-
     """
 
     # create this dict with default values
@@ -62,9 +61,7 @@ def create_polling_intervals() -> dict:
 
     # update if these exist in config
     for job_size in CromwellJobSizes:
-        if job_size.value in get_config().get(
-            'cromwell_polling_intervals', {}
-        ):
+        if job_size.value in get_config().get('cromwell_polling_intervals', {}):
             polling_interval_dict[job_size].update(
                 get_config()['cromwell_polling_intervals'][job_size.value]
             )

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -48,9 +48,9 @@ def create_polling_intervals() -> dict:
 
     # create this dict with default values
     polling_interval_dict = {
-        CromwellJobSizes.SMALL: {'min': 30, 'max': 180},
-        CromwellJobSizes.MEDIUM: {'min': 60, 'max': 600},
-        CromwellJobSizes.LARGE: {'min': 300, 'max': 3600},
+        CromwellJobSizes.SMALL: {'min': 30, 'max': 140},
+        CromwellJobSizes.MEDIUM: {'min': 40, 'max': 400},
+        CromwellJobSizes.LARGE: {'min': 200, 'max': 2000},
     }
 
     # update if these exist in config

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -44,6 +44,13 @@ def create_polling_intervals() -> dict:
     for each job size, there is a min and max value
     analysis-runner implements a backoff-retrier when checking for
     success, with a minimum value, gradually reaching a max ceiling
+
+    a config section containing overrides would look like
+
+    [cromwell_polling_intervals.medium]
+    min = 69
+    max = 420
+
     """
 
     # create this dict with default values
@@ -55,11 +62,11 @@ def create_polling_intervals() -> dict:
 
     # update if these exist in config
     for job_size in CromwellJobSizes:
-        if job_size.value in get_config()['workflow'].get(
+        if job_size.value in get_config().get(
             'cromwell_polling_intervals', {}
         ):
             polling_interval_dict[job_size].update(
-                get_config()['workflow']['cromwell_polling_intervals'][job_size.value]
+                get_config()['cromwell_polling_intervals'][job_size.value]
             )
     return polling_interval_dict
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -4,6 +4,7 @@ Common methods for all GATK-SV workflows
 import re
 from enum import Enum
 from os.path import join
+from random import randint
 from typing import Any
 
 from analysis_runner.cromwell import (
@@ -53,6 +54,13 @@ def set_polling_intervals() -> dict:
             polling_interval_dict[interval].update(
                 get_config()['workflow']['cromwell_polling'][interval.value]
             )
+
+    # add some jitter (randomness) to the polling intervals, so that tasks don't
+    # always poll at the same time (mostly a concern for per-SG jobs)
+    for interval in PollingInterval:
+        for key in ['min', 'max']:
+            current = polling_interval_dict[interval][key]
+            polling_interval_dict[interval][key] = randint(current, current * 2)
 
     return polling_interval_dict
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -55,11 +55,14 @@ def create_polling_intervals() -> dict:
 
     # update if these exist in config
     for job_size in CromwellJobSizes:
-        if job_size.value in get_config()['workflow'].get('cromwell_polling_intervals', {}):
+        if job_size.value in get_config()['workflow'].get(
+            'cromwell_polling_intervals', {}
+        ):
             polling_interval_dict[job_size].update(
                 get_config()['workflow']['cromwell_polling_intervals'][job_size.value]
             )
     return polling_interval_dict
+
 
 def _sv_batch_meta(
     output_path: str,  # pylint: disable=W0613:unused-argument
@@ -167,8 +170,12 @@ def add_gatk_sv_jobs(
     polling_intervals = create_polling_intervals()
 
     # obtain upper and lower polling bounds for this job size
-    polling_minimum = randint(polling_intervals[job_size]['min'], polling_intervals[job_size]['min'] * 2)
-    polling_maximum = randint(polling_intervals[job_size]['max'], polling_intervals[job_size]['max'] * 2)
+    polling_minimum = randint(
+        polling_intervals[job_size]['min'], polling_intervals[job_size]['min'] * 2
+    )
+    polling_maximum = randint(
+        polling_intervals[job_size]['max'], polling_intervals[job_size]['max'] * 2
+    )
 
     # If a config section exists for this workflow, apply overrides
     if override := get_config()['resource_overrides'].get(wfl_name):

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -13,6 +13,7 @@ from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch
 
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
+    PollingInterval,
     SV_CALLERS,
     _sv_batch_meta,
     add_gatk_sv_jobs,
@@ -190,8 +191,7 @@ class GatherBatchEvidence(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            cromwell_status_min_poll_interval=500,
-            cromwell_status_max_poll_interval=2000
+            job_size=PollingInterval.LARGE,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -281,8 +281,7 @@ class ClusterBatch(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            cromwell_status_min_poll_interval=100,
-            cromwell_status_max_poll_interval=600
+            job_size=PollingInterval.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -362,8 +361,7 @@ class GenerateBatchMetrics(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            cromwell_status_min_poll_interval=400,
-            cromwell_status_max_poll_interval=1800
+            job_size=PollingInterval.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -460,8 +458,7 @@ class FilterBatch(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            cromwell_status_min_poll_interval=100,
-            cromwell_status_max_poll_interval=600
+            job_size=PollingInterval.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -13,7 +13,7 @@ from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch
 
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    PollingInterval,
+    CromwellJobSizes,
     SV_CALLERS,
     _sv_batch_meta,
     add_gatk_sv_jobs,
@@ -191,7 +191,7 @@ class GatherBatchEvidence(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.LARGE,
+            job_size=CromwellJobSizes.LARGE,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -281,7 +281,7 @@ class ClusterBatch(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.MEDIUM,
+            job_size=CromwellJobSizes.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -361,7 +361,7 @@ class GenerateBatchMetrics(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.MEDIUM,
+            job_size=CromwellJobSizes.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -458,7 +458,7 @@ class FilterBatch(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.MEDIUM,
+            job_size=CromwellJobSizes.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -17,7 +17,7 @@ from cpg_workflows.jobs.seqr_loader_sv import (
     annotate_dataset_jobs_sv,
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    PollingInterval,
+    CromwellJobSizes,
     SV_CALLERS,
     _sv_filtered_meta,
     add_gatk_sv_jobs,
@@ -219,7 +219,7 @@ class MakeCohortVcf(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.MEDIUM,
+            job_size=CromwellJobSizes.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -269,7 +269,7 @@ class FormatVcfForGatk(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.SMALL,
+            job_size=CromwellJobSizes.SMALL,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -17,6 +17,7 @@ from cpg_workflows.jobs.seqr_loader_sv import (
     annotate_dataset_jobs_sv,
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
+    PollingInterval,
     SV_CALLERS,
     _sv_filtered_meta,
     add_gatk_sv_jobs,
@@ -218,6 +219,7 @@ class MakeCohortVcf(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
+            job_size=PollingInterval.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 
@@ -267,6 +269,7 @@ class FormatVcfForGatk(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
+            job_size=PollingInterval.SMALL,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -11,7 +11,7 @@ from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 
 from cpg_workflows.jobs import sample_batching
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    PollingInterval,
+    CromwellJobSizes,
     SV_CALLERS,
     _sv_individual_meta,
     add_gatk_sv_jobs,
@@ -158,7 +158,7 @@ class GatherSampleEvidence(SequencingGroupStage):
             expected_out_dict=expected_d,
             sequencing_group_id=sequencing_group.id,
             labels=billing_labels,
-            job_size=PollingInterval.LARGE,
+            job_size=CromwellJobSizes.LARGE,
         )
         return self.make_outputs(sequencing_group, data=expected_d, jobs=jobs)
 
@@ -228,7 +228,7 @@ class EvidenceQC(CohortStage):
             input_dict=input_dict,
             expected_out_dict=expected_d,
             labels=billing_labels,
-            job_size=PollingInterval.MEDIUM,
+            job_size=CromwellJobSizes.MEDIUM,
         )
         return self.make_outputs(cohort, data=expected_d, jobs=jobs)
 


### PR DESCRIPTION
- Closes https://github.com/populationgenomics/production-pipelines/issues/581

Enables config override of the polling intervals for Cromwell jobs
Creates a 't-shirt sizing' model instead of curating each job's duration individually