### PR TITLE
Allow workflow outputs to be written to `-analysis`

### DIFF
--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -422,6 +422,10 @@ class Stage(Generic[TargetT], ABC):
     def prefix(self) -> Path:
         return get_workflow().prefix / self.name
 
+    @property
+    def analysis_prefix(self) -> Path:
+        return get_workflow().analysis_prefix / self.name
+
     def __str__(self):
         res = f'{self._name}'
         if self.skipped:
@@ -922,6 +926,10 @@ class Workflow:
     @property
     def output_version(self) -> str:
         return self._output_version or get_cohort().alignment_inputs_hash()
+
+    @property
+    def analysis_prefix(self) -> Path:
+        return self._prefix(category='analysis')
 
     @property
     def tmp_prefix(self) -> Path:


### PR DESCRIPTION
Some pipeline outputs would benefit from manual review, but the Stage/dataset/cohort prefix structure doesn't currently support addresses in the analysis buckets.

This would be used for data intended for manual review, not for the majority of data generated by analysis pipelines. Issue #598 is an example of where the pipeline writes some QC objects, but they are on `-main` with the rest of the data which is a barrier to manual inspection, making this a tricky solve