### PR TITLE
Fix intermediate file overwriting in test-tmp bucket to prevent script failures due to existing files

### DIFF
--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -115,7 +115,7 @@ def impute_sex(
             )
             vds = VariantDataset(
                 reference_data=vds.reference_data, variant_data=tmp_variant_data
-            ).checkpoint(str(tmp_prefix / f'{name}_checkpoint.vds'))
+            ).checkpoint(str(tmp_prefix / f'{name}_checkpoint.vds'), overwrite=True)
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 
     # Infer sex (adds row fields: is_female, var_data_chr20_mean_dp, sex_karyotype)


### PR DESCRIPTION
In areas of `sample_qc.py` there are checks for file existence using `can_resuse()`. Currently for files in the `<project>-test-tmp` bucket `can_reuse(overwrite=True)` is called, where if the file exists we don't reuse it and overwrite instead. This fix continues this approach inside the filtering of intervals `lcr_intervals_ht`, `seg_dup_intervals_ht` where checkpoints are performed after each filter and the files are written to the `tmp` bucket. However, currently if this file exists, because `overwrite` has not been specified, the script will not write the files and break (not what we want!)

To resolve this issue, the code has been updated to include the `overwrite=True` parameter in the `checkpoint()` function call (note: not using `can_reuse(ovewrite=True)`, instead `checkpoint` accepts an overwrite parameter). This ensures that existing files are overwritten without causing the script to break. Without this change, running the script repeatedly in close succession would lead to failures due to existing files in the test-tmp bucket.

Note: the checkpointing during this filtration step was recently implemented to reduce memory load see PR #570 