### PR TITLE
Fix Y Ploidy Inflation in SampleQC Stage: Allow variants_only_x_ploidy and variants_only_y_ploidy to be set in config file

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -53,6 +53,12 @@ pca_plot_name = 'hgdp_1kg_sites'
 # set whether PCA output labels are from given population names, or random forest
 # inferred population labels
 inferred_ancestry = false
+# Whether or not to infer ploidy using the variant data:
+# Using variant sites only for ploidy calculations causes ChrY ploidy inflation.
+# Setting `variants_only_x_ploidy` and `variants_only_y_ploidy` to `False` (default value) causes
+# function to use reference blocks for ploidy calculations
+# https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C
+inf_ploidy_using_var = true
 
 # Parameters for sample QC. The default values for soft filtering taken from gnomAD QC:
 # https://macarthurlab.org/2019/10/16/gnomad-v3-0, with `max_n_snps` and 

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -58,7 +58,7 @@ inferred_ancestry = false
 # Setting `variants_only_x_ploidy` and `variants_only_y_ploidy` to `False` (default value) causes
 # function to use reference blocks for ploidy calculations
 # https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C
-inf_ploidy_using_var = true
+inf_ploidy_using_var = false
 
 # Parameters for sample QC. The default values for soft filtering taken from gnomAD QC:
 # https://macarthurlab.org/2019/10/16/gnomad-v3-0, with `max_n_snps` and 

--- a/cpg_workflows/large_cohort/relatedness.py
+++ b/cpg_workflows/large_cohort/relatedness.py
@@ -139,7 +139,9 @@ def _compute_sample_rankings(ht: hl.Table) -> hl.Table:
     @return: table ordered by rank, with the following row fields:
         `rank`, `filtered`
     """
-    use_only_variants = get_config()['large_cohort'].get('inf_ploidy_using_var', False)
+    use_only_variants = get_config()['large_cohort']['pca_background'].get(
+        'inf_ploidy_using_var', False
+    )
     if use_only_variants:
         ranking_column = 'var_data_chr20_mean_dp'
     else:

--- a/cpg_workflows/large_cohort/relatedness.py
+++ b/cpg_workflows/large_cohort/relatedness.py
@@ -139,10 +139,7 @@ def _compute_sample_rankings(ht: hl.Table) -> hl.Table:
     @return: table ordered by rank, with the following row fields:
         `rank`, `filtered`
     """
-    use_only_variants = get_config()['large_cohort']['pca_background'].get(
-        'inf_ploidy_using_var', False
-    )
-    if use_only_variants:
+    if 'var_data_chr20_mean_dp' in ht.row:
         ranking_column = 'var_data_chr20_mean_dp'
     else:
         ranking_column = 'autosomal_mean_dp'

