### PR TITLE
Correct formatter arg in JoinRawCalls Stage

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -303,7 +303,7 @@ class JoinRawCalls(CohortStage):
         """ """
 
         input_dict: dict[str, Any] = {
-            'formatter_args': '--fix-end',
+            'FormatVcfForGatk.formatter_args': '--fix-end',
             'prefix': cohort.name,
             'ped_file': make_combined_ped(cohort, self.prefix),
             'reference_fasta': get_fasta(),


### PR DESCRIPTION
based on this commit to the Broad GATK-SV https://github.com/broadinstitute/gatk-sv/commit/a4405025da987d1fbc726b54e296ff072207d885

the argument to the `JoinRawCalls` WDL should be 

```
'FormatVcfForGatk.formatter_args': '--fix-end',
```

instead of the current 
```
'formatter_args': '--fix-end',
```

I swear I've run this workflow before in its current form and not hit this issue. Quite confused