### PR TITLE
Remove dataproc from MakeSiteOnlyVcf

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -215,9 +215,7 @@ class MakeSiteOnlyVcf(CohortStage):
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        # from cpg_workflows.large_cohort.site_only_vcf import run
         from cpg_workflows.large_cohort import site_only_vcf
-        from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
 
         j = get_batch().new_job(
             'MakeSiteOnlyVcf', (self.get_job_attrs() or {}) | {'tool': 'hail query'}
@@ -237,25 +235,6 @@ class MakeSiteOnlyVcf(CohortStage):
             )
         )
 
-        # j = dataproc_job(
-        #     job_name=self.__class__.__name__,
-        #     function=run,
-        #     function_path_args=dict(
-        #         vds_path=inputs.as_path(cohort, Combiner),
-        #         sample_qc_ht_path=inputs.as_path(cohort, SampleQC),
-        #         relateds_to_drop_ht_path=inputs.as_path(
-        #             cohort, Relatedness, key='relateds_to_drop'
-        #         ),
-        #         out_vcf_path=self.expected_outputs(cohort)['vcf'],
-        #         tmp_prefix=self.tmp_prefix,
-        #     ),
-        #     depends_on=inputs.get_jobs(cohort),
-        #     # hl.export_vcf() uses non-preemptible workers' disk to merge VCF files.
-        #     # 10 samples take 2.3G, 400 samples take 60G, which roughly matches
-        #     # `huge_disk` (also used in the AS-VQSR VCF-gather job)
-        #     worker_boot_disk_size=200,
-        #     secondary_worker_boot_disk_size=200,
-        # )
         return self.make_outputs(cohort, self.expected_outputs(cohort), [j])
 
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -215,28 +215,47 @@ class MakeSiteOnlyVcf(CohortStage):
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        # from cpg_workflows.large_cohort.site_only_vcf import run
+        from cpg_workflows.large_cohort import site_only_vcf
         from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
-        from cpg_workflows.large_cohort.site_only_vcf import run
 
-        j = dataproc_job(
-            job_name=self.__class__.__name__,
-            function=run,
-            function_path_args=dict(
-                vds_path=inputs.as_path(cohort, Combiner),
-                sample_qc_ht_path=inputs.as_path(cohort, SampleQC),
-                relateds_to_drop_ht_path=inputs.as_path(
-                    cohort, Relatedness, key='relateds_to_drop'
-                ),
-                out_vcf_path=self.expected_outputs(cohort)['vcf'],
-                tmp_prefix=self.tmp_prefix,
-            ),
-            depends_on=inputs.get_jobs(cohort),
-            # hl.export_vcf() uses non-preemptible workers' disk to merge VCF files.
-            # 10 samples take 2.3G, 400 samples take 60G, which roughly matches
-            # `huge_disk` (also used in the AS-VQSR VCF-gather job)
-            worker_boot_disk_size=200,
-            secondary_worker_boot_disk_size=200,
+        j = get_batch().new_job(
+            'MakeSiteOnlyVcf', (self.get_job_attrs() or {}) | {'tool': 'hail query'}
         )
+        j.image(image_path('cpg_workflows'))
+
+        j.command(
+            query_command(
+                site_only_vcf,
+                site_only_vcf.run.__name__,
+                str(inputs.as_path(cohort, Combiner)),
+                str(inputs.as_path(cohort, SampleQC)),
+                str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
+                str(self.expected_outputs(cohort)['vcf']),
+                str(self.tmp_prefix),
+                setup_gcp=True,
+            )
+        )
+
+        # j = dataproc_job(
+        #     job_name=self.__class__.__name__,
+        #     function=run,
+        #     function_path_args=dict(
+        #         vds_path=inputs.as_path(cohort, Combiner),
+        #         sample_qc_ht_path=inputs.as_path(cohort, SampleQC),
+        #         relateds_to_drop_ht_path=inputs.as_path(
+        #             cohort, Relatedness, key='relateds_to_drop'
+        #         ),
+        #         out_vcf_path=self.expected_outputs(cohort)['vcf'],
+        #         tmp_prefix=self.tmp_prefix,
+        #     ),
+        #     depends_on=inputs.get_jobs(cohort),
+        #     # hl.export_vcf() uses non-preemptible workers' disk to merge VCF files.
+        #     # 10 samples take 2.3G, 400 samples take 60G, which roughly matches
+        #     # `huge_disk` (also used in the AS-VQSR VCF-gather job)
+        #     worker_boot_disk_size=200,
+        #     secondary_worker_boot_disk_size=200,
+        # )
         return self.make_outputs(cohort, self.expected_outputs(cohort), [j])
 
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -2,6 +2,7 @@ from cpg_utils import Path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import get_batch, image_path, query_command
 
+from cpg_workflows.filetypes import GvcfPath
 from cpg_workflows.targets import Cohort
 from cpg_workflows.utils import slugify
 from cpg_workflows.workflow import (
@@ -32,6 +33,17 @@ class Combiner(CohortStage):
 
         # from cpg_workflows.large_cohort.combiner import run
         # from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
+        # gvcf_by_sgid = {
+        #     sequencing_group.id: GvcfPath(
+        #         inputs.as_path(target=sequencing_group, stage=Genotype, key='gvcf')
+        #     )
+        #     for sequencing_group in cohort.get_sequencing_groups()
+        # }
+        # gvcf_out_path = self.tmp_prefix / 'gvcf_list' / '.txt'
+        # with gvcf_out_path.open('w') as f:
+        #     for _, gvcf in gvcf_by_sgid.items():
+        #         f.write(f'{gvcf}\n')
+        # combine all of these GVCFs into a single VDS using combiner
 
         j = get_batch().new_job(
             'Combiner', (self.get_job_attrs() or {}) | {'tool': 'hail query'}
@@ -42,7 +54,7 @@ class Combiner(CohortStage):
             query_command(
                 combiner,
                 combiner.run.__name__,
-                str(inputs.as_path(cohort, Genotype)),
+                # str(inputs.as_path(cohort, Genotype)),
                 str(self.expected_outputs(cohort)),
                 str(self.tmp_prefix),
                 setup_gcp=True,


### PR DESCRIPTION
This pull request aims to address concerns regarding the dependency on Dataproc for the MakeSiteOnlyVcf stage of large cohort processing. See this Slack thread [here](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1708485526044469).

Moving this job away from non-preemptible machines within Dataproc to pre-emptible machines in QoB raises concerns about the risk of process failure due to the potentially extended processing times for large datasets. Nonetheless, it seems possible to remove dataproc from this stage.

**Note**: An alternative is to move towards Hail's ability to conduct parallel exports during VCF merging that would help nullify the pre-emption issue. Although integrating parallel exports into the pipeline may be complex, it could significantly optimise the process and eliminate the need for Dataproc.