### PR TITLE
Move DenseSubset from Dataproc to Batch

### DIFF
--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -8,8 +8,8 @@ from cpg_workflows.utils import can_reuse
 
 
 def run(
-    vds_path: Path,
-    out_dense_mt_path: Path,
+    vds_path: str,
+    out_dense_mt_path: str,
 ) -> hl.MatrixTable:
     """
     Filter a sparse VariantDataset to a set of predetermined QC sites
@@ -17,9 +17,9 @@ def run(
     @return: filtered and densified MatrixTable.
     """
     if can_reuse(out_dense_mt_path, overwrite=True):
-        return hl.read_matrix_table(str(out_dense_mt_path))
+        return hl.read_matrix_table(out_dense_mt_path)
 
-    vds = hl.vds.read_vds(str(vds_path))
+    vds = hl.vds.read_vds(vds_path)
 
     logging.info('Splitting multiallelics')
     vds = hl.vds.split_multi(vds, filter_changed_loci=True)
@@ -35,4 +35,4 @@ def run(
         f'Number of predetermined QC variants found in the VDS: {mt.count_rows()}'
     )
     mt = mt.naive_coalesce(5000)
-    return mt.checkpoint(str(out_dense_mt_path), overwrite=True)
+    return mt.checkpoint(out_dense_mt_path, overwrite=True)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -90,8 +90,8 @@ class DenseSubset(CohortStage):
             query_command(
                 dense_subset,
                 dense_subset.run.__name__,
-                inputs.as_path(cohort, Combiner),
-                self.expected_outputs(cohort),
+                str(inputs.as_path(cohort, Combiner)),
+                str(self.expected_outputs(cohort)),
                 setup_gcp=True,
             )
         )

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -79,17 +79,21 @@ class DenseSubset(CohortStage):
         return get_workflow().prefix / 'dense_subset.mt'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
-        from cpg_workflows.large_cohort.dense_subset import run
+        from cpg_workflows.large_cohort import dense_subset
 
-        j = dataproc_job(
-            job_name=self.__class__.__name__,
-            function=run,
-            function_path_args=dict(
-                vds_path=inputs.as_path(cohort, Combiner),
-                out_dense_mt_path=self.expected_outputs(cohort),
-            ),
-            depends_on=inputs.get_jobs(cohort),
+        j = get_batch().new_job(
+            'Dense Subset', (self.get_job_attrs() or {}) | {'tool': 'hail query'}
+        )
+        j.image(image_path('cpg_workflows'))
+
+        j.command(
+            query_command(
+                dense_subset,
+                dense_subset.run.__name__,
+                inputs.as_path(cohort, Combiner),
+                self.expected_outputs(cohort),
+                setup_gcp=True,
+            )
         )
         return self.make_outputs(cohort, self.expected_outputs(cohort), [j])
 

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -180,8 +180,8 @@ class TestAllLargeCohortMethods:
 
         dense_mt_path = res_pref / 'dense.mt'
         dense_subset.run(
-            vds_path=vds_path,
-            out_dense_mt_path=dense_mt_path,
+            vds_path=str(vds_path),
+            out_dense_mt_path=str(dense_mt_path),
         )
 
         relateds_to_drop_ht_path = res_pref / 'relateds_to_drop.ht'


### PR DESCRIPTION
We're currently having issues with the DenseSubset stage. It's failing with little explanation as to why. 

But, we don't need to use Dataproc for the DenseSubset stage anymore. 

This change moved it to a Query on Batch implementation. 