### PR TITLE
Add permanent sites table

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -76,5 +76,4 @@ delete_scratch_on_exit = false
 
 [references.gnomad]
 tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht"
-predetermined_qc_variants_prefix = 'gs://cpg-hgdp-1kg-' 
-predetermined_qc_variants_path = '/sites_table/v1-0/pruned_variants.ht'
+predetermined_qc_variants_table = 'gs://cpg-hgdp-1kg-test/sites_table/v1-0/pruned_variants.ht' 

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -76,4 +76,4 @@ delete_scratch_on_exit = false
 
 [references.gnomad]
 tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht"
-predetermined_qc_variants_table = 'gs://cpg-hgdp-1kg-test/sites_table/v1-0/pruned_variants.ht' 
+predetermined_qc_variants_table = 'gs://cpg-common-main/references/ancestry/pruned_variants.ht/' 

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -76,4 +76,3 @@ delete_scratch_on_exit = false
 
 [references.gnomad]
 tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht"
-predetermined_qc_variants_table = 'gs://cpg-common-main/references/ancestry/pruned_variants.ht/' 

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -22,8 +22,7 @@ def add_background(
     """
     Add background dataset samples to the dense MT and sample QC HT.
     """
-    access_level = get_config()['workflow'].get('access_level')
-    sites_table = str(reference_path('gnomad/predetermined_qc_variants_prefix')) + access_level + str(reference_path('gnomad/predetermined_qc_variants_path'))
+    sites_table = reference_path('gnomad/predetermined_qc_variants_table')
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = (
         dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -22,7 +22,7 @@ def add_background(
     """
     Add background dataset samples to the dense MT and sample QC HT.
     """
-    sites_table = str(reference_path('gnomad/predetermined_qc_variants_table'))
+    sites_table = get_config()['references']['ancestry']['sites_table']
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = (
         dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -22,7 +22,7 @@ def add_background(
     """
     Add background dataset samples to the dense MT and sample QC HT.
     """
-    sites_table = reference_path('gnomad/predetermined_qc_variants_table')
+    sites_table = str(reference_path('gnomad/predetermined_qc_variants_table'))
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = (
         dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')

--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -25,8 +25,7 @@ def run(
     vds = hl.vds.split_multi(vds, filter_changed_loci=True)
 
     logging.info('Filtering variants to predetermined QC variants...')
-    access_level = get_config()['workflow'].get('access_level')
-    sites_table = str(reference_path('gnomad/predetermined_qc_variants_prefix')) + access_level + str(reference_path('gnomad/predetermined_qc_variants_path'))
+    sites_table = reference_path('gnomad/predetermined_qc_variants_table')
     qc_variants_ht = hl.read_table(sites_table)
     vds = hl.vds.filter_variants(vds, qc_variants_ht)
     logging.info('Densifying data...')

--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -25,7 +25,7 @@ def run(
     vds = hl.vds.split_multi(vds, filter_changed_loci=True)
 
     logging.info('Filtering variants to predetermined QC variants...')
-    sites_table = reference_path('gnomad/predetermined_qc_variants_table')
+    sites_table = str(reference_path('gnomad/predetermined_qc_variants_table'))
     qc_variants_ht = hl.read_table(sites_table)
     vds = hl.vds.filter_variants(vds, qc_variants_ht)
     logging.info('Densifying data...')

--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -25,7 +25,7 @@ def run(
     vds = hl.vds.split_multi(vds, filter_changed_loci=True)
 
     logging.info('Filtering variants to predetermined QC variants...')
-    sites_table = str(reference_path('gnomad/predetermined_qc_variants_table'))
+    sites_table = get_config()['references']['ancestry']['sites_table']
     qc_variants_ht = hl.read_table(sites_table)
     vds = hl.vds.filter_variants(vds, qc_variants_ht)
     logging.info('Densifying data...')

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -70,6 +70,11 @@ def create_config(
         },
         references={
             'genome_build': 'GRCh38',
+            'ancestry': {
+                'sites_table': (
+                    gnomad_prefix / 'sample_qc-' / 'pre_ld_pruning_qc_variants.ht'
+                    ),
+            },
             'gnomad': {
                 'tel_and_cent_ht': (
                     gnomad_prefix
@@ -93,12 +98,6 @@ def create_config(
                     / 'mills'
                     / 'Mills_and_1000G_gold_standard.indels.hg38.ht'
                 ),
-                'predetermined_qc_variants_prefix': (
-                    gnomad_prefix / 'sample_qc-'
-                ),
-                'predetermined_qc_variants_path': (
-                    '/pre_ld_pruning_qc_variants.ht'
-                )
             },
             'broad': {
                 'genome_calling_interval_lists': (

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -72,7 +72,7 @@ def create_config(
             'genome_build': 'GRCh38',
             'ancestry': {
                 'sites_table': (
-                    gnomad_prefix / 'sample_qc-' / 'pre_ld_pruning_qc_variants.ht'
+                    gnomad_prefix / 'sample_qc-test' / 'pre_ld_pruning_qc_variants.ht'
                     ),
             },
             'gnomad': {


### PR DESCRIPTION
Add sites table from `cpg-common-main`, instead of pulling the sites table from `hgdp-1kg-test` or `hgdp-1kg-main`. 

For context, see the [PR](https://github.com/populationgenomics/references/pull/42#pullrequestreview-1810428108) to get the sites table onto `cpg-common`, as well as [this](https://centrepopgen.slack.com/archives/C030X7WGFCL/p1704684891602139) slack thread for context.