### PR TITLE
Changing annotate_sex() to use reference blocks for ploidy calculationns in stead of variant sites in X and Y chromosomes

### DIFF
--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -8,10 +8,11 @@ import logging
 import hail as hl
 from cpg_utils import Path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import reference_path, genome_build
+from cpg_utils.hail_batch import genome_build, reference_path
+from gnomad.sample_qc.pipeline import annotate_sex
+
 from cpg_workflows.inputs import get_cohort
 from cpg_workflows.utils import can_reuse
-from gnomad.sample_qc.pipeline import annotate_sex
 
 
 def run(
@@ -127,8 +128,12 @@ def impute_sex(
         overwrite=not get_config()['workflow'].get('check_intermediates'),
         included_intervals=calling_intervals_ht,
         gt_expr='LGT',
-        variants_only_x_ploidy=True,
-        variants_only_y_ploidy=True,
+        # Using variant sites only for ploidy calculations causes ChrY ploidy inflation.
+        # Setting `variants_only_x_ploidy` and `variants_only_y_ploidy` to `False` (default value) causes
+        # function to use reference blocks for ploidy calculations
+        # https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C
+        variants_only_x_ploidy=False,
+        variants_only_y_ploidy=False,
         variants_filter_lcr=False,  # already filtered above
         variants_filter_segdup=False,  # already filtered above
         variants_filter_decoy=False,


### PR DESCRIPTION
Context: There were more inferred "X" than "XY" samples in the TenK10K Phase 1 cohort. We further investigated this by looking at  Y ploidy and X ploidy values generated at the SampleQC stage and found that Y ploidy values were inflated, ranging from 2-6 in "X" and "XY" samples when the expected range is 0-1.
Possible fix: Set `variants_only_x_ploidy` and `variants_only_y_ploidy` in  `annotate_sex()` of `SampleQC` to the default value of `False`. They are both currently set to `True` in the pipeline. This change would mean that we use reference block depths, and not solely allele depths at variant sites, for calculating coverage across sex chromosomes, and subsequently sex imputation.
We tested this fix in the `test` `VDS`  and it produces Y ploidy values of ~0 in "XX" samples and ~1 in "X" (presumably "XY") samples, as expected.
The default value for these parameters in gnomad v3's `SampleQC` is also set to `False`.

>https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C