### PR TITLE
gCNV annotate cohort

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.20
+current_version = 1.19.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.18.20
+  VERSION: 1.19.0
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -391,7 +391,7 @@ def merge_calls(
     sg_vcfs: list[str],
     docker_image: str,
     job_attrs: dict[str, str],
-    output_path: Path,
+    output_path: Path
 ):
     """
     This job will run a fast simple merge on per-SGID call files

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -488,8 +488,8 @@ def update_vcf_attributes(input_tmp: str, output_file: str):
                 # but do insert additional INFO field lines
                 if line.startswith('##INFO=<ID=END'):
                     headers.extend([
-                        '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="SV Type">\n',
-                        '##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="SV Length">\n']
+                        '##INFO=<ID=SVTYPE,Number=.,Type=String,Description="SV Type">\n',
+                        '##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="SV Length">\n']
                     )
             # for non-header lines
             else:

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -60,18 +60,9 @@ def annotate_cohort_gcnv(
         sourceFilePath=vcf_path,
         genomeVersion=genome_build().replace('GRCh', ''),
         hail_version=hl.version(),
-        datasetType='SV',
+        datasetType='CNV',
+        sampleType='WES'
     )
-    if sequencing_type := get_config()['workflow'].get('sequencing_type'):
-        # Map to Seqr-style string
-        # https://github.com/broadinstitute/seqr/blob/e0c179c36c0f68c892017de5eab2e4c1b9ffdc92/seqr/models.py#L592-L594
-        mt = mt.annotate_globals(
-            sampleType={
-                'genome': 'WGS',
-                'exome': 'WES',
-                'single_cell': 'RNA',
-            }.get(sequencing_type, ''),
-        )
 
     # reimplementation of
     # github.com/populationgenomics/seqr-loading-pipelines..luigi_pipeline/lib/model/sv_mt_schema.py
@@ -100,13 +91,7 @@ def annotate_cohort_gcnv(
             > 0,
             mt.filters,
         ),
-        bothsides_support=mt.filters.any(lambda x: x == BOTHSIDES_SUPPORT),
-        algorithms=mt.info.ALGORITHMS,
-        cpx_intervals=hl.or_missing(
-            hl.is_defined(mt.info.CPX_INTERVALS),
-            mt.info.CPX_INTERVALS.map(lambda x: get_cpx_interval(x)),
-        ),
-        sv_types=mt.alleles[1].replace('[<>]', '').split(':', 2),
+        sv_types=mt.alleles[1].replace('[<>]', ''),
     )
 
     # save those changes

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -40,6 +40,7 @@ def parse_genes(gene_col: hl.expr.StringExpression) -> hl.expr.SetExpression:
 def hl_agg_collect_set_union(gene_col: hl.expr.SetExpression) -> hl.expr.SetExpression:
     return hl.flatten(hl.agg.collect_as_set(gene_col))
 
+
 def annotate_cohort_gcnv(
     vcf_path: str, out_mt_path: str, checkpoint_prefix: str | None = None
 ):
@@ -145,7 +146,7 @@ def annotate_cohort_gcnv(
 
     mt = mt.annotate_rows(
         # this expected mt.variant_name to be present, and it's not
-        variantId=hl.format(f"%s_%s_{datetime.date.today():%m%d%Y}", mt.rsid, mt.svType),
+        variantId=hl.format(f'%s_%s_{datetime.date.today():%m%d%Y}', mt.rsid, mt.svType),
         geneIds=hl.set(hl.filter(
             hl.is_defined,
             [
@@ -164,8 +165,8 @@ def annotate_cohort_gcnv(
                     major_consequence_genes.contains(gene),
                     hl.if_else(
                         lof_genes.contains(gene),
-                        "LOF",
-                        "COPY_GAIN",
+                        'LOF',
+                        'COPY_GAIN',
                     ),
                 ),
             ),

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -1,0 +1,324 @@
+"""
+Hail Query functions for seqr loader; SV edition.
+"""
+
+import gzip
+import logging
+import requests
+
+import hail as hl
+
+from cpg_utils import to_path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import genome_build, reference_path
+from cpg_workflows.utils import read_hail, checkpoint_hail
+
+
+# I'm just going to go ahead and steal these constants from their seqr loader
+GENE_SYMBOL = 'gene_symbol'
+GENE_ID = 'gene_id'
+MAJOR_CONSEQUENCE = 'major_consequence'
+PASS = 'PASS'
+
+# Used to filter mt.info fields.
+CONSEQ_PREDICTED_PREFIX = 'PREDICTED_'
+NON_GENE_PREDICTIONS = {
+    'PREDICTED_INTERGENIC',
+    'PREDICTED_NONCODING_BREAKPOINT',
+    'PREDICTED_NONCODING_SPAN',
+}
+
+
+def annotate_cohort_gcnv(
+    vcf_path: str, out_mt_path: str, checkpoint_prefix: str | None = None
+):
+    """
+    Translate an annotated gCNV VCF into a Seqr-ready format
+    Relevant gCNV specific schema
+    https://github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/lib/model/gcnv_mt_schema.py
+    Relevant gCNV loader script
+    https://github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/seqr_gcnv_loading.py
+    Args:
+        vcf_path (str): Where is the VCF??
+        out_mt_path (str): And where do you need output!?
+        checkpoint_prefix (str): CHECKPOINT!@!!
+    """
+
+    logger = logging.getLogger('annotate_cohort_gcnv')
+    logger.setLevel(logging.INFO)
+
+    logger.info(f'Importing SV VCF {vcf_path}')
+    mt = hl.import_vcf(
+        vcf_path,
+        reference_genome=genome_build(),
+        skip_invalid_loci=True,
+        force_bgz=True,
+    )
+
+    # add attributes required for Seqr
+    mt = mt.annotate_globals(
+        sourceFilePath=vcf_path,
+        genomeVersion=genome_build().replace('GRCh', ''),
+        hail_version=hl.version(),
+        datasetType='SV',
+    )
+    if sequencing_type := get_config()['workflow'].get('sequencing_type'):
+        # Map to Seqr-style string
+        # https://github.com/broadinstitute/seqr/blob/e0c179c36c0f68c892017de5eab2e4c1b9ffdc92/seqr/models.py#L592-L594
+        mt = mt.annotate_globals(
+            sampleType={
+                'genome': 'WGS',
+                'exome': 'WES',
+                'single_cell': 'RNA',
+            }.get(sequencing_type, ''),
+        )
+
+    # reimplementation of
+    # github.com/populationgenomics/seqr-loading-pipelines..luigi_pipeline/lib/model/sv_mt_schema.py
+    mt = mt.annotate_rows(
+        sc=mt.info.AC[0],
+        sf=mt.info.AF[0],
+        sn=mt.info.AN,
+        end=mt.info.END,
+        end_locus=hl.if_else(
+            hl.is_defined(mt.info.END2),
+            hl.struct(contig=mt.info.CHR2, position=mt.info.END2),
+            hl.struct(contig=mt.locus.contig, position=mt.info.END),
+        ),
+        sv_callset_Het=mt.info.N_HET,
+        sv_callset_Hom=mt.info.N_HOMALT,
+        gnomad_svs_ID=mt.info['gnomad_v2.1_sv_SVID'],
+        gnomad_svs_AF=mt.info['gnomad_v2.1_sv_AF'],
+        gnomad_svs_AC=hl.missing('float64'),
+        gnomad_svs_AN=hl.missing('float64'),
+        # I DON'T HAVE THESE ANNOTATIONS
+        # gnomad_svs_AC=unsafe_cast_int32(mt.info.gnomAD_V2_AC),
+        # gnomad_svs_AN=unsafe_cast_int32(mt.info.gnomAD_V2_AN),
+        StrVCTVRE_score=hl.parse_float(mt.info.StrVCTVRE),
+        filters=hl.or_missing(  # hopefully this plays nicely
+            (mt.filters.filter(lambda x: (x != PASS) & (x != BOTHSIDES_SUPPORT))).size()
+            > 0,
+            mt.filters,
+        ),
+        bothsides_support=mt.filters.any(lambda x: x == BOTHSIDES_SUPPORT),
+        algorithms=mt.info.ALGORITHMS,
+        cpx_intervals=hl.or_missing(
+            hl.is_defined(mt.info.CPX_INTERVALS),
+            mt.info.CPX_INTERVALS.map(lambda x: get_cpx_interval(x)),
+        ),
+        sv_types=mt.alleles[1].replace('[<>]', '').split(':', 2),
+    )
+
+    # save those changes
+    mt = checkpoint_hail(mt, 'initial_annotation_round.mt', checkpoint_prefix)
+
+    # get the Gene-Symbol mapping dict
+    gene_id_mapping_file = download_gencode_gene_id_mapping(
+        get_config().get('gencode_release', '42')
+    )
+    gene_id_mapping = parse_gtf_from_local(gene_id_mapping_file)
+
+    # OK, NOW IT'S BUSINESS TIME
+    conseq_predicted_gene_cols = [
+        gene_col
+        for gene_col in mt.info
+        if (
+            gene_col.startswith(CONSEQ_PREDICTED_PREFIX)
+            and gene_col not in NON_GENE_PREDICTIONS
+        )
+    ]
+
+    # register a chain file
+    liftover_path = reference_path('liftover_38_to_37')
+    rg37 = hl.get_reference('GRCh37')
+    rg38 = hl.get_reference('GRCh38')
+    rg38.add_liftover(str(liftover_path), rg37)
+
+    # annotate with mapped genes
+    # Note I'm adding a Flake8 noqa for B023 (loop variable gene_col unbound)
+    # I've experimented in a notebook and this seems to perform as expected
+    # The homologous small variant seqr_loader method performs a similar function
+    # but in a slightly more complicated way (mediated by a method in the S-L-P
+    # codebase, so as not to trigger Flake8 evaluation)
+    # pos/contig/xpos sourced from
+    # seqr-loading-pipelines...luigi_pipeline/lib/model/seqr_mt_schema.py#L12
+    mt = mt.annotate_rows(
+        sortedTranscriptConsequences=hl.filter(
+            hl.is_defined,
+            [
+                mt.info[gene_col].map(
+                    lambda gene: hl.struct(
+                        **{
+                            GENE_SYMBOL: gene,
+                            GENE_ID: gene_id_mapping.get(gene, hl.missing(hl.tstr)),
+                            MAJOR_CONSEQUENCE: gene_col.replace(  # noqa: B023
+                                CONSEQ_PREDICTED_PREFIX, '', 1
+                            ),
+                        }
+                    )
+                )
+                for gene_col in conseq_predicted_gene_cols
+            ],
+        ).flatmap(lambda x: x),
+        contig=mt.locus.contig.replace('^chr', ''),
+        start=mt.locus.position,
+        pos=mt.locus.position,
+        xpos=get_expr_for_xpos(mt.locus),
+        xstart=get_expr_for_xpos(mt.locus),
+        xstop=get_expr_for_xpos(mt.end_locus),
+        rg37_locus=hl.liftover(mt.locus, 'GRCh37'),
+        rg37_locus_end=hl.or_missing(
+            mt.end_locus.position
+            <= hl.literal(hl.get_reference('GRCh38').lengths)[mt.end_locus.contig],
+            hl.liftover(
+                hl.locus(
+                    mt.end_locus.contig,
+                    mt.end_locus.position,
+                    reference_genome='GRCh38',
+                ),
+                'GRCh37',
+            ),
+        ),
+        svType=mt.sv_types[0],
+        sv_type_detail=hl.if_else(
+            mt.sv_types[0] == 'CPX',
+            mt.info.CPX_TYPE,
+            hl.or_missing(
+                (mt.sv_types[0] == 'INS') & (hl.len(mt.sv_types) > 1),
+                mt.sv_types[1],
+            ),
+        ),
+        variantId=mt.rsid,
+        docId=mt.rsid[0:512],
+    )
+
+    # and some more annotation stuff
+    mt = mt.annotate_rows(
+        transcriptConsequenceTerms=hl.set(
+            mt.sortedTranscriptConsequences.map(lambda x: x[MAJOR_CONSEQUENCE]).extend(
+                [mt.sv_types[0]]
+            )
+        ),
+        geneIds=hl.set(
+            mt.sortedTranscriptConsequences.filter(
+                lambda x: x[MAJOR_CONSEQUENCE] != 'NEAREST_TSS'
+            ).map(lambda x: x[GENE_ID])
+        ),
+        rsid=hl.missing('tstr'),
+    )
+
+    # write this output
+    mt.write(out_mt_path, overwrite=True)
+
+
+def annotate_dataset_sv(mt_path: str, out_mt_path: str):
+    """
+    load the stuff specific to samples in this dataset
+    do this after subsetting to specific samples
+
+    Removing the current logic around comparing genotypes to a previous
+    callset - doesn't fit with the current implementation
+
+    Args:
+        mt_path (str): path to the annotated MatrixTable
+        out_mt_path (str): and where do you want it to end up?
+    """
+
+    logging.info('Annotating genotypes')
+
+    mt = read_hail(mt_path)
+    is_called = hl.is_defined(mt.GT)
+    num_alt = hl.if_else(is_called, mt.GT.n_alt_alleles(), -1)
+    # was_previously_called = hl.is_defined(mt.CONC_ST) & ~mt.CONC_ST.contains('EMPTY')
+    # prev_num_alt = hl.if_else(
+    #     was_previously_called, PREVIOUS_GENOTYPE_N_ALT_ALLELES[hl.set(mt.CONC_ST)], -1
+    # )
+    # concordant_genotype = num_alt == prev_num_alt
+    # discordant_genotype = (num_alt != prev_num_alt) & (prev_num_alt > 0)
+    # novel_genotype = (num_alt != prev_num_alt) & (prev_num_alt == 0)
+    mt = mt.annotate_rows(
+        genotypes=hl.agg.collect(
+            hl.struct(
+                sample_id=mt.s,
+                gq=mt.GQ,
+                cn=mt.RD_CN,
+                num_alt=num_alt,
+                # prev_num_alt=hl.or_missing(discordant_genotype, prev_num_alt),
+                # prev_call=hl.or_missing(
+                #     is_called, was_previously_called & concordant_genotype
+                # ),
+                # new_call=hl.or_missing(
+                #     is_called, ~was_previously_called | novel_genotype
+                # ),
+            )
+        )
+    )
+
+    def _genotype_filter_samples(fn):
+        # Filter on the genotypes.
+        return hl.set(mt.genotypes.filter(fn).map(lambda g: g.sample_id))
+
+    # top level - decorator
+    def _capture_i_decorator(func):
+        # call the returned_function(i) which locks in the value of i
+        def _inner_filter(i):
+            # the _genotype_filter_samples will call this _func with g
+            def _func(g):
+                return func(i, g)
+
+            return _func
+
+        return _inner_filter
+
+    @_capture_i_decorator
+    def _filter_num_alt(i, g):
+        return i == g.num_alt
+
+    @_capture_i_decorator
+    def _filter_samples_gq(i, g):
+        return (g.gq >= i) & (g.gq < i + 10)
+
+    @_capture_i_decorator
+    def _filter_sample_cn(i, g):
+        return g.cn == i
+
+    # github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/lib/model/sv_mt_schema.py#L221
+    # github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/lib/model/seqr_mt_schema.py#L251
+    mt = mt.annotate_rows(
+        # omit samples field for GATKSV callsets. Leaving this here as likely needed
+        # for gCNV specific callsets (maybe)
+        # samples=_genotype_filter_samples(lambda g: True),
+        # samples_new_alt=_genotype_filter_samples(
+        #     lambda g: g.new_call | hl.is_defined(g.prev_num_alt)
+        # ),
+        samples_no_call=_genotype_filter_samples(lambda g: g.num_alt == -1),
+        samples_num_alt=hl.struct(
+            **{
+                '%i' % i: _genotype_filter_samples(_filter_num_alt(i))
+                for i in range(1, 3, 1)
+            }
+        ),
+        samples_gq_sv=hl.struct(
+            **{
+                ('%i_to_%i' % (i, i + 10)): _genotype_filter_samples(
+                    _filter_samples_gq(i)
+                )
+                for i in range(0, 90, 10)
+            }
+        ),
+        # As per `samples` field, I beleive CN stats should only be generated for gCNV only
+        # callsets. In particular samples_cn_2 is used to select ALT_ALT variants,
+        # presumably because this genotype is only asigned when this CN is alt (ie on chrX)
+        # samples_cn=hl.struct(
+        #     **{
+        #         f'{i}': _genotype_filter_samples(_filter_sample_cn(i))
+        #         for i in range(0, 4, 1)
+        #     },
+        #     gte_4=_genotype_filter_samples(lambda g: g.cn >= 4),
+        # ),
+    )
+
+    logging.info('Genotype fields annotated')
+    mt.describe()
+    mt.write(out_mt_path, overwrite=True)
+    logging.info(f'Written  SV MT to {out_mt_path}')

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -696,7 +696,7 @@ class AnnotateDatasetSv(DatasetStage):
             'mt': (
                 dataset.prefix()
                 / 'mt'
-                / f'{get_workflow().output_version}-{dataset.name}.mt'
+                / f'SV-{get_workflow().output_version}-{dataset.name}.mt'
             ),
         }
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -373,7 +373,7 @@ class AnnotateCNVVcfWithStrvctvre(
     analysis_keys=['annotated_vcf'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )
-class AnnotateCohortForSeqr(CohortStage):
+class AnnotateGCNVCohortForSeqr(CohortStage):
     """
     Rearrange the annotations across the cohort to suit Seqr
     """

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -2,16 +2,18 @@
 Stages that implement GATK-gCNV.
 """
 
