### PR TITLE
Y-Ploidy Issues: Use variant data for X ploidy and ref-blocks for Y ploidy

### DIFF
--- a/cpg_workflows/large_cohort/relatedness.py
+++ b/cpg_workflows/large_cohort/relatedness.py
@@ -133,22 +133,17 @@ def flag_related(
 def _compute_sample_rankings(ht: hl.Table) -> hl.Table:
     """
     Orders samples by hard filters and coverage and adds rank, which is the lower,
-    the better. The ranking is based on either 'var_data_chr20_mean_dp' or
-    'autosomal_mean_dp' depending on the 'inf_ploidy_using_var' configuration.
+    the better.
 
-    @param ht: table with either `var_data_chr20_mean_dp` or `autosomal_mean_dp` and `filters` fields.
+    @param ht: table with a `var_data_chr20_mean_dp` and `filters` fields.
     @return: table ordered by rank, with the following row fields:
         `rank`, `filtered`
     """
-    if 'var_data_chr20_mean_dp' in ht.row:
-        ranking_column = 'var_data_chr20_mean_dp'
-    else:
-        ranking_column = 'autosomal_mean_dp'
     ht = ht.drop(*list(ht.globals.dtype.keys()))
     ht = ht.select(
-        ranking_column,
+        'var_data_chr20_mean_dp',
         filtered=hl.len(ht.filters) > 0,
     )
-    ht = ht.order_by(ht.filtered, hl.desc(ht[ranking_column]))
+    ht = ht.order_by(ht.filtered, hl.desc(ht.var_data_chr20_mean_dp))
     ht = ht.add_index(name='rank')
     return ht.key_by('s').select('filtered', 'rank')

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -122,17 +122,14 @@ def impute_sex(
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 
     # Infer sex (adds row fields: is_female, var_data_chr20_mean_dp, sex_karyotype)
-    inf_ploidy_using_var = get_config()['large_cohort']['pca_background'].get(
-        'inf_ploidy_using_var', False
-    )
     sex_ht = annotate_sex(
         vds,
         tmp_prefix=str(tmp_prefix / 'annotate_sex'),
         overwrite=not get_config()['workflow'].get('check_intermediates'),
         included_intervals=calling_intervals_ht,
         gt_expr='LGT',
-        variants_only_x_ploidy=inf_ploidy_using_var,
-        variants_only_y_ploidy=inf_ploidy_using_var,
+        variants_only_x_ploidy=True,
+        variants_only_y_ploidy=False,
         variants_filter_lcr=False,  # already filtered above
         variants_filter_segdup=False,  # already filtered above
         variants_filter_decoy=False,
@@ -182,13 +179,9 @@ def add_soft_filters(ht: hl.Table) -> hl.Table:
     # if `inf_ploidy_using_var` is set to True, then the coverage is computed
     # using only variants. Otherwise, the coverage is computed using reference blocks
     # and the column name subsequently changes
-    if 'var_data_chr20_mean_dp' in ht.row:
-        autosomal_coverage_colname = 'var_data_chr20_mean_dp'
-    else:
-        autosomal_coverage_colname = 'autosomal_mean_dp'
     ht = add_filter(
         ht,
-        ht[autosomal_coverage_colname] < cutoffs['min_coverage'],
+        ht.var_data_chr20_mean_dp < cutoffs['min_coverage'],
         'low_coverage',
     )
 

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -120,7 +120,6 @@ def create_config(
             'combiner': {
                 'intervals': ['chr20:start-end', 'chrX:start-end', 'chrY:start-end']
             },
-            'pca_background': {'inf_ploidy_using_var': False},
         },
     )
 


### PR DESCRIPTION
As per gnomAD v4 https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0/#sex-inference documentation, the Broad used different methods to infer ploidy for X and Y. ChrX used variant sites to infer ploidy, while ChrY used reference blocks. Previous PR's used ref-blocks for both sex chromosomes, though this lead to Hail Batch/Dataproc failures after nearly 16 hours, see here: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1706054837310759 and https://centrepopgen.slack.com/archives/C018KFBCR1C/p1704233101883849 for context.

