### PR TITLE
gCNV Joint Genotyping

### DIFF
--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -1,12 +1,12 @@
 [workflow]
 name = 'gcnv'
-intervals_path = 'gs://cpg-common-main/references/hg38/v0/exome_calling_regions.v1.interval_list'
+#intervals_path = 'gs://cpg-common-main/references/hg38/v0/exome_calling_regions.v1.interval_list'
 exclude_intervals = ['chrM']
 # Aim for 10-50Mbp genomic coverage per shard
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]
-ploidy_priors = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv'
+#ploidy_priors = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv'
 allosomal_contigs = ['chrX', 'chrY']
-num_samples_per_scatter_block = 2
+num_samples_per_scatter_block = 5
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -23,3 +23,4 @@ sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/s
 # github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
 external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
 external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
+noncoding_bed = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed'

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -4,13 +4,13 @@ intervals_path = 'gs://cpg-common-main/references/hg38/v0/exome_calling_regions.
 exclude_intervals = ['chrM']
 # Aim for 10-50Mbp genomic coverage per shard
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]
-#ploidy_priors = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv'
 allosomal_contigs = ['chrX', 'chrY']
 
+# vague inspiration by the following config, though this likely represents low thresholds for subsampled test data
 # https://github.com/broadinstitute/gatk/blob/cfd4d87ec29ac45a68f13a37f30101f326546b7d/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
-num_samples_per_scatter_block = 5
-gncv_max_events = 120
-gncv_max_pass_events = 10
+num_samples_per_scatter_block = 10
+gncv_max_events = 320
+gncv_max_pass_events = 30
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -6,7 +6,11 @@ exclude_intervals = ['chrM']
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]
 #ploidy_priors = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv'
 allosomal_contigs = ['chrX', 'chrY']
+
+# https://github.com/broadinstitute/gatk/blob/cfd4d87ec29ac45a68f13a37f30101f326546b7d/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
 num_samples_per_scatter_block = 5
+gncv_max_events = 120
+gncv_max_pass_events = 10
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -6,6 +6,7 @@ exclude_intervals = ['chrM']
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]
 ploidy_priors = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv'
 allosomal_contigs = ['chrX', 'chrY']
+num_samples_per_scatter_block = 2
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -24,3 +24,4 @@ sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/s
 external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
 external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
 noncoding_bed = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed'
+strvctvre_phylop = 'gs://cpg-common-test/references/hg38.phyloP100way.bw'

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -1,6 +1,6 @@
 [workflow]
 name = 'gcnv'
-#intervals_path = 'gs://cpg-common-main/references/hg38/v0/exome_calling_regions.v1.interval_list'
+intervals_path = 'gs://cpg-common-main/references/hg38/v0/exome_calling_regions.v1.interval_list'
 exclude_intervals = ['chrM']
 # Aim for 10-50Mbp genomic coverage per shard
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -356,15 +356,11 @@ def postprocess_calls(
       {extra_args}
     """)
 
-    # index the output VCFs
+    # index the output VCFs - GATK does this already?
+    # or maybe it only generates indexes when the clustered input is provided
     j.command(f"""
-    if ! [ -f "{j.output['intervals.vcf.gz']}.tbi" ]; then
-        tabix {j.output['intervals.vcf.gz']}
-    fi
-
-    if ! [ -f "{j.output['segments.vcf.gz']}.tbi" ]; then
-        tabix {j.output['segments.vcf.gz']}
-    fi
+    tabix -f {j.output['intervals.vcf.gz']}
+    tabix -f {j.output['segments.vcf.gz']}
     """)
 
     if clustered_vcf:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -337,14 +337,12 @@ def postprocess_calls(
     reference_string = f'-R {reference.base}' if clustered_vcf else ''
 
     j.command(f"""
-    ls $BATCH_TMPDIR
     OUTS=$(dirname {j.output['intervals.vcf.gz']})
     BATCH_OUTS=$(dirname $OUTS)
-    ls -l $BATCH_OUTS
     mkdir $OUTS
     gatk PostprocessGermlineCNVCalls \\
       --sequence-dictionary {reference.dict} {allosomal_contigs_args} \\
-      --contig-ploidy-calls $BATCH_TMPDIR/ploidy-calls \\
+      --contig-ploidy-calls $BATCH_TMPDIR/inputs/ploidy-calls \\
       {model_shard_args} {calls_shard_args} \\
       --sample-index {sample_index} \\
       --output-genotyped-intervals {j.output['intervals.vcf.gz']} \\

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -400,7 +400,7 @@ def joint_segment_vcfs(
     reference: ResourceGroup,
     intervals: ResourceFile,  # hmm,
     job_attrs: dict,
-) -> tuple[Job, Resource]:
+) -> tuple[Job, ResourceGroup]:
     """
     This job will run the joint segmentation step of the gCNV workflow
     Takes individual Segment VCFs and merges them into a single VCF
@@ -420,6 +420,8 @@ def joint_segment_vcfs(
     vcf_string = ''
     for each_vcf in segment_vcfs:
         vcf_string += f' -V {each_vcf}'
+
+    # this already creates a tabix index
     job.command(
         f"""
     set -e
