### PR TITLE
Remove build-during-pr workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,12 +55,6 @@ jobs:
         run: |
           docker build . -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }}
 
-      - name: push PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:pr-${{ github.event.number }}
-          docker push $DOCKER_DEV/$IMAGE_NAME:pr-${{ github.event.number }}
-
       - name: manually triggered build
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |


### PR DESCRIPTION
This is a hold over from an older workflow, where we would build a new image for every commit into an open PR. 

Now that we no longer do that, remove this section