### PR TITLE
Higher-level abstraction to replace `JobResource.get_java_mem_mb()`

### DIFF
--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -221,8 +221,7 @@ def _haplotype_caller_one(
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
     gatk --java-options \
-    "-Xms{job_res.get_java_mem_mb()}m \
-    -Xmx{job_res.get_java_mem_mb()}m \
+    "{job_res.java_mem_options()} \
     -XX:GCTimeLimit=50 \
     -XX:GCHeapFreeLimit=10" \\
     HaplotypeCaller \\
@@ -359,7 +358,7 @@ def postproc_gvcf(
     | bcftools view -Oz -o $GVCF_NODP
     tabix -p vcf $GVCF_NODP
 
-    gatk --java-options "-Xms{job_res.get_java_mem_mb()}m" \\
+    gatk --java-options "{job_res.java_mem_options()}" \\
     ReblockGVCF \\
     --reference {reference.base} \\
     -V $GVCF_NODP \\

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -350,7 +350,7 @@ def _add_joint_genotyper_job(
     cmd = f"""\
     {input_cmd}
 
-    gatk --java-options "-Xmx{res.get_java_mem_mb()}m" \\
+    gatk --java-options "{res.java_mem_options()}" \\
     {tool.name} \\
     -R {reference.base} \\
     -O {j.output_vcf['vcf.gz']} \\
@@ -423,7 +423,7 @@ def _add_excess_het_filter(
     # Capturing stderr to avoid Batch pod from crashing with OOM from millions of
     # warning messages from VariantFiltration, e.g.:
     # > JexlEngine - ![0,9]: 'ExcessHet > 54.69;' undefined variable ExcessHet
-    gatk --java-options -Xms{res.get_java_mem_mb()}m \\
+    gatk --java-options "{res.java_mem_options()}" \\
     VariantFiltration \\
     --filter-expression 'ExcessHet > {excess_het_threshold}' \\
     --filter-name ExcessHet \\
@@ -477,7 +477,7 @@ def add_make_sitesonly_job(
     j.command(
         command(
             f"""
-    gatk --java-options -Xms{res.get_java_mem_mb()}m \\
+    gatk --java-options "{res.java_mem_options()}" \\
     MakeSitesOnlyVcf \\
     -I {input_vcf['vcf.gz']} \\
     -O {j.output_vcf['vcf.gz']}

--- a/cpg_workflows/jobs/mito.py
+++ b/cpg_workflows/jobs/mito.py
@@ -358,7 +358,6 @@ def mito_mutect2(
     j.image(image_path('gatk'))
 
     res = STANDARD.set_resources(j, ncpu=4)
-    java_mem_mb = res.get_java_mem_mb()
 
     j.declare_resource_group(
         output_vcf={
@@ -369,7 +368,7 @@ def mito_mutect2(
     )
 
     cmd = f"""
-        gatk --java-options "-Xmx{java_mem_mb}m" Mutect2 \
+        gatk --java-options "{res.java_mem_options()}" Mutect2 \
             -R {reference.base} \
             -I {cram.cram} \
             --read-filter MateOnSameContigOrNoMappedMateReadFilter \

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -158,7 +158,7 @@ def markdup(
 
     assert isinstance(j.output_cram, hb.ResourceGroup)
     cmd = f"""
-    picard MarkDuplicates -Xms{resource.get_java_mem_mb()}M \\
+    picard {resource.java_mem_options()} MarkDuplicates \\
     I={sorted_bam} O={j.temp_bam} M={j.markdup_metrics} \\
     TMP_DIR=$(dirname {j.output_cram.cram})/picard-tmp \\
     ASSUME_SORT_ORDER=coordinate
@@ -221,7 +221,7 @@ def vcf_qc(
         input_file = vcf_or_gvcf['vcf.gz']
 
     cmd = f"""\
-    picard -Xms2000m -Xmx{res.get_java_mem_mb()}m \
+    picard {res.java_mem_options()} \
     CollectVariantCallingMetrics \
     INPUT={input_file} \
     OUTPUT=$BATCH_TMPDIR/prefix \
@@ -289,7 +289,7 @@ def picard_collect_metrics(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
-    picard -Xmx{res.get_java_mem_mb()}m \\
+    picard {res.java_mem_options()} \\
       CollectMultipleMetrics \\
       INPUT=$CRAM \\
       REFERENCE_SEQUENCE={reference.base} \\
@@ -372,7 +372,7 @@ def picard_hs_metrics(
     O=$BATCH_TMPDIR/intervals.interval_list \\
     SD={reference.dict}
 
-    picard -Xmx{res.get_java_mem_mb()}m \\
+    picard {res.java_mem_options()} \\
       CollectHsMetrics \\
       INPUT=$CRAM \\
       REFERENCE_SEQUENCE={reference.base} \\
@@ -426,7 +426,7 @@ def picard_wgs_metrics(
     retry_gs_cp {str(cram_path.path)} $CRAM
     retry_gs_cp {str(cram_path.index_path)} $CRAI
 
-    picard -Xmx{res.get_java_mem_mb()}m \\
+    picard {res.java_mem_options()} \\
       CollectWgsMetrics \\
       INPUT=$CRAM \\
       VALIDATION_STRINGENCY=SILENT \\

--- a/cpg_workflows/jobs/vqsr.py
+++ b/cpg_workflows/jobs/vqsr.py
@@ -399,9 +399,7 @@ def indel_recalibrator_job(
         f"""set -euo pipefail
 
     gatk --java-options \
-      "-Xms{res.get_java_mem_mb()}m \
-      -XX:+UseParallelGC \
-      -XX:ParallelGCThreads={res.get_nthreads() - 2}" \\
+      "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
       VariantRecalibrator \\
       -V {siteonly_vcf['vcf.gz']} \\
       -O {j.recalibration} \\
@@ -480,9 +478,7 @@ def snps_recalibrator_create_model_job(
         f"""set -euo pipefail
 
     gatk --java-options \
-      "-Xms{res.get_java_mem_mb()}m \
-      -XX:+UseParallelGC \
-      -XX:ParallelGCThreads={res.get_nthreads() - 2}" \\
+      "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
       VariantRecalibrator \\
       -V {siteonly_vcf['vcf.gz']} \\
       -O {j.recalibration} \\
@@ -558,9 +554,7 @@ def snps_recalibrator_scattered(
     MODEL_REPORT={model_file}
 
     gatk --java-options \
-      "-Xms{res.get_java_mem_mb()}m \
-      -XX:+UseParallelGC \
-      -XX:ParallelGCThreads={res.get_nthreads() - 2}" \\
+      "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
       VariantRecalibrator \\
       -V {siteonly_vcf['vcf.gz']} \\
       -O {j.recalibration} \\
@@ -625,9 +619,7 @@ def snps_recalibrator_job(
         f"""set -euo pipefail
 
     gatk --java-options \
-      "-Xms{res.get_java_mem_mb()}m \
-      -XX:+UseParallelGC \
-      -XX:ParallelGCThreads={res.get_nthreads() - 2}" \\
+      "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
       VariantRecalibrator \\
       -V {sites_only_variant_filtered_vcf['vcf.gz']} \\
       -O {j.recalibration} \\
@@ -677,7 +669,7 @@ def snps_gather_tranches_job(
     j.command(
         f"""set -euo pipefail
 
-    gatk --java-options -Xms{res.get_java_mem_mb()}m \\
+    gatk --java-options "{res.java_mem_options()}" \\
       GatherTranches \\
       --mode SNP \\
       {inputs_cmdl} \\
@@ -725,7 +717,7 @@ def apply_recalibration_snps(
     cp {recalibration} $BATCH_TMPDIR/recalibration
     cp {recalibration_idx} $BATCH_TMPDIR/recalibration.idx
 
-    gatk --java-options -Xms{res.get_java_mem_mb()}m \\
+    gatk --java-options "{res.java_mem_options()}" \\
     ApplyVQSR \\
     -O $BATCH_TMPDIR/output.vcf.gz \\
     -V {input_vcf['vcf.gz']} \\
@@ -792,7 +784,7 @@ def apply_recalibration_indels(
     mv {recalibration} $BATCH_TMPDIR/recalibration
     mv {recalibration_idx} $BATCH_TMPDIR/recalibration.idx
 
-    gatk --java-options -Xms{res.get_java_mem_mb()}m \\
+    gatk --java-options "{res.java_mem_options()}" \\
     ApplyVQSR \\
     --tmp-dir $BATCH_TMPDIR \\
     -O {j.output_vcf['vcf.gz']} \\

--- a/cpg_workflows/resources.py
+++ b/cpg_workflows/resources.py
@@ -245,15 +245,6 @@ class JobResource:
         """
         return self.get_ncpu() * self.machine_type.mem_gb_per_core
 
-    def get_java_mem_mb(self) -> int:
-        """
-        Calculate memory to pass to the `java -Xms` option.
-        Subtracts 1G to start a java VM, and converts to MB as the option doesn't
-        support fractions of GB.
-        """
-        # get_mem_gb() is usually decimal GB, but our value is used as binary MiB
-        return int(math.floor((self.get_mem_gb() - 1) * 953.6))
-
     def java_mem_options(self, overhead_gb: float = 1) -> str:
         """
         Returns -Xms -Xmx options to set Java JVM memory usage to use all the memory


### PR DESCRIPTION
This addresses (most of) #500 by introducing `java_mem_options()` to encapsulate both `-Xms` and `-Xmx` options, and also `java_gc_thread_options()` to simplify another repeated `-XX` pattern.

We could add `get_…` to the names of these methods, but unlike the other getters that return an individual property, these produce a complete option string — so they can be thought of as being conceptually different.

The only real behaviour change here is in the `markdup()` memory override, in which when you set `resource_overrides.picard_mem_gb` the Java heap now actually takes advantage of all the memory you've given it.

There are still several snippets that hard-code various lowish memory values for `-Xmx` etc which could be brought into the fold.