-from cpg_utils import Path
+from cpg_utils import to_path, Path
 from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
-from cpg_utils.hail_batch import get_batch, image_path
+from cpg_utils.hail_batch import get_batch, image_path, query_command
 from cpg_workflows.jobs import gcnv
+from cpg_workflows.query_modules import seqr_loader_cnv
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     get_images,
     get_references,
     queue_annotate_sv_jobs,
 )
 from cpg_workflows.targets import SequencingGroup, Cohort
+from cpg_workflows.utils import ExpectedResultT
 from cpg_workflows.workflow import (
     stage,
     CohortStage,
@@ -300,8 +302,24 @@ class AnnotateCNV(CohortStage):
         return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
 
 
-@stage(required_stages=AnnotateCNV)
-class AnnotateCNVVcfWithStrvctvre(CohortStage):
+def _gcnv_srvctvre_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, str]:
+    """
+    Callable, adds custom analysis object meta attribute
+    """
+    return {'type': 'gCNV-STRVCTCRE-annotated'}
+
+
+@stage(
+    required_stages=AnnotateCNV,
+    analysis_type='sv',
+    analysis_keys=['strvctvre_vcf'],
+    update_analysis_meta=_gcnv_srvctvre_meta
+)
+class AnnotateCNVVcfWithStrvctvre(
+    CohortStage
+):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
             'strvctvre_vcf': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz',