--- a/cpg_workflows/large_cohort/relatedness.py
+++ b/cpg_workflows/large_cohort/relatedness.py
@@ -84,8 +84,9 @@ def flag_related(
     """
     Rank samples and flag samples to drop so there is only one sample per family
     left, with the highest rank in the family. The ranking is based on either
-    'var_data_chr20_mean_dp' or 'autosomal_mean_dp' depending on the
-    'inf_ploidy_using_var' configuration in the `sample_qc_ht`.
+    'var_data_chr20_mean_dp' or 'autosomal_mean_dp' depending on which is present
+    in the `sample_qc_ht` table. The presence of either column is determined by
+    the 'inf_ploidy_using_var' parameter in the config toml.
 
     @param relatedness_ht: table with relatedness information.
     @param sample_qc_ht: table with either `var_data_chr20_mean_dp` or `autosomal_mean_dp`

--- a/cpg_workflows/large_cohort/relatedness.py
+++ b/cpg_workflows/large_cohort/relatedness.py
@@ -83,9 +83,16 @@ def flag_related(
 ) -> hl.Table:
     """
     Rank samples and flag samples to drop so there is only one sample per family
-    left, with the highest rank in the family.
+    left, with the highest rank in the family. The ranking is based on either
+    'var_data_chr20_mean_dp' or 'autosomal_mean_dp' depending on the
+    'inf_ploidy_using_var' configuration in the `sample_qc_ht`.
 
-    `sample_qc_ht` has to have a `filters` and `var_data_chr20_mean_dp` columns.
+    @param relatedness_ht: table with relatedness information.
+    @param sample_qc_ht: table with either `var_data_chr20_mean_dp` or `autosomal_mean_dp`
+                         and `filters` fields.
+    @param out_relateds_to_drop_ht_path: path to write the output table of samples to drop.
+    @param tmp_prefix: path for temporary files.
+    @return: table of samples to drop, ordered by rank.
     """
     logging.info(f'Flagging related samples to drop')
     if can_reuse(out_relateds_to_drop_ht_path):
@@ -125,17 +132,23 @@ def flag_related(
 def _compute_sample_rankings(ht: hl.Table) -> hl.Table:
     """
     Orders samples by hard filters and coverage and adds rank, which is the lower,
-    the better.
+    the better. The ranking is based on either 'var_data_chr20_mean_dp' or
+    'autosomal_mean_dp' depending on the 'inf_ploidy_using_var' configuration.
 
-    @param ht: table with a `var_data_chr20_mean_dp` and `filters` fields.
+    @param ht: table with either `var_data_chr20_mean_dp` or `autosomal_mean_dp` and `filters` fields.
     @return: table ordered by rank, with the following row fields:
         `rank`, `filtered`
     """
+    use_only_variants = get_config()['large_cohort'].get('inf_ploidy_using_var', False)
+    if use_only_variants:
+        ranking_column = 'var_data_chr20_mean_dp'
+    else:
+        ranking_column = 'autosomal_mean_dp'
     ht = ht.drop(*list(ht.globals.dtype.keys()))
     ht = ht.select(
-        'var_data_chr20_mean_dp',
+        ranking_column,
         filtered=hl.len(ht.filters) > 0,
     )
-    ht = ht.order_by(ht.filtered, hl.desc(ht.var_data_chr20_mean_dp))
+    ht = ht.order_by(ht.filtered, hl.desc(ht[ranking_column]))
     ht = ht.add_index(name='rank')
     return ht.key_by('s').select('filtered', 'rank')

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -137,10 +137,6 @@ def impute_sex(
         variants_filter_segdup=False,  # already filtered above
         variants_filter_decoy=False,
     )
-    # Rename  `autosomal_mean_dp` to `var_data_chr20_mean_dp` (not sure if we want to hardcode 'chr20' here)
-    sex_ht = sex_ht.rename(
-        {'autosomal_mean_dp': f'var_data_chr20_mean_dp'}
-    )
     logging.info('Sex table:')
     sex_ht.describe()
     sex_ht = sex_ht.transmute(

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -122,7 +122,7 @@ def impute_sex(
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 
     # Infer sex (adds row fields: is_female, var_data_chr20_mean_dp, sex_karyotype)
-    inf_ploidy_using_var = get_config()['large_cohort'].get(
+    inf_ploidy_using_var = get_config()['large_cohort']['pca_background'].get(
         'inf_ploidy_using_var', False
     )
     sex_ht = annotate_sex(
@@ -179,9 +179,19 @@ def add_soft_filters(ht: hl.Table) -> hl.Table:
 
     # Remove low-coverage samples
     # chrom 20 coverage is computed to infer sex and used here
+    # if `inf_ploidy_using_var` is set to True, then the coverage is computed
+    # using only variants. Otherwise, the coverage is computed using reference blocks
+    # and the column name subsequently changes
+    use_only_variants = get_config()['large_cohort']['pca_background'].get(
+        'inf_ploidy_using_var', False
+    )
+    if use_only_variants:
+        autosomal_coverage_colname = 'var_data_chr20_mean_dp'
+    else:
+        autosomal_coverage_colname = 'autosomal_mean_dp'
     ht = add_filter(
         ht,
-        ht.var_data_chr20_mean_dp < cutoffs['min_coverage'],
+        ht[autosomal_coverage_colname] < cutoffs['min_coverage'],
         'low_coverage',
     )
 

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -122,7 +122,9 @@ def impute_sex(
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 
     # Infer sex (adds row fields: is_female, var_data_chr20_mean_dp, sex_karyotype)
-    inf_ploidy_using_var = get_config()['large_cohort'].get('inf_ploidy_using_var')
+    inf_ploidy_using_var = get_config()['large_cohort'].get(
+        'inf_ploidy_using_var', False
+    )
     sex_ht = annotate_sex(
         vds,
         tmp_prefix=str(tmp_prefix / 'annotate_sex'),

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -8,10 +8,11 @@ import logging
 import hail as hl
 from cpg_utils import Path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import reference_path, genome_build
+from cpg_utils.hail_batch import genome_build, reference_path
+from gnomad.sample_qc.pipeline import annotate_sex
+
 from cpg_workflows.inputs import get_cohort
 from cpg_workflows.utils import can_reuse
-from gnomad.sample_qc.pipeline import annotate_sex
 
 
 def run(
@@ -121,14 +122,15 @@ def impute_sex(
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 
     # Infer sex (adds row fields: is_female, var_data_chr20_mean_dp, sex_karyotype)
+    inf_ploidy_using_var = get_config()['large_cohort'].get('inf_ploidy_using_var')
     sex_ht = annotate_sex(
         vds,
         tmp_prefix=str(tmp_prefix / 'annotate_sex'),
         overwrite=not get_config()['workflow'].get('check_intermediates'),
         included_intervals=calling_intervals_ht,
         gt_expr='LGT',
-        variants_only_x_ploidy=True,
-        variants_only_y_ploidy=True,
+        variants_only_x_ploidy=inf_ploidy_using_var,
+        variants_only_y_ploidy=inf_ploidy_using_var,
         variants_filter_lcr=False,  # already filtered above
         variants_filter_segdup=False,  # already filtered above
         variants_filter_decoy=False,

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -182,10 +182,7 @@ def add_soft_filters(ht: hl.Table) -> hl.Table:
     # if `inf_ploidy_using_var` is set to True, then the coverage is computed
     # using only variants. Otherwise, the coverage is computed using reference blocks
     # and the column name subsequently changes
-    use_only_variants = get_config()['large_cohort']['pca_background'].get(
-        'inf_ploidy_using_var', False
-    )
-    if use_only_variants:
+    if 'var_data_chr20_mean_dp' in ht.row:
         autosomal_coverage_colname = 'var_data_chr20_mean_dp'
     else:
         autosomal_coverage_colname = 'autosomal_mean_dp'

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -303,7 +303,7 @@ class JoinRawCalls(CohortStage):
         """ """
 
         input_dict: dict[str, Any] = {
-            'formatter_args': '--fix-end',
+            'FormatVcfForGatk.formatter_args': '--fix-end',
             'prefix': cohort.name,
             'ped_file': make_combined_ped(cohort, self.prefix),
             'reference_fasta': get_fasta(),

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -120,6 +120,7 @@ def create_config(
             'combiner': {
                 'intervals': ['chr20:start-end', 'chrX:start-end', 'chrY:start-end']
             },
+            'pca_background': {'inf_ploidy_using_var': False},
         },
     )
 


### PR DESCRIPTION
There was an observed imbalance in the number of inferred "X" and "XY" samples in the TenK10K Phase 1 cohort. A closer investigation revealed that Y ploidy values were inflated, ranging from 2-6 in both "X" and "XY" samples, contrary to the expected range of 0-1.

**Possible fix:**
The proposed fix involves setting `variants_only_x_ploidy` and `variants_only_y_ploidy` in the `annotate_sex()` function of the SampleQC stage to the default value of False. Currently, both parameters are set to True in the pipeline. This change ensures that reference block depths, rather than solely allele depths at variant sites, are used for calculating coverage across sex chromosomes and subsequently for sex imputation.

We have tested this fix in the test VDS, and it produces Y ploidy values of ~0 in "XX" samples and ~1 in "X" (presumably "XY") samples, aligning with expectations. The default value for these parameters in gnomad v3's SampleQC is also set to False.

This change would allow the user to set the value for `variants_only_x_ploidy` and `variants_only_y_ploidy` in the large_cohort.toml file using `inf_ploidy_using_var`



>https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C