### PR TITLE
Precompute coverage mt

### DIFF
--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -21,8 +21,8 @@ def run(
     out_sample_qc_ht_path: Path,
     tmp_prefix: Path,
 ):
-    if can_reuse(out_sample_qc_ht_path, overwrite=True):
-        return hl.read_table(str(out_sample_qc_ht_path))
+    # if can_reuse(out_sample_qc_ht_path, overwrite=True):
+    #     return hl.read_table(str(out_sample_qc_ht_path))
 
     ht = initialise_sample_table()
 
@@ -35,15 +35,17 @@ def run(
 
     # Run Hail sample-QC stats:
     sqc_ht_path = tmp_prefix / 'sample_qc.ht'
-    if can_reuse(sqc_ht_path, overwrite=True):
-        sqc_ht = hl.read_table(str(sqc_ht_path))
-    else:
-        # Filter to autosomes:
-        autosome_vds = hl.vds.filter_chromosomes(
-            vds, keep=[f'chr{chrom}' for chrom in range(1, 23)]
-        )
-        sqc_ht = hl.vds.sample_qc(autosome_vds)
-        sqc_ht = sqc_ht.checkpoint(str(sqc_ht_path), overwrite=True)
+    # if can_reuse(sqc_ht_path, overwrite=True):
+    #     sqc_ht = hl.read_table(str(sqc_ht_path))
+    # else:
+
+    # Filter to autosomes:
+    autosome_vds = hl.vds.filter_chromosomes(
+        vds, keep=[f'chr{chrom}' for chrom in range(1, 23)]
+    )
+    sqc_ht = hl.vds.sample_qc(autosome_vds)
+    sqc_ht = sqc_ht.checkpoint(str(sqc_ht_path), overwrite=True)
+
     ht = ht.annotate(sample_qc=sqc_ht[ht.s])
     logging.info('Sample QC table:')
     ht.describe()
@@ -172,9 +174,9 @@ def impute_sex(
     Impute sex based on coverage.
     """
     checkpoint_path = tmp_prefix / 'sample_qc' / 'sex.ht'
-    if can_reuse(str(checkpoint_path), overwrite=True):
-        sex_ht = hl.read_table(str(checkpoint_path))
-        return ht.annotate(**sex_ht[ht.s])
+    # if can_reuse(str(checkpoint_path), overwrite=True):
+    #     sex_ht = hl.read_table(str(checkpoint_path))
+    #     return ht.annotate(**sex_ht[ht.s])
 
     # Load calling intervals
     seq_type = get_config()['workflow']['sequencing_type']

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -125,7 +125,7 @@ def generate_sex_coverage_mt(
     if can_reuse(checkpoint_path):
         calling_intervals = hl.read_matrix_table(str(checkpoint_path))
     else:
-        calling_intervals = calling_intervals.checkpoint(str(checkpoint_path), overwrite=True)
+        calling_intervals = calling_intervals.checkpoint(str(checkpoint_path))
 
     interval = calling_intervals.key[0]
     (any_bad_intervals, chrs_represented) = calling_intervals.aggregate(
@@ -158,7 +158,7 @@ def generate_sex_coverage_mt(
     if can_reuse(checkpoint_path):
         coverage = hl.read_matrix_table(str(checkpoint_path))
     else:
-        coverage = coverage.checkpoint(str(checkpoint_path), overwrite=True)
+        coverage = coverage.checkpoint(str(checkpoint_path))
 
     return coverage
 

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -104,8 +104,8 @@ def generate_sex_coverage_mt(
             not isinstance(calling_intervals.key[0].dtype, hl.tinterval) or
             calling_intervals.key[0].dtype.point_type != vds.reference_data.locus.dtype
     ):
-        raise ValueError(f"'impute_sex_chromosome_ploidy': expect calling_intervals to be list of intervals or"
-                         f" table with single key of type interval<locus>, found table with key: {key_dtype}")
+        raise ValueError(f'"impute_sex_chromosome_ploidy": expect calling_intervals to be list of intervals or '
+                         f'table with single key of type interval<locus>, found table with key: {key_dtype}')
 
     rg = vds.reference_data.locus.dtype.reference_genome
     par_boundaries = []

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -21,8 +21,8 @@ def run(
     out_sample_qc_ht_path: Path,
     tmp_prefix: Path,
 ):
-    # if can_reuse(out_sample_qc_ht_path, overwrite=True):
-    #     return hl.read_table(str(out_sample_qc_ht_path))
+    if can_reuse(out_sample_qc_ht_path, overwrite=True):
+        return hl.read_table(str(out_sample_qc_ht_path))
 
     ht = initialise_sample_table()
 
@@ -35,16 +35,16 @@ def run(
 
     # Run Hail sample-QC stats:
     sqc_ht_path = tmp_prefix / 'sample_qc.ht'
-    # if can_reuse(sqc_ht_path, overwrite=True):
-    #     sqc_ht = hl.read_table(str(sqc_ht_path))
-    # else:
+    if can_reuse(sqc_ht_path, overwrite=True):
+        sqc_ht = hl.read_table(str(sqc_ht_path))
+    else:
 
-    # Filter to autosomes:
-    autosome_vds = hl.vds.filter_chromosomes(
-        vds, keep=[f'chr{chrom}' for chrom in range(1, 23)]
-    )
-    sqc_ht = hl.vds.sample_qc(autosome_vds)
-    sqc_ht = sqc_ht.checkpoint(str(sqc_ht_path), overwrite=True)
+        # Filter to autosomes:
+        autosome_vds = hl.vds.filter_chromosomes(
+            vds, keep=[f'chr{chrom}' for chrom in range(1, 23)]
+        )
+        sqc_ht = hl.vds.sample_qc(autosome_vds)
+        sqc_ht = sqc_ht.checkpoint(str(sqc_ht_path), overwrite=True)
 
     ht = ht.annotate(sample_qc=sqc_ht[ht.s])
     logging.info('Sample QC table:')
@@ -124,7 +124,7 @@ def generate_sex_coverage_mt(
 
     # checkpoint for efficient multiple downstream usages
     checkpoint_path = tmp_prefix / 'sample_qc' / 'calling_intervals_partial.ht'
-    if can_reuse(checkpoint_path):
+    if can_reuse(checkpoint_path, overwrite=True):
         calling_intervals = hl.read_matrix_table(str(checkpoint_path))
     else:
         calling_intervals = calling_intervals.checkpoint(str(checkpoint_path))
@@ -154,10 +154,11 @@ def generate_sex_coverage_mt(
     mt = mt.annotate_rows(interval=calling_intervals[mt.locus].interval_dup)
     mt = mt.filter_rows(hl.is_defined(mt.interval))
     coverage = mt.select_entries(sum_dp=mt.DP, interval_size=hl.is_defined(mt.DP))
+    coverage = coverage.key_rows_by('locus')
 
     # checkpoint the coverage mt prior to returning
     checkpoint_path = tmp_prefix / 'sample_qc' / 'sex_coverage_precomputed.ht'
-    if can_reuse(checkpoint_path):
+    if can_reuse(checkpoint_path, overwrite=True):
         coverage = hl.read_matrix_table(str(checkpoint_path))
     else:
         coverage = coverage.checkpoint(str(checkpoint_path))
@@ -174,9 +175,9 @@ def impute_sex(
     Impute sex based on coverage.
     """
     checkpoint_path = tmp_prefix / 'sample_qc' / 'sex.ht'
-    # if can_reuse(str(checkpoint_path), overwrite=True):
-    #     sex_ht = hl.read_table(str(checkpoint_path))
-    #     return ht.annotate(**sex_ht[ht.s])
+    if can_reuse(str(checkpoint_path), overwrite=True):
+        sex_ht = hl.read_table(str(checkpoint_path))
+        return ht.annotate(**sex_ht[ht.s])
 
     # Load calling intervals
     seq_type = get_config()['workflow']['sequencing_type']

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -169,6 +169,10 @@ class TestAllLargeCohortMethods:
             'cpg_workflows.large_cohort.site_only_vcf.can_reuse',
             lambda x: False
         )
+        mocker.patch(
+            'cpg_workflows.large_cohort.sample_qc.can_reuse',
+            lambda x: False
+        )
 
         start_query_context()
 

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -169,10 +169,10 @@ class TestAllLargeCohortMethods:
             'cpg_workflows.large_cohort.site_only_vcf.can_reuse',
             lambda x: False
         )
