### PR TITLE
Allow main builds to main artifactory

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -64,7 +64,7 @@ jobs:
           docker push $DOCKER_MAIN/$IMAGE_NAME:latest
 
       - name: manually triggered build
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' }}
         run: |
           docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
           docker push $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,22 +55,16 @@ jobs:
         run: |
           docker build . -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }}
 
-      - name: push PR
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: push latest
+        if: ${{ github.ref_name == 'main' }}
         run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:pr-${{ github.event.number }}
-          docker push $DOCKER_DEV/$IMAGE_NAME:pr-${{ github.event.number }}
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:$VERSION
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:latest
+          docker push $DOCKER_MAIN/$IMAGE_NAME:$VERSION
+          docker push $DOCKER_MAIN/$IMAGE_NAME:latest
 
       - name: manually triggered build
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
           docker push $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
-
-      - name: push latest
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:$VERSION
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:latest
-          docker push $DOCKER_MAIN/$IMAGE_NAME:$VERSION
-          docker push $DOCKER_MAIN/$IMAGE_NAME:latest


### PR DESCRIPTION
Replacement for #590 

- A while back we blocked manually-triggered builds from reaching the main artifactory
- When we want to refresh the cpg-workflows image (e.g. deps, but no code change) we don't have a way to do that

This change alters the workflow yaml:

- all builds on `main`, manually triggered or not, are equivalent; build and push to main artifactory with the tags `VERSION` and `latest`
- removes the section designed to build a new image when a new commit is added to an open PR. The workflow no longer runs at this time