@@ -347,3 +365,57 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
             strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', '')
         )
         return self.make_outputs(cohort, data=expected_d, jobs=strv_job)
+
+
+@stage(
+    required_stages=AnnotateCNVVcfWithStrvctvre,
+    analysis_type='sv',
+    analysis_keys=['annotated_vcf'],
+    update_analysis_meta=_gcnv_srvctvre_meta,
+)
+class AnnotateCohortForSeqr(CohortStage):
+    """
+    Rearrange the annotations across the cohort to suit Seqr
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> ExpectedResultT:
+        # convert temp path to str to avoid checking existence
+        return {
+            'tmp_prefix': str(self.tmp_prefix),
+            'mt': self.prefix / 'gcnv_annotated_cohort.mt'
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
+        """
+
+        vcf_path = inputs.as_path(target=cohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf')
+
+        checkpoint_prefix = (
+            to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
+        )
+        j = get_batch().new_job(f'annotate gCNV cohort', self.get_job_attrs(cohort))
+        j.image(image_path('cpg_workflows'))
+        j.command(
+            query_command(
+                seqr_loader_cnv,
+                seqr_loader_cnv.annotate_cohort_gcnv.__name__,
+                str(vcf_path),
+                str(self.expected_outputs(cohort)['mt']),
+                str(checkpoint_prefix),
+                setup_gcp=True,
+            )
+        )
+
+        # todo is this necessary?
+        if depends_on := inputs.get_jobs(cohort):
+            j.depends_on(*depends_on)
+
+        return self.make_outputs(
+            cohort,
+            data=self.expected_outputs(cohort),
+            jobs=j,
+        )
+
+

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -370,7 +370,7 @@ class AnnotateCNVVcfWithStrvctvre(
 @stage(
     required_stages=AnnotateCNVVcfWithStrvctvre,
     analysis_type='sv',
-    analysis_keys=['annotated_vcf'],
+    analysis_keys=['mt'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )
 class AnnotateGCNVCohortForSeqr(CohortStage):

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -330,20 +330,20 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
         )['vcf']
 
         strv_job.declare_resource_group(
-            output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
+            output_vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
         )
 
         # run strvctvre
         strv_job.command(
             f'python StrVCTVRE.py '
             f'-i {input_vcf} '
-            f'-o {strv_job.output_vcf["vcf.gz"]} '
+            f'-o {strv_job.output_vcf["vcf.bgz"]} '
             f'-f vcf '
             f'-p {phylop_in_batch}'
         )
-        strv_job.command(f'tabix {strv_job.output_vcf["vcf.gz"]}')
+        strv_job.command(f'tabix {strv_job.output_vcf["vcf.bgz"]}')
 
         get_batch().write_output(
-            strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.gz', '')
+            strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', '')
         )
         return self.make_outputs(cohort, data=expected_d, jobs=strv_job)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -378,7 +378,7 @@ class AnnotateGCNVCohortForSeqr(CohortStage):
     Rearrange the annotations across the cohort to suit Seqr
     """
 
-    def expected_outputs(self, cohort: Cohort) -> ExpectedResultT:
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
         # convert temp path to str to avoid checking existence
         return {
             'tmp_prefix': str(self.tmp_prefix),
@@ -417,5 +417,3 @@ class AnnotateGCNVCohortForSeqr(CohortStage):
             data=self.expected_outputs(cohort),
             jobs=j,
         )
-
-

--- a/main.py
+++ b/main.py
@@ -24,7 +24,13 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import AnnotateCNV, AnnotateCNVVcfWithStrvctvre, GermlineCNVCalls, FastCombineGCNVs
+from cpg_workflows.stages.gcnv import (
+    AnnotateCNV,
+    AnnotateCNVVcfWithStrvctvre,
+    AnnotateGCNVCohortForSeqr,
+    GermlineCNVCalls,
+    FastCombineGCNVs,
+)
 from cpg_workflows.stages.aip import GeneratePanelData, QueryPanelapp, RunHailFiltering, ValidateMOI, CreateAIPHTML
 from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.stages.happy_validation import (
@@ -58,7 +64,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [GermlineCNVCalls, FastCombineGCNVs, AnnotateCNV, AnnotateCNVVcfWithStrvctvre],
+    'gcnv': [GermlineCNVCalls, FastCombineGCNVs, AnnotateCNV, AnnotateCNVVcfWithStrvctvre, AnnotateGCNVCohortForSeqr],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.18.20',
+    version='1.19.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds the equivalent to AnnotateCohort but for gCNV results

Most of this is new code, some tweaks to previous stages:

1. Fixing of `Number=1` in the added VCF headers to `Number=.` (spotted by @jmarshall)
2. `get_expr_for_xpos` in the SV script now also takes a hail Struct (an update to the type inference, usage here is passing a Struct with the same attributes as a Hail Locus, so behaviour is unchanged) - some linting changes in this file
3. The SV MT generated has a better name (prefixed with `SV` to differentiate from the small variant analysis results. We could also move this to a separate folder instead of `dataset bucket/mt`)
4. Correction to the output names in the Strvctvre Stage - a borked string replacement was generating final files called `XXX.vCf.gz.vcf.bgz`. Also adds metamist registration to these output files

All the rest is adding the AnnotateCohort functionality for gCNV data, emulating the SV equivalent in our pipeline, but based on [this](https://github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/lib/model/gcnv_mt_schema.py#L16)