### PR TITLE
Update reference path

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_plots.py
+++ b/cpg_workflows/large_cohort/ancestry_plots.py
@@ -76,7 +76,11 @@ def run(
 
     # Key samples by their external IDs
     use_external_id = get_config()['large_cohort']['use_external_id']
-    ht = key_by_external_id(scores_ht, sample_ht) if use_external_id else scores_ht.cache()
+    ht = (
+        key_by_external_id(scores_ht, sample_ht)
+        if use_external_id
+        else scores_ht.cache()
+    )
 
     # Use eigenvalues to calculate variance
     eigenvalues = eigenvalues_ht.f0.collect()
@@ -90,18 +94,30 @@ def run(
     sample_names = ht.s.collect()
     datasets = ht.dataset.collect()
     use_inferred = get_config()['large_cohort']['pca_background']['inferred_ancestry']
-    # if the inferred ancestry is set to true in the config, annotate the PCA with the 
+    # if the inferred ancestry is set to true in the config, annotate the PCA with the
     # inferred population ancestry (calculated in the ancestry_pca.py script
-    superpopulation_label = ht.training_pop.collect() if use_inferred else ht.superpopulation.collect()
-    population_label = ht.training_pop.collect() if use_inferred else ht.population.collect()
+    superpopulation_label = (
+        ht.training_pop.collect() if use_inferred else ht.superpopulation.collect()
+    )
+    population_label = (
+        ht.training_pop.collect() if use_inferred else ht.population.collect()
+    )
     # Change 'none' values to dataset name
     analysis_dataset_name = get_config()['workflow']['dataset']
-    workflow_dataset = get_config()['workflow'].get('input_datasets', [analysis_dataset_name])
+    workflow_dataset = get_config()['workflow'].get(
+        'input_datasets', [analysis_dataset_name]
+    )
     # join dataset names with underscore, in case there are multiple
     workflow_dataset = '_'.join(workflow_dataset)
-    superpopulation_label = [workflow_dataset if x is None else x for x in superpopulation_label]
+    superpopulation_label = [
+        workflow_dataset if x is None else x for x in superpopulation_label
+    ]
     population_label = [workflow_dataset if x is None else x for x in population_label]
-    is_training = ht.is_training.collect() if use_inferred else [False] * len(ht.is_training.collect())
+    is_training = (
+        ht.is_training.collect()
+        if use_inferred
+        else [False] * len(ht.is_training.collect())
+    )
     for scope, title, labels in [
         ('dataset', 'Dataset', datasets),
         ('superpopulation', 'Superpopulation', superpopulation_label),
@@ -173,7 +189,8 @@ def _plot_pca(
                 samples=sample_names,
                 dataset=datasets,
                 is_training=[
-                    {True: PROVIDED_LABEL, False: INFERRED_LABEL}.get(v) for v in is_training
+                    {True: PROVIDED_LABEL, False: INFERRED_LABEL}.get(v)
+                    for v in is_training
                 ],
             )
         )
@@ -210,7 +227,7 @@ def _plot_loadings(number_of_pcs, loadings_ht, out_path_pattern=None):
     if plot_name:
         pca_suffix = plot_name.replace('-', '_')
     gtf_ht = hl.experimental.import_gtf(
-        str(reference_path('broad/protein_coding_gtf')),
+        str(reference_path('gatk-sv/protein_coding_gtf')),
         reference_genome=genome_build(),
         skip_invalid_contigs=True,
         min_partitions=12,

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -1,6 +1,7 @@
 """
 Test large-cohort workflow.
 """
+
 import os
 from os.path import exists
 from pathlib import Path
@@ -99,16 +100,18 @@ def create_config(
                     / 'Mills_and_1000G_gold_standard.indels.hg38.ht'
                 ),
             },
-            'broad': {
-                'genome_calling_interval_lists': (
-                    broad_prefix / 'wgs_calling_regions.hg38.interval_list'
-                ),
+            'gatk-sv': {
                 'protein_coding_gtf': (
                     broad_prefix
                     / 'sv-resources'
                     / 'resources'
                     / 'v1'
                     / 'MANE.GRCh38.v0.95.select_ensembl_genomic.gtf'
+                ),
+            },
+            'broad': {
+                'genome_calling_interval_lists': (
+                    broad_prefix / 'wgs_calling_regions.hg38.interval_list'
                 ),
             },
         },


### PR DESCRIPTION
Latest attempt to PlotAncestry things failed https://batch.hail.populationgenomics.org.au/batches/433599/jobs/2 

This is because a reference was moved 
https://github.com/populationgenomics/references/pull/31/files

```
Traceback (most recent call last):
  File "/tmp/5546914b25644d3b80a641bcfa94ed0e/dataproc_script.py", line 35, in <module>
    main()
  File "/opt/conda/default/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/default/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/opt/conda/default/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/default/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/tmp/5546914b25644d3b80a641bcfa94ed0e/dataproc_script.py", line 31, in main
    func(*[to_path(path) for path in function_path_args], *function_str_args)
  File "/tmp/5546914b25644d3b80a641bcfa94ed0e/pyscripts_c7sihjyj.zip/cpg_workflows/large_cohort/ancestry_plots.py", line 126, in run
    _plot_loadings(num_pcs_to_plot, loadings_ht, out_path_pattern=out_path_pattern)
  File "/tmp/5546914b25644d3b80a641bcfa94ed0e/pyscripts_c7sihjyj.zip/cpg_workflows/large_cohort/ancestry_plots.py", line 213, in _plot_loadings
    str(reference_path('broad/protein_coding_gtf')),
  File "/opt/conda/default/lib/python3.10/site-packages/cpg_utils/hail_batch.py", line 566, in reference_path
    return to_path(retrieve(['references'] + key.strip('/').split('/')))
  File "/opt/conda/default/lib/python3.10/site-packages/cpg_utils/config.py", line 204, in retrieve
    raise ConfigError(f'Key "{k}" not found in {d}')
cpg_utils.config.ConfigError: Key "protein_coding_gtf" not found in {'dragmap_prefix': 'gs://cpg-common-main/references/hg38/v0/dragen_reference', ...}
```


Updating job to point to the new location. 