### PR TITLE
Remove 'v' Prefix from VDS Version in Large Cohort Pipeline for Better Output Version Handling

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -18,8 +18,6 @@ class Combiner(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> Path:
         if vds_version := get_config()['workflow'].get('vds_version'):
             vds_version = slugify(vds_version)
-            if not vds_version.startswith('v'):
-                vds_version = f'v{vds_version}'
 
         vds_version = vds_version or get_workflow().output_version
         return cohort.analysis_dataset.prefix() / 'vds' / f'{vds_version}.vds'


### PR DESCRIPTION
This Pull Request (PR) addresses an issue in the large_cohort pipeline where specifying an `output_version` in the configuration file doesn't allow for both reusing a previous VDS version and specifying a new `sample_qc_ht` version prefix.

The large_cohort pipeline has a parameter to specify the VDS version, but it prepends a 'v' to this version. This becomes a problem when the previous VDS was specified by `output_version`, because a VDS with a name like `v1-0.vds` won't exist.

To solve this issue, the PR removes the prepending of 'v' to the `vds_version`. This allows for the correct referencing of VDS files when they are named using the `output_version` scheme, and enables the generation of a new `sample_qc_ht` version while reusing a specified `output_version` VDS.

This change enhances the flexibility of the large_cohort pipeline, making it possible to compare new `SampleQC` results with a previous `sample_qc_ht `output, while also using the corresponding VDS from the previous run.