@@ -429,7 +431,6 @@ def joint_segment_vcfs(
         {vcf_string} \\
         --model-call-intervals {intervals} \\
         -ped {pedigree}
-    # tabix {job.output["vcf.gz"]}
     """
     )
     return job, job.output
@@ -488,7 +489,7 @@ def run_joint_segmentation(
                 intervals=intervals_in_batch,
                 job_attrs=job_attrs or {} | {'title': f'sub-chunk_{subchunk_index}'},
             )
-            chunked_vcfs.append(vcf_group)
+            chunked_vcfs.append(vcf_group['vcf'])
             get_batch().write_output(
                 vcf_group, f'{tmp_prefix}/subchunk_{subchunk_index}'
             )

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -358,8 +358,13 @@ def postprocess_calls(
 
     # index the output VCFs
     j.command(f"""
-    tabix {j.output['intervals.vcf.gz']}
-    tabix {j.output['segments.vcf.gz']}
+    if ! [ -f "{j.output['intervals.vcf.gz']}.tbi" ]; then
+        tabix {j.output['intervals.vcf.gz']}
+    fi
+
+    if ! [ -f "{j.output['segments.vcf.gz']}.tbi" ]; then
+        tabix {j.output['segments.vcf.gz']}
+    fi
     """)
 
     if clustered_vcf:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -429,7 +429,7 @@ def joint_segment_vcfs(
 
 
 def run_joint_segmentation(
-    segment_vcfs: list[str],
+    segment_vcfs: list[ResourceFile],
     pedigree: str,
     intervals: str,
     tmp_prefix: str,
@@ -469,8 +469,9 @@ def run_joint_segmentation(
         ):
             # create a new job for each chunk
             # read these files into this batch
+            print(chunk_vcfs)
             local_vcfs = [
-                get_batch().read_input_group(vcf=vcf, index=f'{vcf}.tbi').vcf
+                get_batch().read_input_group(vcf=vcf, index=f'{vcf}.tbi')['vcf']
                 for vcf in chunk_vcfs
             ]
             job, vcf_group = joint_segment_vcfs(

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -412,7 +412,9 @@ def joint_segment_vcfs(
     Returns:
         the job that does the work, and the resulting resource group of VCF & index
     """
-    job = get_batch().new_job(f'Joint Segmentation', job_attrs | {'tool': 'gatk'})
+    job = get_batch().new_job(
+        f'Joint Segmentation {title}', job_attrs | {'tool': 'gatk'}
+    )
     job.declare_resource_group(
         output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
     )
@@ -489,7 +491,7 @@ def run_joint_segmentation(
                 reference=reference,
                 intervals=intervals_in_batch,
                 job_attrs=job_attrs or {} | {'title': f'sub-chunk_{subchunk_index}'},
-                title=f'sub-chunk_{subchunk_index}'
+                title=f'sub-chunk_{subchunk_index}',
             )
             chunked_vcfs.append(vcf_group['vcf.gz'])
             get_batch().write_output(
@@ -511,7 +513,7 @@ def run_joint_segmentation(
         reference=reference,
         intervals=intervals_in_batch,
         job_attrs=job_attrs or {} | {'title': f'all-chunks'},
-        title=f'all-chunks'
+        title='all-chunks',
     )
     jobs.append(job)
 

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -42,7 +42,7 @@ def prepare_intervals(
 
     if sequencing_type == 'exome':
         intervals = get_batch().read_input(
-            str(reference_path('broad/exome_calling_interval_lists'))
+            get_config()['workflow'].get('intervals_path')
         )
         preprocess_cmd = f"""
         gatk PreprocessIntervals \\

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -417,11 +417,18 @@ def joint_segment_vcfs(
     )
     job.image(image_path('gatk_gcnv'))
     job.memory('8Gi')
+    vcf_string = ''
+    for each_vcf in segment_vcfs:
+        vcf_string += f' -V {each_vcf}'
     job.command(
         f"""
     set -e
     gatk --java-options "-Xmx6000m" JointGermlineCNVSegmentation \\
-    -R {reference.base} -O {job.output["vcf.gz"]} {' -V '.join(segment_vcfs)} --model-call-intervals {intervals} -ped {pedigree}
+        -R {reference.base} \\
+        -O {job.output["vcf.gz"]} \\
+        {vcf_string} \\
+        --model-call-intervals {intervals} \\
+        -ped {pedigree}
     tabix {job.output["vcf.gz"]}
     """
     )

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -334,8 +334,8 @@ def postprocess_calls(
 
     extra_args = ''
     if clustered_vcf:
-        local_clusters = get_batch().read_input(clustered_vcf)
-        local_intervals = get_batch().read_input(intervals_vcf)
+        local_clusters = get_batch().read_input_group(vcf=clustered_vcf, index=f'{clustered_vcf}.tbi').vcf
+        local_intervals = get_batch().read_input_group(vcf=intervals_vcf, index=f'{intervals_vcf}.tbi').vcf
         extra_args += f"""--clustered-breakpoints {local_clusters} \\
          --input-intervals-vcf {local_intervals} \\
           -R {reference.base}

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -337,7 +337,8 @@ def postprocess_calls(
     reference_string = f'-R {reference.base}' if clustered_vcf else ''
 
     j.command(f"""
-    OUTS=dirname {j.output['intervals.vcf.gz']}
+    ls $BATCH_TMPDIR
+    OUTS=$(dirname {j.output['intervals.vcf.gz']})
     ls -l $OUTS
     gatk PostprocessGermlineCNVCalls \\
       --sequence-dictionary {reference.dict} {allosomal_contigs_args} \\

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -399,6 +399,7 @@ def joint_segment_vcfs(
     pedigree: ResourceFile,
     reference: ResourceGroup,
     intervals: ResourceFile,  # hmm,
+    title: str,
     job_attrs: dict,
 ) -> tuple[Job, ResourceGroup]:
     """
@@ -488,6 +489,7 @@ def run_joint_segmentation(
                 reference=reference,
                 intervals=intervals_in_batch,
                 job_attrs=job_attrs or {} | {'title': f'sub-chunk_{subchunk_index}'},
+                title=f'sub-chunk_{subchunk_index}'
             )
             chunked_vcfs.append(vcf_group['vcf.gz'])
             get_batch().write_output(
@@ -509,6 +511,7 @@ def run_joint_segmentation(
         reference=reference,
         intervals=intervals_in_batch,
         job_attrs=job_attrs or {} | {'title': f'all-chunks'},
+        title=f'all-chunks'
     )
     jobs.append(job)
 

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -371,11 +371,15 @@ def postprocess_calls(
             echo "EXCESSIVE_NUMBER_OF_EVENTS" >> {j.qc_file}
         fi
         """)
-        get_batch().write_output(j.qc_file, qc_file)
 
     j.command(command(batch_job_commands, setup_gcp=True))
 
     get_batch().write_output(j.output, output_prefix)
+
+    # the resource only exists once the command has been issued with
+    # job.command()
+    if qc_file:
+        get_batch().write_output(j.qc_file, qc_file)
 
     return j
 

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -429,7 +429,7 @@ def joint_segment_vcfs(
         {vcf_string} \\
         --model-call-intervals {intervals} \\
         -ped {pedigree}
-    tabix {job.output["vcf.gz"]}
+    # tabix {job.output["vcf.gz"]}
     """
     )
     return job, job.output

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -489,7 +489,7 @@ def run_joint_segmentation(
                 intervals=intervals_in_batch,
                 job_attrs=job_attrs or {} | {'title': f'sub-chunk_{subchunk_index}'},
             )
-            chunked_vcfs.append(vcf_group['vcf'])
+            chunked_vcfs.append(vcf_group['vcf.gz'])
             get_batch().write_output(
                 vcf_group, f'{tmp_prefix}/subchunk_{subchunk_index}'
             )

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -332,9 +332,14 @@ def postprocess_calls(
         }
     )
 
-    clustered_vcf_string = f'--clustered-breakpoints {clustered_vcf}' if clustered_vcf else ''
-    intervals_vcf_string = f'--input-intervals-vcf {intervals_vcf}' if intervals_vcf else ''
-    reference_string = f'-R {reference.base}' if clustered_vcf else ''
+    extra_args = ''
+    if clustered_vcf:
+        local_clusters = get_batch().read_input(clustered_vcf)
+        local_intervals = get_batch().read_input(intervals_vcf)
+        extra_args += f"""--clustered-breakpoints {local_clusters} \\
+         --input-intervals-vcf {local_intervals} \\
+          -R {reference.base}
+        """
 
     j.command(f"""
     OUTS=$(dirname {j.output['intervals.vcf.gz']})
@@ -348,7 +353,7 @@ def postprocess_calls(
       --output-genotyped-intervals {j.output['intervals.vcf.gz']} \\
       --output-genotyped-segments {j.output['segments.vcf.gz']} \\
       --output-denoised-copy-ratios {j.output['ratios.tsv']} \\
-      {clustered_vcf_string} {intervals_vcf_string} {reference_string}
+      {extra_args}
     """)
 
     # index the output VCFs

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -305,14 +305,14 @@ def postprocess_calls(
 
     ploidy_calls_tarball = get_batch().read_input(str(ploidy_calls_path))
 
-    gcp_related_commands = [f'tar -xzf {ploidy_calls_tarball} -C $BATCH_TMPDIR']
+    gcp_related_commands = [f'tar -xzf {ploidy_calls_tarball} -C $BATCH_TMPDIR/inputs']
 
     model_shard_args = ''
     calls_shard_args = ''
     for name, path in shard_paths.items():
-        gcp_related_commands.append(f'gsutil cat {path} | tar -xz -C $BATCH_TMPDIR')
-        model_shard_args += f' --model-shard-path $BATCH_TMPDIR/{name}-model'
-        calls_shard_args += f' --calls-shard-path $BATCH_TMPDIR/{name}-calls'
+        gcp_related_commands.append(f'gsutil cat {path} | tar -xz -C $BATCH_TMPDIR/inputs')
+        model_shard_args += f' --model-shard-path $BATCH_TMPDIR/inputs/{name}-model'
+        calls_shard_args += f' --calls-shard-path $BATCH_TMPDIR/inputs/{name}-calls'
 
     j.command(command(gcp_related_commands, setup_gcp=True))
 
@@ -339,7 +339,9 @@ def postprocess_calls(
     j.command(f"""
     ls $BATCH_TMPDIR
     OUTS=$(dirname {j.output['intervals.vcf.gz']})
-    ls -l $OUTS
+    BATCH_OUTS=$(dirname $OUTS)
+    ls -l $BATCH_OUTS
+    mkdir $OUTS
     gatk PostprocessGermlineCNVCalls \\
       --sequence-dictionary {reference.dict} {allosomal_contigs_args} \\
       --contig-ploidy-calls $BATCH_TMPDIR/ploidy-calls \\

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -637,7 +637,9 @@ def update_vcf_attributes(input_tmp: str, output_file: str):
                 original_start = int(l_split[1])
 
                 # e.g. AN_Orig=61;END=56855888;SVTYPE=DUP
-                original_info = d = dict(el.split('=') for el in l_split[7].split(';'))
+                original_info: dict[str, str] = dict(
+                    el.split('=') for el in l_split[7].split(';')
+                )
 
                 # steal the END integer
                 end_int = int(original_info['END'])
@@ -653,7 +655,7 @@ def update_vcf_attributes(input_tmp: str, output_file: str):
                 l_split[2] = f'CNV_{chrom}_{start}_{end_int}_{alt_allele}'
 
                 # update the INFO field with Length and Type (DUP/DEL, not "CNV")
-                original_info['SVLEN'] = end_int - original_start
+                original_info['SVLEN'] = str(end_int - original_start)
                 l_split[7] = ';'.join(f'{k}={v}' for k, v in original_info.items())
 
                 # put it together and what have you got?

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -304,7 +304,7 @@ def clean_ped_family_ids(ped_line: str) -> str:
     >>> clean_ped_family_ids('family1\tchild1\t0\t0\t1\t0\\n')
     'family1\tchild1\t0\t0\t1\t0\\n'
     >>> clean_ped_family_ids('family-1-dirty\tchild1\t0\t0\t1\t0\\n')
-    'family-1-dirty\tchild1\t0\t0\t1\t0\\n'
+    'family_1_dirty\tchild1\t0\t0\t1\t0\\n'
 
     Args:
         ped_line (str): line from the pedigree file, unsplit

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -2,7 +2,6 @@
 single-sample components of the GATK SV workflow
 """
 import logging
-from random import randint
 from typing import Any
 
 from cpg_utils import Path

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -242,7 +242,7 @@ class GCNVJointSegmentation(CohortStage):
         return self.make_outputs(cohort, data=expected_out, jobs=jobs)
 
 
-@stage(required_stages=[GCNVJointSegmentation, GermlineCNVCalls])
+@stage(required_stages=[GCNVJointSegmentation, GermlineCNVCalls, DeterminePloidy])
 class RecalculateClusteredQuality(SequencingGroupStage):
     """
     following joint segmentation, we need to post-process the clustered breakpoints

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -224,9 +224,7 @@ class GCNVJointSegmentation(CohortStage):
 
         expected_out = self.expected_outputs(cohort)
 
-        # ped_path = cohort.write_ped_file(expected_out['pedigree'])
-        # this is a placeholder due to the mismatched sample IDs in test
-        ped_path = 'gs://cpg-seqr-test-tmp/exome/gcnv/a48b821c7e32352a0e683f7164bd3bee61144c_119/GCNVJointSegmentation/pedigree.ped'
+        ped_path = cohort.write_ped_file(expected_out['pedigree'])
 
         jobs = gcnv.run_joint_segmentation(
             all_vcfs,

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -41,8 +41,8 @@ class PrepareIntervals(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
-            'preprocessed': self.prefix / f'{cohort.name}.preprocessed.interval_list',
-            'annotated': self.prefix / f'{cohort.name}.annotated.tsv',
+            'preprocessed': self.prefix / 'preprocessed.interval_list',
+            'annotated': self.prefix / 'annotated_intervals.tsv',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -94,9 +94,9 @@ class DeterminePloidy(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
-            'filtered': self.prefix / f'{cohort.name}.filtered.interval_list',
-            'calls': self.prefix / f'{cohort.name}-ploidy-calls.tar.gz',
-            'model': self.prefix / f'{cohort.name}-ploidy-model.tar.gz',
+            'filtered': self.prefix / 'filtered.interval_list',
+            'calls': self.prefix / 'ploidy-calls.tar.gz',
+            'model': self.prefix / 'ploidy-model.tar.gz',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -191,9 +191,9 @@ class GCNVJointSegmentation(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> ExpectedResultT:
         return {
             'clustered_vcf': self.prefix
-            / f'{cohort.name}.JointClusteredSegments.vcf.gz',
+            / 'JointClusteredSegments.vcf.gz',
             'clustered_vcf_idx': self.prefix
-            / f'{cohort.name}.JointClusteredSegments.vcf.gz.tbi',
+            / 'JointClusteredSegments.vcf.gz.tbi',
             'pedigree': str(self.tmp_prefix / 'pedigree.ped'),
             'tmp_prefix': str(self.tmp_prefix / 'intermediate_jointseg'),
         }

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -288,234 +288,202 @@ class RecalculateClusteredQuality(SequencingGroupStage):
         return self.make_outputs(sequencing_group, data=expected_out, jobs=jobs)
 
 
-# @stage(required_stages=GermlineCNVCalls)
-# class PrepareVcfsForMerge(SequencingGroupStage):
-#     """
-#     Fixes the GT header in the VCFs produced by gCNV
-#     During experimentation these were found to be Integer instead of String
-#     This will be fixed in a future release of GATK
-#     Also splits multiallelic loci (all sites are called as Dup/Del GTs)
-#     Each site needs to have only one Alt allele for the annotation step
-#     """
-#
-#     def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
-#         return {
-#             'fixed_intervals': self.prefix / f'{seqgroup.id}.fixed_intervals.vcf.bgz',
-#             'fixed_intervals_index': self.prefix
-#             / f'{seqgroup.id}.fixed_intervals.vcf.bgz.tbi',
-#         }
-#
-#     def queue_jobs(
-#         self, seqgroup: SequencingGroup, inputs: StageInput
-#     ) -> StageOutput | None:
-#         outputs = self.expected_outputs(seqgroup)
-#
-#         jobs = gcnv.fix_intervals_vcf(
-#             get_batch(),
-#             inputs.as_path(seqgroup, GermlineCNVCalls, 'intervals'),
-#             self.get_job_attrs(seqgroup),
-#             output_path=outputs['fixed_intervals'],
-#         )
-#         return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
-#
-#
-# @stage(required_stages=PrepareVcfsForMerge)
-# class FastCombineGCNVs(CohortStage):
-#     """
-#     Produces final multi-sample VCF results by running a merge
-#     """
-#
-#     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-#         return {
-#             'combined_calls': self.prefix / 'gcnv_joint_call.vcf.bgz',
-#             'combined_calls_index': self.prefix / 'gcnv_joint_call.vcf.bgz.tbi',
-#         }
-#
-#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-#         outputs = self.expected_outputs(cohort)
-#
-#         # do a slapdash bcftools merge on all input files...
-#         gcnv_vcfs = inputs.as_dict_by_target(PrepareVcfsForMerge)
-#         all_vcfs = [
-#             str(gcnv_vcfs[sgid]['fixed_intervals'])
-#             for sgid in cohort.get_sequencing_group_ids()
-#         ]
-#
-#         pipeline_image = get_images(['sv_pipeline_docker'])['sv_pipeline_docker']
-#
-#         job_or_none = gcnv.merge_calls(
-#             get_batch(),
-#             sg_vcfs=all_vcfs,
-#             docker_image=pipeline_image,
-#             job_attrs=self.get_job_attrs(cohort),
-#             output_path=outputs['combined_calls'],
-#         )
-#         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
-#
-#
-# @stage(
-#     required_stages=FastCombineGCNVs,
-#     analysis_type='sv',
-#     analysis_keys=['annotated_vcf'],
-#     update_analysis_meta=_gcnv_annotated_meta,
-# )
-# class AnnotateCNV(CohortStage):
-#     """
-#     Smaller, direct annotation using SvAnnotate
-#     Add annotations, such as the inferred function and allele frequencies of variants,
-#     to final VCF.
-#
-#     This is a full clone of the GATK-SV pipeline Cromwell stage, but use on a slightly
-#     different output. Trying to work out the best way to handle this through inheritance
-#
-#     Annotations methods include:
-#     * Functional annotation - annotate SVs with inferred functional consequence on
-#       protein-coding regions, regulatory regions such as UTR and promoters, and other
-#       non-coding elements.
-#     * Allele frequency annotation - annotate SVs with their allele frequencies across
-#       all samples, and samples of specific sex, as well as specific subpopulations.
-#     * Allele Frequency annotation with external callset - annotate SVs with the allele
-#       frequencies of their overlapping SVs in another callset, e.g. gnomad SV callset.
-#     """
-#
-#     def expected_outputs(self, cohort: Cohort) -> dict:
-#         return {
-#             'annotated_vcf': self.prefix / 'gcnv_annotated.vcf.bgz',
-#             'annotated_vcf_index': self.prefix / 'gcnv_annotated.vcf.bgz.tbi',
-#         }
-#
-#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-#         """
-#         configure and queue jobs for SV annotation
-#         passing the VCF Index has become implicit, which may be a problem for us
-#         """
-#         expected_out = self.expected_outputs(cohort)
-#
-#         billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
-#
-#         job_or_none = queue_annotate_sv_jobs(
-#             batch=get_batch(),
-#             cohort=cohort,
-#             cohort_prefix=self.prefix,
-#             input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)['combined_calls'],
-#             outputs=expected_out,
-#             labels=billing_labels,
-#         )
-#         return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
-#
-#
-# def _gcnv_srvctvre_meta(
-#     output_path: str,  # pylint: disable=W0613:unused-argument
-# ) -> dict[str, str]:
-#     """
-#     Callable, adds custom analysis object meta attribute
-#     """
-#     return {'type': 'gCNV-STRVCTCRE-annotated'}
-#
-#
-# @stage(
-#     required_stages=AnnotateCNV,
-#     analysis_type='sv',
-#     analysis_keys=['strvctvre_vcf'],
-#     update_analysis_meta=_gcnv_srvctvre_meta
-# )
-# class AnnotateCNVVcfWithStrvctvre(
-#     CohortStage
-# ):
-#     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-#         return {
-#             'strvctvre_vcf': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz',
-#             'strvctvre_vcf_index': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz.tbi',
-#         }
-#
-#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-#         strv_job = get_batch().new_job(
-#             'StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'}
-#         )
-#
-#         strv_job.image(image_path('strvctvre'))
-#         strv_job.storage('20Gi')
-#         strv_job.memory('8Gi')
-#
-#         strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
-#         phylop_in_batch = get_batch().read_input(strvctvre_phylop)
-#
-#         input_dict = inputs.as_dict(cohort, AnnotateCNV)
-#         expected_d = self.expected_outputs(cohort)
-#
-#         # read vcf and index into the batch
-#         input_vcf = get_batch().read_input_group(
-#             vcf=str(input_dict['annotated_vcf']),
-#             vcf_index=str(input_dict['annotated_vcf_index']),
-#         )['vcf']
-#
-#         strv_job.declare_resource_group(
-#             output_vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
-#         )
-#
-#         # run strvctvre
-#         strv_job.command(
-#             f'python StrVCTVRE.py '
-#             f'-i {input_vcf} '
-#             f'-o {strv_job.output_vcf["vcf.bgz"]} '
-#             f'-f vcf '
-#             f'-p {phylop_in_batch}'
-#         )
-#         strv_job.command(f'tabix {strv_job.output_vcf["vcf.bgz"]}')
-#
-#         get_batch().write_output(
-#             strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', '')
-#         )
-#         return self.make_outputs(cohort, data=expected_d, jobs=strv_job)
-#
-#
-# @stage(
-#     required_stages=AnnotateCNVVcfWithStrvctvre,
-#     analysis_type='sv',
-#     analysis_keys=['mt'],
-#     update_analysis_meta=_gcnv_srvctvre_meta,
-# )
-# class AnnotateGCNVCohortForSeqr(CohortStage):
-#     """
-#     Rearrange the annotations across the cohort to suit Seqr
-#     """
-#
-#     def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
-#         # convert temp path to str to avoid checking existence
-#         return {
-#             'tmp_prefix': str(self.tmp_prefix),
-#             'mt': self.prefix / 'gcnv_annotated_cohort.mt'
-#         }
-#
-#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-#         """
-#         Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
-#         """
-#
-#         vcf_path = inputs.as_path(target=cohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf')
-#
-#         checkpoint_prefix = (
-#             to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
-#         )
-#         j = get_batch().new_job(f'annotate gCNV cohort', self.get_job_attrs(cohort))
-#         j.image(image_path('cpg_workflows'))
-#         j.command(
-#             query_command(
-#                 seqr_loader_cnv,
-#                 seqr_loader_cnv.annotate_cohort_gcnv.__name__,
-#                 str(vcf_path),
-#                 str(self.expected_outputs(cohort)['mt']),
-#                 str(checkpoint_prefix),
-#                 setup_gcp=True,
-#             )
-#         )
-#
-#         # todo is this necessary?
-#         if depends_on := inputs.get_jobs(cohort):
-#             j.depends_on(*depends_on)
-#
-#         return self.make_outputs(
-#             cohort,
-#             data=self.expected_outputs(cohort),
-#             jobs=j,
-#         )
+@stage(required_stages=RecalculateClusteredQuality)
+class FastCombineGCNVs(CohortStage):
+    """
+    Produces final multi-sample VCF results by running a merge
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        return {
+            'combined_calls': self.prefix / 'gcnv_joint_call.vcf.bgz',
+            'combined_calls_index': self.prefix / 'gcnv_joint_call.vcf.bgz.tbi',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        outputs = self.expected_outputs(cohort)
+
+        # do a slapdash bcftools merge on all input files...
+        gcnv_vcfs = inputs.as_dict_by_target(RecalculateClusteredQuality)
+        all_vcfs = [
+            str(gcnv_vcfs[sgid]['genotyped_segments_vcf'])
+            for sgid in cohort.get_sequencing_group_ids()
+        ]
+
+        pipeline_image = get_images(['sv_pipeline_docker'])['sv_pipeline_docker']
+
+        job_or_none = gcnv.merge_calls(
+            sg_vcfs=all_vcfs,
+            docker_image=pipeline_image,
+            job_attrs=self.get_job_attrs(cohort),
+            output_path=outputs['combined_calls'],
+        )
+        return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
+
+
+@stage(
+    required_stages=FastCombineGCNVs,
+    analysis_type='sv',
+    analysis_keys=['annotated_vcf'],
+    update_analysis_meta=_gcnv_annotated_meta,
+)
+class AnnotateCNV(CohortStage):
+    """
+    Smaller, direct annotation using SvAnnotate
+    Add annotations, such as the inferred function and allele frequencies of variants,
+    to final VCF.
+
+    This is a full clone of the GATK-SV pipeline Cromwell stage, but use on a slightly
+    different output. Trying to work out the best way to handle this through inheritance
+
+    Annotations methods include:
+    * Functional annotation - annotate SVs with inferred functional consequence on
+      protein-coding regions, regulatory regions such as UTR and promoters, and other
+      non-coding elements.
+    * Allele frequency annotation - annotate SVs with their allele frequencies across
+      all samples, and samples of specific sex, as well as specific subpopulations.
+    * Allele Frequency annotation with external callset - annotate SVs with the allele
+      frequencies of their overlapping SVs in another callset, e.g. gnomad SV callset.
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> dict:
+        return {
+            'annotated_vcf': self.prefix / 'gcnv_annotated.vcf.bgz',
+            'annotated_vcf_index': self.prefix / 'gcnv_annotated.vcf.bgz.tbi',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        configure and queue jobs for SV annotation
+        passing the VCF Index has become implicit, which may be a problem for us
+        """
+        expected_out = self.expected_outputs(cohort)
+
+        billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
+
+        job_or_none = queue_annotate_sv_jobs(
+            batch=get_batch(),
+            cohort=cohort,
+            cohort_prefix=self.prefix,
+            input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)['combined_calls'],
+            outputs=expected_out,
+            labels=billing_labels,
+        )
+        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
+
+
+def _gcnv_srvctvre_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, str]:
+    """
+    Callable, adds custom analysis object meta attribute
+    """
+    return {'type': 'gCNV-STRVCTCRE-annotated'}
+
+
+@stage(
+    required_stages=AnnotateCNV,
+    analysis_type='sv',
+    analysis_keys=['strvctvre_vcf'],
+    update_analysis_meta=_gcnv_srvctvre_meta
+)
+class AnnotateCNVVcfWithStrvctvre(
+    CohortStage
+):
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        return {
+            'strvctvre_vcf': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz',
+            'strvctvre_vcf_index': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz.tbi',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        strv_job = get_batch().new_job(
+            'StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'}
+        )
+
+        strv_job.image(image_path('strvctvre'))
+        strv_job.storage('20Gi')
+        strv_job.memory('8Gi')
+
+        strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
+        phylop_in_batch = get_batch().read_input(strvctvre_phylop)
+
+        input_dict = inputs.as_dict(cohort, AnnotateCNV)
+        expected_d = self.expected_outputs(cohort)
+
+        # read vcf and index into the batch
+        input_vcf = get_batch().read_input_group(
+            vcf=str(input_dict['annotated_vcf']),
+            vcf_index=str(input_dict['annotated_vcf_index']),
+        )['vcf']
+
+        strv_job.declare_resource_group(
+            output_vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
+        )
+
+        # run strvctvre
+        strv_job.command(
+            f'python StrVCTVRE.py '
+            f'-i {input_vcf} '
+            f'-o {strv_job.output_vcf["vcf.bgz"]} '
+            f'-f vcf '
+            f'-p {phylop_in_batch}'
+        )
+        strv_job.command(f'tabix {strv_job.output_vcf["vcf.bgz"]}')
+
+        get_batch().write_output(
+            strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', '')
+        )
+        return self.make_outputs(cohort, data=expected_d, jobs=strv_job)
+
+
+@stage(
+    required_stages=AnnotateCNVVcfWithStrvctvre,
+    analysis_type='sv',
+    analysis_keys=['mt'],
+    update_analysis_meta=_gcnv_srvctvre_meta,
+)
+class AnnotateGCNVCohortForSeqr(CohortStage):
+    """
+    Rearrange the annotations across the cohort to suit Seqr
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
+        # convert temp path to str to avoid checking existence
+        return {
+            'tmp_prefix': str(self.tmp_prefix),
+            'mt': self.prefix / 'gcnv_annotated_cohort.mt'
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
+        """
+
+        vcf_path = inputs.as_path(target=cohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf')
+
+        checkpoint_prefix = (
+            to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
+        )
+        j = get_batch().new_job(f'annotate gCNV cohort', self.get_job_attrs(cohort))
+        j.image(image_path('cpg_workflows'))
+        j.command(
+            query_command(
+                seqr_loader_cnv,
+                seqr_loader_cnv.annotate_cohort_gcnv.__name__,
+                str(vcf_path),
+                str(self.expected_outputs(cohort)['mt']),
+                str(checkpoint_prefix),
+                setup_gcp=True,
+            )
+        )
+
+        # todo is this necessary?
+        if depends_on := inputs.get_jobs(cohort):
+            j.depends_on(*depends_on)
+
+        return self.make_outputs(
+            cohort,
+            data=self.expected_outputs(cohort),
+            jobs=j,
+        )

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -112,7 +112,7 @@ class DeterminePloidy(CohortStage):
 
         jobs = gcnv.filter_and_determine_ploidy(
             get_batch(),
-            str(reference_path('gatk_sv/contig_ploidy_priors.tsv')),
+            str(reference_path('gatk_sv/contig_ploidy_priors')),
             # get_config()['workflow'].get('ploidy_priors'),
             prep_intervals['preprocessed'],
             prep_intervals['annotated'],

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -439,7 +439,7 @@ class AnnotateCNVVcfWithStrvctvre(
 
 @stage(
     required_stages=AnnotateCNVVcfWithStrvctvre,
-    analysis_type='sv',
+    analysis_type='es-index',
     analysis_keys=['mt'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -5,6 +5,7 @@ Stages that implement GATK-gCNV.
 from cpg_utils import to_path, Path
 from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch, image_path, query_command, reference_path
+from cpg_workflows.inputs import get_cohort
 from cpg_workflows.jobs import gcnv
 from cpg_workflows.query_modules import seqr_loader_cnv
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
@@ -168,10 +169,11 @@ class GermlineCNVCalls(SequencingGroupStage):
 
     def queue_jobs(self, seqgroup: SequencingGroup, inputs: StageInput) -> StageOutput:
         outputs = self.expected_outputs(seqgroup)
+        determine_ploidy = inputs.as_dict(get_cohort(), DeterminePloidy)
 
         jobs = gcnv.postprocess_calls_1(
-            inputs.as_path(seqgroup.dataset, DeterminePloidy, 'calls'),
-            inputs.as_dict(seqgroup.dataset, GermlineCNV),
+            determine_ploidy['calls'],
+            inputs.as_dict(get_cohort(), GermlineCNV),
             # FIXME get the sample index via sample_name.txt files instead
             seqgroup.dataset.get_sequencing_group_ids().index(seqgroup.id),
             self.get_job_attrs(seqgroup),

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -227,7 +227,8 @@ class GCNVJointSegmentation(CohortStage):
 
         expected_out = self.expected_outputs(cohort)
 
-        ped_path = cohort.write_ped_file(expected_out['pedigree'])
+        # ped_path = cohort.write_ped_file(expected_out['pedigree'])
+        ped_path = 'gs://cpg-seqr-test-tmp/exome/gcnv/a48b821c7e32352a0e683f7164bd3bee61144c_119/GCNVJointSegmentation/pedigree.ped'
 
         jobs = gcnv.run_joint_segmentation(
             all_vcfs,

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -196,7 +196,7 @@ class GCNVJointSegmentation(CohortStage):
             / 'JointClusteredSegments.vcf.gz',
             'clustered_vcf_idx': self.prefix
             / 'JointClusteredSegments.vcf.gz.tbi',
-            'pedigree': str(self.tmp_prefix / 'pedigree.ped'),
+            'pedigree': self.tmp_prefix / 'pedigree.ped',
             'tmp_prefix': str(self.tmp_prefix / 'intermediate_jointseg'),
         }
 
@@ -239,6 +239,20 @@ class GCNVJointSegmentation(CohortStage):
         )
         return self.make_outputs(cohort, data=expected_out, jobs=jobs)
 
+
+# @stage(required_stages=GCNVJointSegmentation)
+# class PostProcessClusteredBreakpoints(SequencingGroupStage):
+#     """
+#     following joint segmentation, we need to post-process the clustered breakpoints
+#     this recalculates each sample's quality scores based on new breakpoints, and
+#     filters low QS or high AF calls
+#     https://github.com/broadinstitute/gatk/blob/master/scripts/cnv_wdl/germline/joint_call_exome_cnvs.wdl#L113
+#     """
+#
+#     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
+#
+#
+#     ...
 
 # @stage(required_stages=GermlineCNVCalls)
 # class PrepareVcfsForMerge(SequencingGroupStage):

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -283,6 +283,7 @@ class RecalculateClusteredQuality(SequencingGroupStage):
             output_prefix=str(self.prefix / sequencing_group.id),
             clustered_vcf=str(joint_seg['clustered_vcf']),
             intervals_vcf=str(gcnv_call_inputs['intervals']),
+            qc_file=str(expected_out['qc_status_file']),
         )
         return self.make_outputs(sequencing_group, data=expected_out, jobs=jobs)
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -242,7 +242,7 @@ class GCNVJointSegmentation(CohortStage):
         return self.make_outputs(cohort, data=expected_out, jobs=jobs)
 
 
-@stage(required_stages=[GCNVJointSegmentation, GermlineCNVCalls, DeterminePloidy])
+@stage(required_stages=[GCNVJointSegmentation, GermlineCNV, GermlineCNVCalls, DeterminePloidy])
 class RecalculateClusteredQuality(SequencingGroupStage):
     """
     following joint segmentation, we need to post-process the clustered breakpoints

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -3,7 +3,7 @@ Stages that implement GATK-gCNV.
 """
 
 from cpg_utils import to_path, Path
-from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
+from cpg_utils.config import try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch, image_path, query_command, reference_path
 from cpg_workflows.inputs import get_cohort
 from cpg_workflows.jobs import gcnv
@@ -14,7 +14,6 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     queue_annotate_sv_jobs,
 )
 from cpg_workflows.targets import SequencingGroup, Cohort
-from cpg_workflows.utils import ExpectedResultT
 from cpg_workflows.workflow import (
     stage,
     CohortStage,
@@ -190,7 +189,7 @@ class GCNVJointSegmentation(CohortStage):
     takes the individual VCFs and runs the joint segmentation step
     """
 
-    def expected_outputs(self, cohort: Cohort) -> ExpectedResultT:
+    def expected_outputs(self, cohort: Cohort) -> dict[str, str | Path]:
         return {
             'clustered_vcf': self.prefix / 'JointClusteredSegments.vcf.gz',
             'clustered_vcf_idx': self.prefix / 'JointClusteredSegments.vcf.gz.tbi',

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -187,233 +187,248 @@ class GermlineCNVCalls(SequencingGroupStage):
 
 
 @stage(required_stages=GermlineCNVCalls)
-class PrepareVcfsForMerge(SequencingGroupStage):
+class GCNVJointSegmentation(CohortStage):
     """
-    Fixes the GT header in the VCFs produced by gCNV
-    During experimentation these were found to be Integer instead of String
-    This will be fixed in a future release of GATK
-    Also splits multiallelic loci (all sites are called as Dup/Del GTs)
-    Each site needs to have only one Alt allele for the annotation step
+    various config elements scavenged from https://github.com/broadinstitute/gatk/blob/cfd4d87ec29ac45a68f13a37f30101f326546b7d/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json#L26
+    continuing adaptation of https://github.com/broadinstitute/gatk/blob/master/scripts/cnv_wdl/germline/joint_call_exome_cnvs.wdl
+    takes the individual VCFs and runs the joint segmentation step
     """
 
-    def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
-        return {
-            'fixed_intervals': self.prefix / f'{seqgroup.id}.fixed_intervals.vcf.bgz',
-            'fixed_intervals_index': self.prefix
-            / f'{seqgroup.id}.fixed_intervals.vcf.bgz.tbi',
-        }
-
-    def queue_jobs(
-        self, seqgroup: SequencingGroup, inputs: StageInput
-    ) -> StageOutput | None:
-        outputs = self.expected_outputs(seqgroup)
-
-        jobs = gcnv.fix_intervals_vcf(
-            get_batch(),
-            inputs.as_path(seqgroup, GermlineCNVCalls, 'intervals'),
-            self.get_job_attrs(seqgroup),
-            output_path=outputs['fixed_intervals'],
-        )
-        return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
-
-
-@stage(required_stages=PrepareVcfsForMerge)
-class FastCombineGCNVs(CohortStage):
-    """
-    Produces final multi-sample VCF results by running a merge
-    """
-
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return {
-            'combined_calls': self.prefix / 'gcnv_joint_call.vcf.bgz',
-            'combined_calls_index': self.prefix / 'gcnv_joint_call.vcf.bgz.tbi',
-        }
+    def expected_outputs(self, cohort: Cohort) -> ExpectedResultT:
+        ...
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        outputs = self.expected_outputs(cohort)
-
-        # do a slapdash bcftools merge on all input files...
-        gcnv_vcfs = inputs.as_dict_by_target(PrepareVcfsForMerge)
-        all_vcfs = [
-            str(gcnv_vcfs[sgid]['fixed_intervals'])
-            for sgid in cohort.get_sequencing_group_ids()
-        ]
-
-        pipeline_image = get_images(['sv_pipeline_docker'])['sv_pipeline_docker']
-
-        job_or_none = gcnv.merge_calls(
-            get_batch(),
-            sg_vcfs=all_vcfs,
-            docker_image=pipeline_image,
-            job_attrs=self.get_job_attrs(cohort),
-            output_path=outputs['combined_calls'],
-        )
-        return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
+        ...
 
 
-@stage(
-    required_stages=FastCombineGCNVs,
-    analysis_type='sv',
-    analysis_keys=['annotated_vcf'],
-    update_analysis_meta=_gcnv_annotated_meta,
-)
-class AnnotateCNV(CohortStage):
-    """
-    Smaller, direct annotation using SvAnnotate
-    Add annotations, such as the inferred function and allele frequencies of variants,
-    to final VCF.
-
-    This is a full clone of the GATK-SV pipeline Cromwell stage, but use on a slightly
-    different output. Trying to work out the best way to handle this through inheritance
-
-    Annotations methods include:
-    * Functional annotation - annotate SVs with inferred functional consequence on
-      protein-coding regions, regulatory regions such as UTR and promoters, and other
-      non-coding elements.
-    * Allele frequency annotation - annotate SVs with their allele frequencies across
-      all samples, and samples of specific sex, as well as specific subpopulations.
-    * Allele Frequency annotation with external callset - annotate SVs with the allele
-      frequencies of their overlapping SVs in another callset, e.g. gnomad SV callset.
-    """
-
-    def expected_outputs(self, cohort: Cohort) -> dict:
-        return {
-            'annotated_vcf': self.prefix / 'gcnv_annotated.vcf.bgz',
-            'annotated_vcf_index': self.prefix / 'gcnv_annotated.vcf.bgz.tbi',
-        }
-
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        """
-        configure and queue jobs for SV annotation
-        passing the VCF Index has become implicit, which may be a problem for us
-        """
-        expected_out = self.expected_outputs(cohort)
-
-        billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
-
-        job_or_none = queue_annotate_sv_jobs(
-            batch=get_batch(),
-            cohort=cohort,
-            cohort_prefix=self.prefix,
-            input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)['combined_calls'],
-            outputs=expected_out,
-            labels=billing_labels,
-        )
-        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
-
-
-def _gcnv_srvctvre_meta(
-    output_path: str,  # pylint: disable=W0613:unused-argument
-) -> dict[str, str]:
-    """
-    Callable, adds custom analysis object meta attribute
-    """
-    return {'type': 'gCNV-STRVCTCRE-annotated'}
-
-
-@stage(
-    required_stages=AnnotateCNV,
-    analysis_type='sv',
-    analysis_keys=['strvctvre_vcf'],
-    update_analysis_meta=_gcnv_srvctvre_meta
-)
-class AnnotateCNVVcfWithStrvctvre(
-    CohortStage
-):
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return {
-            'strvctvre_vcf': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz',
-            'strvctvre_vcf_index': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz.tbi',
-        }
-
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        strv_job = get_batch().new_job(
-            'StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'}
-        )
-
-        strv_job.image(image_path('strvctvre'))
-        strv_job.storage('20Gi')
-        strv_job.memory('8Gi')
-
-        strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
-        phylop_in_batch = get_batch().read_input(strvctvre_phylop)
-
-        input_dict = inputs.as_dict(cohort, AnnotateCNV)
-        expected_d = self.expected_outputs(cohort)
-
-        # read vcf and index into the batch
-        input_vcf = get_batch().read_input_group(
-            vcf=str(input_dict['annotated_vcf']),
-            vcf_index=str(input_dict['annotated_vcf_index']),
-        )['vcf']
-
-        strv_job.declare_resource_group(
-            output_vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
-        )
-
-        # run strvctvre
-        strv_job.command(
-            f'python StrVCTVRE.py '
-            f'-i {input_vcf} '
-            f'-o {strv_job.output_vcf["vcf.bgz"]} '
-            f'-f vcf '
-            f'-p {phylop_in_batch}'
-        )
-        strv_job.command(f'tabix {strv_job.output_vcf["vcf.bgz"]}')
-
-        get_batch().write_output(
-            strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', '')
-        )
-        return self.make_outputs(cohort, data=expected_d, jobs=strv_job)
-
-
-@stage(
-    required_stages=AnnotateCNVVcfWithStrvctvre,
-    analysis_type='sv',
-    analysis_keys=['mt'],
-    update_analysis_meta=_gcnv_srvctvre_meta,
-)
-class AnnotateGCNVCohortForSeqr(CohortStage):
-    """
-    Rearrange the annotations across the cohort to suit Seqr
-    """
-
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
-        # convert temp path to str to avoid checking existence
-        return {
-            'tmp_prefix': str(self.tmp_prefix),
-            'mt': self.prefix / 'gcnv_annotated_cohort.mt'
-        }
-
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        """
-        Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
-        """
-
-        vcf_path = inputs.as_path(target=cohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf')
-
-        checkpoint_prefix = (
-            to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
-        )
-        j = get_batch().new_job(f'annotate gCNV cohort', self.get_job_attrs(cohort))
-        j.image(image_path('cpg_workflows'))
-        j.command(
-            query_command(
-                seqr_loader_cnv,
-                seqr_loader_cnv.annotate_cohort_gcnv.__name__,
-                str(vcf_path),
-                str(self.expected_outputs(cohort)['mt']),
-                str(checkpoint_prefix),
-                setup_gcp=True,
-            )
-        )
-
-        # todo is this necessary?
-        if depends_on := inputs.get_jobs(cohort):
-            j.depends_on(*depends_on)
-
-        return self.make_outputs(
-            cohort,
-            data=self.expected_outputs(cohort),
-            jobs=j,
-        )
+# @stage(required_stages=GermlineCNVCalls)
+# class PrepareVcfsForMerge(SequencingGroupStage):
+#     """
+#     Fixes the GT header in the VCFs produced by gCNV
+#     During experimentation these were found to be Integer instead of String
+#     This will be fixed in a future release of GATK
+#     Also splits multiallelic loci (all sites are called as Dup/Del GTs)
+#     Each site needs to have only one Alt allele for the annotation step
+#     """
+#
+#     def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
+#         return {
+#             'fixed_intervals': self.prefix / f'{seqgroup.id}.fixed_intervals.vcf.bgz',
+#             'fixed_intervals_index': self.prefix
+#             / f'{seqgroup.id}.fixed_intervals.vcf.bgz.tbi',
+#         }
+#
+#     def queue_jobs(
+#         self, seqgroup: SequencingGroup, inputs: StageInput
+#     ) -> StageOutput | None:
+#         outputs = self.expected_outputs(seqgroup)
+#
+#         jobs = gcnv.fix_intervals_vcf(
+#             get_batch(),
+#             inputs.as_path(seqgroup, GermlineCNVCalls, 'intervals'),
+#             self.get_job_attrs(seqgroup),
+#             output_path=outputs['fixed_intervals'],
+#         )
+#         return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
+#
+#
+# @stage(required_stages=PrepareVcfsForMerge)
+# class FastCombineGCNVs(CohortStage):
+#     """
+#     Produces final multi-sample VCF results by running a merge
+#     """
+#
+#     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+#         return {
+#             'combined_calls': self.prefix / 'gcnv_joint_call.vcf.bgz',
+#             'combined_calls_index': self.prefix / 'gcnv_joint_call.vcf.bgz.tbi',
+#         }
+#
+#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+#         outputs = self.expected_outputs(cohort)
+#
+#         # do a slapdash bcftools merge on all input files...
+#         gcnv_vcfs = inputs.as_dict_by_target(PrepareVcfsForMerge)
+#         all_vcfs = [
+#             str(gcnv_vcfs[sgid]['fixed_intervals'])
+#             for sgid in cohort.get_sequencing_group_ids()
+#         ]
+#
+#         pipeline_image = get_images(['sv_pipeline_docker'])['sv_pipeline_docker']
+#
+#         job_or_none = gcnv.merge_calls(
+#             get_batch(),
+#             sg_vcfs=all_vcfs,
+#             docker_image=pipeline_image,
+#             job_attrs=self.get_job_attrs(cohort),
+#             output_path=outputs['combined_calls'],
+#         )
+#         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
+#
+#
+# @stage(
+#     required_stages=FastCombineGCNVs,
+#     analysis_type='sv',
+#     analysis_keys=['annotated_vcf'],
+#     update_analysis_meta=_gcnv_annotated_meta,
+# )
+# class AnnotateCNV(CohortStage):
+#     """
+#     Smaller, direct annotation using SvAnnotate
+#     Add annotations, such as the inferred function and allele frequencies of variants,
+#     to final VCF.
+#
+#     This is a full clone of the GATK-SV pipeline Cromwell stage, but use on a slightly
+#     different output. Trying to work out the best way to handle this through inheritance
+#
+#     Annotations methods include:
+#     * Functional annotation - annotate SVs with inferred functional consequence on
+#       protein-coding regions, regulatory regions such as UTR and promoters, and other
+#       non-coding elements.
+#     * Allele frequency annotation - annotate SVs with their allele frequencies across
+#       all samples, and samples of specific sex, as well as specific subpopulations.
+#     * Allele Frequency annotation with external callset - annotate SVs with the allele
+#       frequencies of their overlapping SVs in another callset, e.g. gnomad SV callset.
+#     """
+#
+#     def expected_outputs(self, cohort: Cohort) -> dict:
+#         return {
+#             'annotated_vcf': self.prefix / 'gcnv_annotated.vcf.bgz',
+#             'annotated_vcf_index': self.prefix / 'gcnv_annotated.vcf.bgz.tbi',
+#         }
+#
+#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+#         """
+#         configure and queue jobs for SV annotation
+#         passing the VCF Index has become implicit, which may be a problem for us
+#         """
+#         expected_out = self.expected_outputs(cohort)
+#
+#         billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
+#
+#         job_or_none = queue_annotate_sv_jobs(
+#             batch=get_batch(),
+#             cohort=cohort,
+#             cohort_prefix=self.prefix,
+#             input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)['combined_calls'],
+#             outputs=expected_out,
+#             labels=billing_labels,
+#         )
+#         return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
+#
+#
+# def _gcnv_srvctvre_meta(
+#     output_path: str,  # pylint: disable=W0613:unused-argument
+# ) -> dict[str, str]:
+#     """
+#     Callable, adds custom analysis object meta attribute
+#     """
+#     return {'type': 'gCNV-STRVCTCRE-annotated'}
+#
+#
+# @stage(
+#     required_stages=AnnotateCNV,
+#     analysis_type='sv',
+#     analysis_keys=['strvctvre_vcf'],
+#     update_analysis_meta=_gcnv_srvctvre_meta
+# )
+# class AnnotateCNVVcfWithStrvctvre(
+#     CohortStage
+# ):
+#     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+#         return {
+#             'strvctvre_vcf': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz',
+#             'strvctvre_vcf_index': self.prefix / 'cnv_strvctvre_annotated.vcf.bgz.tbi',
+#         }
+#
+#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+#         strv_job = get_batch().new_job(
+#             'StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'}
+#         )
+#
+#         strv_job.image(image_path('strvctvre'))
+#         strv_job.storage('20Gi')
+#         strv_job.memory('8Gi')
+#
+#         strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
+#         phylop_in_batch = get_batch().read_input(strvctvre_phylop)
+#
+#         input_dict = inputs.as_dict(cohort, AnnotateCNV)
+#         expected_d = self.expected_outputs(cohort)
+#
+#         # read vcf and index into the batch
+#         input_vcf = get_batch().read_input_group(
+#             vcf=str(input_dict['annotated_vcf']),
+#             vcf_index=str(input_dict['annotated_vcf_index']),
+#         )['vcf']
+#
+#         strv_job.declare_resource_group(
+#             output_vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'}
+#         )
+#
+#         # run strvctvre
+#         strv_job.command(
+#             f'python StrVCTVRE.py '
+#             f'-i {input_vcf} '
+#             f'-o {strv_job.output_vcf["vcf.bgz"]} '
+#             f'-f vcf '
+#             f'-p {phylop_in_batch}'
+#         )
+#         strv_job.command(f'tabix {strv_job.output_vcf["vcf.bgz"]}')
+#
+#         get_batch().write_output(
+#             strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', '')
+#         )
+#         return self.make_outputs(cohort, data=expected_d, jobs=strv_job)
+#
+#
+# @stage(
+#     required_stages=AnnotateCNVVcfWithStrvctvre,
+#     analysis_type='sv',
+#     analysis_keys=['mt'],
+#     update_analysis_meta=_gcnv_srvctvre_meta,
+# )
+# class AnnotateGCNVCohortForSeqr(CohortStage):
+#     """
+#     Rearrange the annotations across the cohort to suit Seqr
+#     """
+#
+#     def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
+#         # convert temp path to str to avoid checking existence
+#         return {
+#             'tmp_prefix': str(self.tmp_prefix),
+#             'mt': self.prefix / 'gcnv_annotated_cohort.mt'
+#         }
+#
+#     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+#         """
+#         Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
+#         """
+#
+#         vcf_path = inputs.as_path(target=cohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf')
+#
+#         checkpoint_prefix = (
+#             to_path(self.expected_outputs(cohort)['tmp_prefix']) / 'checkpoints'
+#         )
+#         j = get_batch().new_job(f'annotate gCNV cohort', self.get_job_attrs(cohort))
+#         j.image(image_path('cpg_workflows'))
+#         j.command(
+#             query_command(
+#                 seqr_loader_cnv,
+#                 seqr_loader_cnv.annotate_cohort_gcnv.__name__,
+#                 str(vcf_path),
+#                 str(self.expected_outputs(cohort)['mt']),
+#                 str(checkpoint_prefix),
+#                 setup_gcp=True,
+#             )
+#         )
+#
+#         # todo is this necessary?
+#         if depends_on := inputs.get_jobs(cohort):
+#             j.depends_on(*depends_on)
+#
+#         return self.make_outputs(
+#             cohort,
+#             data=self.expected_outputs(cohort),
+#             jobs=j,
+#         )

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -436,10 +436,11 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
         strv_job.command(
             f'python StrVCTVRE.py '
             f'-i {input_vcf} '
-            f'-o {strv_job.output_vcf["vcf.bgz"]} '
+            f'-o temp.vcf '
             f'-f vcf '
             f'-p {phylop_in_batch}'
         )
+        strv_job.command(f'bgzip temp.vcf -c > {strv_job.output_vcf["vcf.bgz"]}')
         strv_job.command(f'tabix {strv_job.output_vcf["vcf.bgz"]}')
 
         get_batch().write_output(

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -452,7 +452,7 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
 
 @stage(
     required_stages=AnnotateCNVVcfWithStrvctvre,
-    analysis_type='es-index',
+    analysis_type='sv',
     analysis_keys=['mt'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -240,19 +240,30 @@ class GCNVJointSegmentation(CohortStage):
         return self.make_outputs(cohort, data=expected_out, jobs=jobs)
 
 
-# @stage(required_stages=GCNVJointSegmentation)
-# class PostProcessClusteredBreakpoints(SequencingGroupStage):
-#     """
-#     following joint segmentation, we need to post-process the clustered breakpoints
-#     this recalculates each sample's quality scores based on new breakpoints, and
-#     filters low QS or high AF calls
-#     https://github.com/broadinstitute/gatk/blob/master/scripts/cnv_wdl/germline/joint_call_exome_cnvs.wdl#L113
-#     """
-#
-#     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
-#
-#
-#     ...
+@stage(required_stages=GCNVJointSegmentation)
+class RecalculateClusteredQuality(SequencingGroupStage):
+    """
+    following joint segmentation, we need to post-process the clustered breakpoints
+    this recalculates each sample's quality scores based on new breakpoints, and
+    filters low QS or high AF calls
+    https://github.com/broadinstitute/gatk/blob/master/scripts/cnv_wdl/germline/joint_call_exome_cnvs.wdl#L113
+    """
+
+    def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
+        return {
+            'genotyped_intervals_vcf': self.prefix / f'{sequencing_group.id}.genotyped_intervals.vcf.gz',
+            'genotyped_intervals_vcf_index': self.prefix / f'{sequencing_group.id}.genotyped_intervals.vcf.gz.tbi',
+            'genotyped_segments_vcf': self.prefix / f'{sequencing_group.id}.genotyped_segments.vcf.gz',
+            'genotyped_segments_vcf_index': self.prefix / f'{sequencing_group.id}.genotyped_segments.vcf.gz.tbi',
+            'denoised_copy_ratios': self.prefix / f'{sequencing_group.id}.denoised_copy_ratios.tsv',
+            'qc_status_file': self.prefix / f'{sequencing_group.id}.qc_status.txt',
+        }
+
+    def queue_jobs(
+        self, sequencing_group: SequencingGroup, inputs: StageInput
+    ) -> StageOutput:
+        ...
+
 
 # @stage(required_stages=GermlineCNVCalls)
 # class PrepareVcfsForMerge(SequencingGroupStage):

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -255,11 +255,11 @@ class RecalculateClusteredQuality(SequencingGroupStage):
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
         return {
-            'genotyped_intervals_vcf': self.prefix / f'{sequencing_group.id}.genotyped_intervals.vcf.gz',
-            'genotyped_intervals_vcf_index': self.prefix / f'{sequencing_group.id}.genotyped_intervals.vcf.gz.tbi',
-            'genotyped_segments_vcf': self.prefix / f'{sequencing_group.id}.genotyped_segments.vcf.gz',
-            'genotyped_segments_vcf_index': self.prefix / f'{sequencing_group.id}.genotyped_segments.vcf.gz.tbi',
-            'denoised_copy_ratios': self.prefix / f'{sequencing_group.id}.denoised_copy_ratios.tsv',
+            'genotyped_intervals_vcf': self.prefix / f'{sequencing_group.id}.intervals.vcf.gz',
+            'genotyped_intervals_vcf_index': self.prefix / f'{sequencing_group.id}.intervals.vcf.gz.tbi',
+            'genotyped_segments_vcf': self.prefix / f'{sequencing_group.id}.segments.vcf.gz',
+            'genotyped_segments_vcf_index': self.prefix / f'{sequencing_group.id}.segments.vcf.gz.tbi',
+            'denoised_copy_ratios': self.prefix / f'{sequencing_group.id}.ratios.tsv',
             'qc_status_file': self.prefix / f'{sequencing_group.id}.qc_status.txt',
         }
 

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -9,6 +9,8 @@ import time
 import traceback
 import unicodedata
 from functools import lru_cache
+
+from itertools import chain, islice
 from os.path import basename, dirname, join
 from random import choices
 from typing import Union, cast
@@ -17,6 +19,41 @@ import hail as hl
 from cpg_utils import Path, to_path
 from cpg_utils.config import get_config
 from hailtop.batch import ResourceFile
+
+
+def chunks(iterable, chunk_size):
+    """
+    Yield successive n-sized chunks from an iterable
+
+    Args:
+        iterable (): any iterable - tuple, str, list, set
+        chunk_size (): size of intervals to return
+
+    Returns:
+        intervals of requested size across the collection
+    """
+
+    if isinstance(iterable, set):
+        iterable = list(iterable)
+
+    for i in range(0, len(iterable), chunk_size):
+        yield iterable[i : (i + chunk_size)]
+
+
+def generator_chunks(generator, size):
+    """
+    Iterates across a generator, returning specifically sized chunks
+
+    Args:
+        generator (): any generator or method implementing yield
+        size (): size of iterator to return
+
+    Returns:
+        a subset of the generator results
+    """
+    iterator = iter(generator)
+    for first in iterator:
+        yield list(chain([first], islice(iterator, size - 1)))
 
 
 def read_hail(path):

--- a/main.py
+++ b/main.py
@@ -24,13 +24,12 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import (
-    AnnotateCNV,
-    AnnotateCNVVcfWithStrvctvre,
-    AnnotateGCNVCohortForSeqr,
-    GermlineCNVCalls,
-    FastCombineGCNVs,
-)
+from cpg_workflows.stages.gcnv import GermlineCNVCalls
+    # AnnotateCNV,
+    # AnnotateCNVVcfWithStrvctvre,
+    # AnnotateGCNVCohortForSeqr,
+    # FastCombineGCNVs,
+
 from cpg_workflows.stages.aip import GeneratePanelData, QueryPanelapp, RunHailFiltering, ValidateMOI, CreateAIPHTML
 from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.stages.happy_validation import (

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import GermlineCNVCalls, GCNVJointSegmentation
+from cpg_workflows.stages.gcnv import GermlineCNVCalls, GCNVJointSegmentation, RecalculateClusteredQuality
     # AnnotateCNV,
     # AnnotateCNVVcfWithStrvctvre,
     # AnnotateGCNVCohortForSeqr,
@@ -63,7 +63,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [GermlineCNVCalls, GCNVJointSegmentation],
+    'gcnv': [GermlineCNVCalls, GCNVJointSegmentation, RecalculateClusteredQuality],
 }
 
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import GermlineCNVCalls
+from cpg_workflows.stages.gcnv import GermlineCNVCalls, GCNVJointSegmentation
     # AnnotateCNV,
     # AnnotateCNVVcfWithStrvctvre,
     # AnnotateGCNVCohortForSeqr,
@@ -63,7 +63,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [GermlineCNVCalls, FastCombineGCNVs, AnnotateCNV, AnnotateCNVVcfWithStrvctvre, AnnotateGCNVCohortForSeqr],
+    'gcnv': [GermlineCNVCalls, GCNVJointSegmentation],
 }
 
 

--- a/main.py
+++ b/main.py
@@ -24,12 +24,15 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import GermlineCNVCalls, GCNVJointSegmentation, RecalculateClusteredQuality
-    # AnnotateCNV,
-    # AnnotateCNVVcfWithStrvctvre,
-    # AnnotateGCNVCohortForSeqr,
-    # FastCombineGCNVs,
-
+from cpg_workflows.stages.gcnv import (
+    GermlineCNVCalls,
+    GCNVJointSegmentation,
+    RecalculateClusteredQuality,
+    FastCombineGCNVs,
+    AnnotateCNV,
+    AnnotateCNVVcfWithStrvctvre,
+    AnnotateGCNVCohortForSeqr,
+)
 from cpg_workflows.stages.aip import GeneratePanelData, QueryPanelapp, RunHailFiltering, ValidateMOI, CreateAIPHTML
 from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.stages.happy_validation import (
@@ -63,7 +66,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [GermlineCNVCalls, GCNVJointSegmentation, RecalculateClusteredQuality],
+    'gcnv': [AnnotateGCNVCohortForSeqr],
 }
 
 

--- a/main.py
+++ b/main.py
@@ -24,15 +24,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import (
-    GermlineCNVCalls,
-    GCNVJointSegmentation,
-    RecalculateClusteredQuality,
-    FastCombineGCNVs,
-    AnnotateCNV,
-    AnnotateCNVVcfWithStrvctvre,
-    AnnotateGCNVCohortForSeqr,
-)
+from cpg_workflows.stages.gcnv import AnnotateGCNVCohortForSeqr
 from cpg_workflows.stages.aip import GeneratePanelData, QueryPanelapp, RunHailFiltering, ValidateMOI, CreateAIPHTML
 from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.stages.happy_validation import (


### PR DESCRIPTION
Lots changed here, I'll try and make a summary...

## Rationale

The previous incarnation of gCNV calls through to annotated joint call was using the wrong data - I erroneously thought that the Intervals VCF was the correctly joint genotyped source of information. Instead the workflow has a whole extra set of steps as shown in [this WDL](https://github.com/broadinstitute/gatk/blob/master/scripts/cnv_wdl/germline/joint_call_exome_cnvs.wdl#L113).

This meant restarting from the per-sample call generation, and shoving in a few more steps. That's what this change is doing.

## New content

### Stages/gCNV

#### Stuff that happens all over

- the batch instance is no longer passed to the job-generating methods, instead the `get_batch()` method is used to accomplish the same
- altered output file name to no longer contain the `cohort.name` - most/all data will be processed under the `seqr` project, so all files would have seqr as a name
- where multiple values are obtained from prior stages (e.g. `inputs.as_path(cohort, Stage, 'key')`, these are obtained once as a dict, and each key is then pulled out. This should avoid re-triggering the logic to find prior stage outputs.

#### DeterminePloidy

- output is stored in regular buckets, not tmp - the joint-genotyping stage now requires these files, and the (relatively) cheap final stages can't be repeated without these files which are expensive to reproduce

#### GermlineCNV

- output files stored in main bucket, same reasoning applies

#### GermlineCNVCalls

- fetching input from prior stages is done using the Cohort, not the Dataset. This was not an issue previously as both were Acute-Care.

#### PrepareVcfsForMerge

- Step completely removed, it was adapting the wrong VCFs, and is not not necessary

#### GCNVJointSegmentation

- Pulls in the Segment VCFs from all individual SG IDs, and triggers the joint-segmentation algorithm. This was done using a dummy Pedigree (IDs inside the files are from prod, file names and metamist entries are from test. GATK failed when the pedigree with prod IDs mismatched the file content)

#### RecalculateClusteredQuality

- Pulls in the clustered results and re-scores the quality for each individual's calls based on the cohort context. This is essentially a second pass through PostProcessGCNVCalls with some additional arguments.
- `Missing`: this step produces a QC file, with the intention that only QC PASS'es are used when generating the joint call. Based on this test run all samples failed 🙃 so we should reconsider the thresholds in use there. If we generate some QC results that make sense there, this should be the end of a first workflow - Hail can't make decisions about which samples to pass into the VCF merging state based on QC results that are generated within the workflow, so we would have to terminate here, and run a second workflow to parse the QC results, and use that data when generating the joint call.

#### FastCombineGCNVs

- Mostly unchanged, except for the source VCF used when merging

---

### Jobs/gCNV

#### postprocess_calls

- Restructured so that two different stages can call this method - one naively to generate VCFs from the sharded Tar files, and once to recalculate qualities in a joint-call context. If the intervals, clusters, and QC file args are provided, the second behaviour is triggered
- The 3 additional arguments are added to the GATK tool command-line args, and read into the batch as appropriate
- The output directory is generated using `mkdir` - I don't know why or how, but the Tar'chive unpacking seems to delete/obfuscate the Hail Batch outputs folder, so the workflows crashed having nowhere to write to.
- The job `command`s are added individually instead of as a single list of commands. The reasoning here is kinda dumb - [this conditional behaviour](https://github.com/populationgenomics/production-pipelines/blob/a3b2150f226ff4c595eba5ff1fbfa58e57e37bd0/cpg_workflows/jobs/gcnv.py#L377-L398) creates the QC file for each sample, then writes that file out to GCP. The hail-batch resource files are only created once the `"{job.output}"` text is included in a call to `job.command`. The previous structure was elegant, but meant that `j.qc_file` wouldn't exist until all commands are sent to Hail. That means that this conditional loop would have to happen twice:
    - if qc file: generate qc stats
    - send command strings to Hail Batch
    - if qc file - retrieve the qc output file
- which undermines the elegance of the original solution

#### run_joint_segmentation  & joint_segment_vcfs

- Runs the joint segmentation operation in GATK, but as a 2-step. If the total number of samples is greater than X (from config), produce an intermediate round of merges
- Step 1: split the group of SG IDs into groups of length X, then produce one merged VCF for each
- Step 2: merge all the intermediate merge files

### update_vcf_attributes

- This method previously compensated for 'missing values' in the combined VCF (mostly missing because I was using the wrong input data. 
- Behaviours which are still required (to comply with Strvctvre more than anything else:
   - add SVLEN (header entry exists, but value is not populated in variant.INFO...)
   - generate a unique ID for each variant (the bcftools merge creates a huge list of ;-delimited IDs, not all of which are relevant to the specific variant)
   - Reassembles the INFO string, plus SVLEN

---

I've re-run this whole pipeline from scratch, with the latest job [here](https://batch.hail.populationgenomics.org.au/batches/433927) (I cancelled it once I spotted that the MT outputs would be registered in metamist wrongly as `es-index`es)

Apologies to all for the general grottiness of this PR

https://batch.hail.populationgenomics.org.au/batches/433950