### PR TITLE
Don't run metrics sub-workflow, don't expect metrics outputs

### DIFF
--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -12,10 +12,16 @@ disk_gb = 40
 [resource_overrides.EvidenceQC.runtime_attr_mediancov]
 disk_gb = 200
 
+[resource_overrides.MakeCohortVcf]
+run_module_metrics = false
+
 # resource overrides for indirect workflows
 
-# during MakeCohortVcf, we need to override the resource requirements for the
-# MakeCohortVcfMetrics sub-workflow
-[sub_workflow_overrides.MakeCohortVcf.MakeCohortVcfMetrics.runtime_attr_vcf_metrics]
-mem_gb = 20
-disk_gb = 40
+
+[sub_workflow_overrides.EXAMPLE.SubWorkflow.runtime_attr_overrides]
+
+## during MakeCohortVcf, we need to override the resource requirements for the
+## MakeCohortVcfMetrics sub-workflow
+#[sub_workflow_overrides.MakeCohortVcf.MakeCohortVcfMetrics.runtime_attr_vcf_metrics]
+#mem_gb = 20
+#disk_gb = 40

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -216,10 +216,11 @@ def add_gatk_sv_jobs(
 
     # sometimes we need to pass inputs on to a sub-workflow, rather than the top
     # level. See the config_overrides toml for an example of how to use this
-    if sub_wfl_inputs := get_config()['sub_workflow_overrides'].get(wfl_name):
-        for sub_wf, sub_section in sub_wfl_inputs.items():
-            for key, value in sub_section.items():
-                paths_as_strings[f'{sub_wf}.{key}'] = value
+    if 'sub_workflow_overrides' in get_config():
+        if sub_wfl_inputs := get_config()['sub_workflow_overrides'].get(wfl_name):
+            for sub_wf, sub_section in sub_wfl_inputs.items():
+                for key, value in sub_section.items():
+                    paths_as_strings[f'{sub_wf}.{key}'] = value
 
     job_prefix = make_job_name(
         wfl_name, sequencing_group=sequencing_group_id, dataset=dataset.name

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -86,7 +86,6 @@ class MakeCohortVcf(CohortStage):
 
         return out_dict
 
-
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
         """
         This is a little bit spicy. Instead of taking a direct dependency on the

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -2,8 +2,7 @@
 The second multi-sample workflow, containing the following stages:
 MakeCohortVCF and AnnotateVCF
 """
-
-
+import logging
 from typing import Any
 
 from cpg_utils import Path, to_path
@@ -64,7 +63,7 @@ class MakeCohortVcf(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict:
         """create output paths"""
-        return {
+        out_dict = {
             'vcf': self.prefix / 'cleaned.vcf.gz',
             'vcf_index': self.prefix / 'cleaned.vcf.gz.tbi',
             'vcf_qc': self.prefix / 'cleaned_SV_VCF_QC_output.tar.gz',
@@ -77,6 +76,16 @@ class MakeCohortVcf(CohortStage):
             # 'complex_genotype_vcf': '.complex_genotype.vcf.gz',
             # 'complex_genotype_vcf_index': '.complex_genotype.vcf.gz.tbi',
         }
+
+        # if we don't run metrics, don't expect the outputs
+        # on by default in the WDL file, so expect this to run unless overridden
+        if override := get_config()['resource_overrides'].get('MakeCohortVcf'):
+            if override.get('run_module_metrics', True):
+                metrics_path = str(out_dict.pop('metrics_file_makecohortvcf'))
+                logging.info(f'Will not create metrics file: {metrics_path}')
+
+        return out_dict
+
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
         """


### PR DESCRIPTION
MakeCohortVcf has been consistently failing until the MakeCohortVcfMetrics sub-workflow was disabled. The `copy_outputs` stage of this Cromwell execution now fails as the metrics file doesn't get generated. I'm going to raise this with the Broad and see what approach they have taken to solve this problem.

This change removes the metrics output from the Stage's expected outputs where the config overrides section disables the metrics workflow.