### PR TITLE
Add logs to show VDS and MT existence checks are for _SUCCESS files

### DIFF
--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -37,10 +37,10 @@ def read_hail(path):
 
 
 def checkpoint_hail(
-        t: hl.Table | hl.MatrixTable,
-        file_name: str,
-        checkpoint_prefix: str | None = None,
-        allow_reuse=False
+    t: hl.Table | hl.MatrixTable,
+    file_name: str,
+    checkpoint_prefix: str | None = None,
+    allow_reuse=False,
 ):
     """
     checkpoint method
@@ -103,8 +103,10 @@ def exists_not_cached(path: Path | str, verbose: bool = True) -> bool:
 
     if path.suffix in ['.mt', '.ht']:
         path /= '_SUCCESS'
+        logging.info(f'Checking for _SUCCESS file in {path}')
     if path.suffix in ['.vds']:
         path /= 'variant_data/_SUCCESS'
+        logging.info(f'Checking for variant_data/_SUCCESS file in {path}')
 
     if verbose:
         # noinspection PyBroadException


### PR DESCRIPTION
Did you know the existence checks for REUSE files are based on the existence of the _SUCCESS file? Cause I didn't. 

May no-one question their sanity like this again. 

Previous issue, https://batch.hail.populationgenomics.org.au/batches/433515/jobs/1 was because the _SUCCESS file didn't exist in the .vds folder