### PR TITLE
Auto-restrict some datasets from generating ES indexes

### DIFF
--- a/configs/defaults/gatk_sv_multisample_2.toml
+++ b/configs/defaults/gatk_sv_multisample_2.toml
@@ -3,6 +3,7 @@ name = 'gatk_sv'
 dataset_gcp_project = 'seqr-308602'
 dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+skip_es_index_for_datasets = ['vcgs-clinical']
 
 [references.gatk_sv]
 # This model is trained on the All Of Us dataset. If this is used in any published work,

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -3,6 +3,7 @@ name = 'seqr_loader'
 dataset_gcp_project = 'seqr-308602'
 dataset = 'seqr'
 status_reporter = 'metamist'
+skip_es_index_for_datasets = ['vcgs-clinical']
 
 # Use GnarlyGenotyper instead of GenotypeGVCFs
 use_gnarly = false

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -771,8 +771,15 @@ class MtToEsSv(DatasetStage):
         Uses analysis-runner's dataproc helper to run a hail query script
         """
         if (
-            es_datasets := get_config()['workflow'].get('create_es_index_for_datasets')
-        ) and dataset.name not in es_datasets:
+            (
+                es_datasets := get_config()['workflow'].get(
+                    'create_es_index_for_datasets'
+                )
+            )
+            and dataset.name not in es_datasets
+        ) or dataset.name in get_config()['workflow'].get(
+            'skip_es_index_for_datasets', []
+        ):
             # Skipping dataset that wasn't explicitly requested to upload to ES
             return self.make_outputs(dataset)
 

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -274,8 +274,15 @@ class MtToEs(DatasetStage):
         Transforms the MT into a Seqr index, requires Dataproc
         """
         if (
-            es_datasets := get_config()['workflow'].get('create_es_index_for_datasets')
-        ) and dataset.name not in es_datasets:
+            (
+                es_datasets := get_config()['workflow'].get(
+                    'create_es_index_for_datasets'
+                )
+            )
+            and dataset.name not in es_datasets
+        ) or dataset.name in get_config()['workflow'].get(
+            'skip_es_index_for_datasets', []
+        ):
             # Skipping dataset that wasn't explicitly requested to upload to ES:
             return self.make_outputs(dataset)
 


### PR DESCRIPTION
(where projects are known to not be in Seqr)

Not sure if this should be present in public config files, or moved to the private repo