### PR TITLE
Remove reference to inf_ploidy_using_var

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -58,7 +58,6 @@ inferred_ancestry = false
 # Setting `variants_only_x_ploidy` and `variants_only_y_ploidy` to `False` (default value) causes
 # function to use reference blocks for ploidy calculations
 # https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C
-inf_ploidy_using_var = false
 
 # Parameters for sample QC. The default values for soft filtering taken from gnomAD QC:
 # https://macarthurlab.org/2019/10/16/gnomad-v3-0, with `max_n_snps` and 

--- a/cpg_workflows/large_cohort/relatedness.py
+++ b/cpg_workflows/large_cohort/relatedness.py
@@ -85,8 +85,7 @@ def flag_related(
     Rank samples and flag samples to drop so there is only one sample per family
     left, with the highest rank in the family. The ranking is based on either
     'var_data_chr20_mean_dp' or 'autosomal_mean_dp' depending on which is present
-    in the `sample_qc_ht` table. The presence of either column is determined by
-    the 'inf_ploidy_using_var' parameter in the config toml.
+    in the `sample_qc_ht` table.
 
     @param relatedness_ht: table with relatedness information.
     @param sample_qc_ht: table with either `var_data_chr20_mean_dp` or `autosomal_mean_dp`

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -176,9 +176,6 @@ def add_soft_filters(ht: hl.Table) -> hl.Table:
 
     # Remove low-coverage samples
     # chrom 20 coverage is computed to infer sex and used here
-    # if `inf_ploidy_using_var` is set to True, then the coverage is computed
-    # using only variants. Otherwise, the coverage is computed using reference blocks
-    # and the column name subsequently changes
     ht = add_filter(
         ht,
         ht.var_data_chr20_mean_dp < cutoffs['min_coverage'],


### PR DESCRIPTION
Removed config parameter to infer ploidy. Refactored docstrings of various functions to remove reference to this config parameter