### PR TITLE
Allow indirect resource overrides of WDL sub-workflows

### DIFF
--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -1,16 +1,21 @@
-[resource_overrides]
-
 # location for any required resource overrides
-
-[resource_overrides.GatherSampleEvidence]
+# these are applied directly to the named workflow
 
 # resource overrides for the GatherSampleEvidence stage
-
 [resource_overrides.GatherSampleEvidence.runtime_attr_scramble_part2]
 mem_gb = 7.5
 
+# resource overrides for the EvidenceQC stage
 [resource_overrides.EvidenceQC.wgd_build_runtime_attr]
 disk_gb = 40
 
 [resource_overrides.EvidenceQC.runtime_attr_mediancov]
 disk_gb = 200
+
+# resource overrides for indirect workflows
+
+# during MakeCohortVcf, we need to override the resource requirements for the
+# MakeCohortVcfMetrics sub-workflow
+[sub_workflow_overrides.MakeCohortVcf.MakeCohortVcfMetrics.runtime_attr_vcf_metrics]
+mem_gb = 20
+disk_gb = 40

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -214,6 +214,13 @@ def add_gatk_sv_jobs(
         else:
             paths_as_strings[f'{wfl_name}.{key}'] = value
 
+    # sometimes we need to pass inputs on to a sub-workflow, rather than the top
+    # level. See the config_overrides toml for an example of how to use this
+    if sub_wfl_inputs := get_config()['sub_workflow_overrides'].get(wfl_name):
+        for sub_wf, sub_section in sub_wfl_inputs.items():
+            for key, value in sub_section.items():
+                paths_as_strings[f'{sub_wf}.{key}'] = value
+
     job_prefix = make_job_name(
         wfl_name, sequencing_group=sequencing_group_id, dataset=dataset.name
     )


### PR DESCRIPTION
We have a way of sending in config overrides for individual WDL files [here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gatk_sv/gatk_sv_common.py#L184-L186)

This is just before [this](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gatk_sv/gatk_sv_common.py#L208-L215) code block, which prepends the workflow title to all the collected arguments to Cromwell

Prepending names in this way means that there's no way to pass inputs indirectly, as the named arguments are always prefixed with the top-level workflow name - Cromwell fails (correctly), as `WF_name.SubWorkflow_name` is not a valid argument

---

This suggestion allows for a slightly more complex section of the config:

```
find config overrides which apply to indirectly invoked sub-workflows of this named workflow
```

These config sections will have a top-level key of the workflow being directly invoked, then nested beneath that the title of the target workflow. Further nested are the actual key-value pairs to send as inputs. Example provided:

- `MakeCohortVcf` (wfl_name) eventually invokes the sub-workflow `MakeCohortVcfMetrics`
- We want to bump resources of `MakeCohortVcfMetrics`
- Config section:

```toml
[sub_workflow_overrides.MakeCohortVcf.MakeCohortVcfMetrics.runtime_attr_vcf_metrics]
mem_gb = 20
disk_gb = 40
```

- This code will identify required sub-workflow overrides for `wfl_name`
- It pulls out this section of the config and forms the following entries in the input dict:

```python
input_dict = {
    'MakeCohortVcfMetrics.runtime_attr_vcf_metrics': {
        'mem_gb': 20, 
        'disk_gb': 40
    }
}
```

My understanding is that Cromwell will parse this as input for the nested WDL, even though this argument is never explicitly passed through the task calls in the relevant WDLs