### PR TITLE
Rebatch all GATK-SV SG IDs

### DIFF
--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -2,6 +2,11 @@
 # these are applied directly to the named workflow
 
 # resource overrides for the GatherSampleEvidence stage
+[resource_overrides.GatherSampleEvidence.runtime_attr_scramble_part1]
+mem_gb = 7.5
+[resource_overrides.GatherSampleEvidence.runtime_attr_wham]
+mem_gb = 16
+# resource overrides for the GatherSampleEvidence stage
 [resource_overrides.GatherSampleEvidence.runtime_attr_scramble_part2]
 mem_gb = 7.5
 

--- a/cpg_workflows/jobs/sample_batching.py
+++ b/cpg_workflows/jobs/sample_batching.py
@@ -107,8 +107,8 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
             {
                 'sequencing_groups': sample_ids.ID.tolist(),
                 'size': len(sample_ids),
-                'mf_ratio': len(md_sex_cov['male'][cov])
-                / len(md_sex_cov['female'][cov]),
+                'mf_ratio': len(md_sex_cov['male'][cov]) or 1
+                / len(md_sex_cov['female'][cov]) or 1,
                 'coverage_medians': sample_ids.median_coverage.tolist(),
             }
         )

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
         this_df.columns = [x.replace('#', '') for x in this_df.columns]
 
         # filter to the PCR-state SGs we're interested in
-        this_df = this_df.query('ID in @sample_ids')
+        this_df = this_df.query('ID in @all_sg_ids')
         dataframes.append(this_df)
 
     one_big_df = pd.concat(dataframes)

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -9,8 +9,11 @@ To do this we join every QC table from Evidence QC which has run so far,
 filter to retain only active SG IDs, then re-batch cleanly.
 """
 
+
 import json
+import logging
 import pandas as pd
+from argparse import ArgumentParser
 from metamist.graphql import gql, query
 
 from cpg_utils import to_path
@@ -18,3 +21,61 @@ from cpg_utils.config import get_config
 from cpg_workflows.jobs.sample_batching import batch_sgs
 
 
+FIND_ACTIVE_SGS = gql("""
+query FindActiveSGs($project: String!) {
+  project(name: $project) {
+    sequencingGroups(activeOnly: {eq: true}) {
+      id
+    }
+  }
+}
+""")
+
+
+def collect_all_sgids(projects: list[str]) -> list[str]:
+    """
+    Collect all active SG IDs for a project
+
+    Args:
+        projects (list[str]): all the projects to collect samples for
+
+    Returns:
+        a list of all unique active sample IDs
+    """
+
+    ongoing_collection: set[str] = set()
+
+    for each_project in projects:
+        response = query(FIND_ACTIVE_SGS, {'project': each_project})
+        ongoing_collection.update([sg['id'] for sg in response['project']['sequencingGroups']])
+    return sorted(ongoing_collection)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    parser = ArgumentParser()
+    parser.add_argument('-i', help='Path to the QC tables', nargs='+', required=True)
+    parser.add_argument('-p', help='Names of all relevant projects', nargs='+', required=True)
+    args, unknown = parser.parse_known_args()
+
+    if unknown:
+        raise ValueError(f'Unrecognised arguments: {unknown}')
+
+    assert args.p and args.i
+    logging.info(f'Collecting all active SG IDs for {args.p}')
+    all_sg_ids = collect_all_sgids(args.p)
+
+    dataframes = []
+    for each in args.i:
+        logging.info(f'Loading {each}')
+        this_df = pd.read_csv(each, sep='\t', low_memory=False)
+        this_df.columns = [x.replace('#', '') for x in this_df.columns]
+
+        # filter to the PCR-state SGs we're interested in
+        this_df = this_df.query('ID in @sample_ids')
+        dataframes.append(this_df)
+
+    one_big_df = pd.concat(dataframes)
+
+    # now make some batches
+    batches = batch_sgs(one_big_df, min_batch_size=200, max_batch_size=300)

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+
+"""
+Aim is to take all previously batched samples and re-batch them to
+get the best possible groupings of samples for GATK-SV
+
+To do this we join every QC table from Evidence QC which has run so far,
+filter to retain only active SG IDs, then re-batch cleanly.
+"""
+
+import json
+import pandas as pd
+from metamist.graphql import gql, query
+
+from cpg_utils import to_path
+from cpg_utils.config import get_config
+from cpg_workflows.jobs.sample_batching import batch_sgs
+
+

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     one_big_df = pd.concat(dataframes)
 
     # now make some batches
-    batches = batch_sgs(one_big_df, min_batch_size=200, max_batch_size=300)
+    batches = batch_sgs(one_big_df, min_batch_size=40, max_batch_size=300)
 
     with to_path(args.o).open('w') as f:
         f.write(json.dumps(batches, indent=2))

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
         this_df = this_df.query('ID in @all_sg_ids')
         dataframes.append(this_df)
 
-    one_big_df = pd.concat(dataframes).drop_duplicates(inplace=True)
+    one_big_df = pd.concat(dataframes).drop_duplicates()
 
     if len(one_big_df) == 0:
         raise ValueError('No samples found in the QC tables')

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -17,7 +17,6 @@ from argparse import ArgumentParser
 from metamist.graphql import gql, query
 
 from cpg_utils import to_path
-from cpg_utils.config import get_config
 from cpg_workflows.jobs.sample_batching import batch_sgs
 
 
@@ -56,6 +55,7 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('-i', help='Path to the QC tables', nargs='+', required=True)
     parser.add_argument('-p', help='Names of all relevant projects', nargs='+', required=True)
+    parser.add_argument('-o', help='Where to write the output', required=True)
     args, unknown = parser.parse_known_args()
 
     if unknown:
@@ -79,3 +79,6 @@ if __name__ == '__main__':
 
     # now make some batches
     batches = batch_sgs(one_big_df, min_batch_size=200, max_batch_size=300)
+
+    with to_path(args.o).open('w') as f:
+        f.write(json.dumps(batches, indent=2))

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -71,14 +71,17 @@ if __name__ == '__main__':
         this_df = pd.read_csv(each, sep='\t', low_memory=False)
         this_df.columns = [x.replace('#', '') for x in this_df.columns]
 
-        # filter to the PCR-state SGs we're interested in
+        # filter to the active SGs we're interested in
         this_df = this_df.query('ID in @all_sg_ids')
         dataframes.append(this_df)
 
-    one_big_df = pd.concat(dataframes)
+    one_big_df = pd.concat(dataframes).drop_duplicates(inplace=True)
+
+    if len(one_big_df) == 0:
+        raise ValueError('No samples found in the QC tables')
 
     # now make some batches
-    batches = batch_sgs(one_big_df, min_batch_size=40, max_batch_size=300)
+    batches = batch_sgs(one_big_df, min_batch_size=200, max_batch_size=300)
 
     with to_path(args.o).open('w') as f:
-        f.write(json.dumps(batches, indent=2))
+        f.write(json.dumps(batches, indent=4))


### PR DESCRIPTION
Adds a new script which can load all the individual dataframes from the EvidenceQC stages, filters to currently live samples, then feeds this into the batch generation process we already have. 