-        mocker.patch(
-            'cpg_workflows.large_cohort.sample_qc.can_reuse',
-            lambda x: False
-        )
+        # mocker.patch(
+        #     'cpg_workflows.large_cohort.sample_qc.can_reuse',
+        #     lambda x: False
+        # )
 
         start_query_context()
 


### PR DESCRIPTION
When we call annotate_sex, we do it without a `coverage_mt`. This leads to a behaviour where the gnomad_methods will go off and generate the pre-computed coverage MT, then call the version of the method which requires that input [here](https://github.com/hail-is/hail/blob/5fde6f2a8cf0d520769efd6f9ea2db10a033f976/hail/python/hail/vds/methods.py#L459).

Effectively this is an attempt to bridge the gap between the method calls, generating that MT using the same code as is present in [the naive impute_sex_chromosome_ploidy](https://github.com/hail-is/hail/blob/5fde6f2a8cf0d520769efd6f9ea2db10a033f976/hail/python/hail/vds/methods.py#L531-L631) method, and checkpointing the results in a recoverable way.

The method [here](https://github.com/hail-is/hail/blob/5fde6f2a8cf0d520769efd6f9ea2db10a033f976/hail/python/hail/vds/methods.py#L595) does checkpoint partway through into Batch temp space, but then carries out a bunch of operations on the returned object without checkpointing. This implementation explicitly checkpoints the final object prior to returning, which may help with memory issues we're seeing in dataproc. Not sure if this change is sufficient.