### PR TITLE
Remove Dataproc from Frequencies stage of Large Cohort

### DIFF
--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -18,10 +18,10 @@ from gnomad.utils.release import make_faf_index_dict
 
 
 def run(
-    vds_path: str,
-    sample_qc_ht_path: str,
-    relateds_to_drop_ht_path: str,
-    out_ht_path: str,
+    vds_path: Path,
+    sample_qc_ht_path: Path,
+    relateds_to_drop_ht_path: Path,
+    out_ht_path: Path,
 ):
     if can_reuse(out_ht_path):
         return

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -18,10 +18,10 @@ from gnomad.utils.release import make_faf_index_dict
 
 
 def run(
-    vds_path: Path,
-    sample_qc_ht_path: Path,
-    relateds_to_drop_ht_path: Path,
-    out_ht_path: Path,
+    vds_path: str,
+    sample_qc_ht_path: str,
+    relateds_to_drop_ht_path: str,
+    out_ht_path: str,
 ):
     if can_reuse(out_ht_path):
         return

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -295,43 +295,43 @@ class LoadVqsr(CohortStage):
 @stage(required_stages=[Combiner, SampleQC, Relatedness])
 class Frequencies(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return self.tmp_prefix / 'no_dp_frequencies.ht'
+        return self.tmp_prefix / 'dp_frequencies.ht'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        from cpg_workflows.large_cohort import frequencies
+        # from cpg_workflows.large_cohort import frequencies
 
-        # from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
-        # from cpg_workflows.large_cohort.frequencies import run
+        from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
+        from cpg_workflows.large_cohort.frequencies import run
 
-        j = get_batch().new_job(
-            'Frequencies',
-            (self.get_job_attrs() or {}) | {'tool': 'hail query'},
-        )
-        j.image(image_path('cpg_workflows'))
-
-        j.command(
-            query_command(
-                frequencies,
-                frequencies.run.__name__,
-                str(inputs.as_path(cohort, Combiner)),
-                str(inputs.as_path(cohort, SampleQC)),
-                str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
-                str(self.expected_outputs(cohort)),
-                setup_gcp=True,
-            ),
-        )
-
-        # j = dataproc_job(
-        #     job_name=self.__class__.__name__,
-        #     function=run,
-        #     function_path_args=dict(
-        #         vds_path=inputs.as_path(cohort, stage=Combiner),
-        #         sample_qc_ht_path=inputs.as_path(cohort, stage=SampleQC),
-        #         relateds_to_drop_ht_path=inputs.as_path(
-        #             cohort, stage=Relatedness, key='relateds_to_drop'
-        #         ),
-        #         out_ht_path=self.expected_outputs(cohort),
-        #     ),
-        #     depends_on=inputs.get_jobs(cohort),
+        # j = get_batch().new_job(
+        #     'Frequencies', (self.get_job_attrs() or {}) | {'tool': 'hail query'}
         # )
+        # j.image(image_path('cpg_workflows'))
+        # j.command(
+        #     query_command(
+        #         frequencies,
+        #         frequencies.run.__name__,
+        #         str(inputs.as_path(cohort, Combiner)),
+        #         str(inputs.as_path(cohort, SampleQC)),
+        #         str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
+        #         str(self.expected_outputs(cohort)),
+        #         setup_gcp=True,
+        #     )
+        # )
+
+        j = dataproc_job(
+            job_name=self.__class__.__name__,
+            function=run,
+            function_path_args=dict(
+                vds_path=inputs.as_path(cohort, stage=Combiner),
+                sample_qc_ht_path=inputs.as_path(cohort, stage=SampleQC),
+                relateds_to_drop_ht_path=inputs.as_path(
+                    cohort,
+                    stage=Relatedness,
+                    key='relateds_to_drop',
+                ),
+                out_ht_path=self.expected_outputs(cohort),
+            ),
+            depends_on=inputs.get_jobs(cohort),
+        )
         return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=[j])

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -295,21 +295,43 @@ class LoadVqsr(CohortStage):
 @stage(required_stages=[Combiner, SampleQC, Relatedness])
 class Frequencies(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return get_workflow().prefix / 'frequencies.ht'
+        return self.tmp_prefix / 'no_dp_frequencies.ht'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
-        from cpg_workflows.large_cohort.frequencies import run
+        from cpg_workflows.large_cohort import frequencies
 
-        j = dataproc_job(
-            job_name=self.__class__.__name__,
-            function=run,
-            function_path_args=dict(
-                vds_path=inputs.as_path(cohort, stage=Combiner),
-                sample_qc_ht_path=inputs.as_path(cohort, stage=SampleQC),
-                relateds_to_drop_ht_path=inputs.as_path(cohort, stage=Relatedness, key='relateds_to_drop'),
-                out_ht_path=self.expected_outputs(cohort),
-            ),
-            depends_on=inputs.get_jobs(cohort),
+        # from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
+        # from cpg_workflows.large_cohort.frequencies import run
+
+        j = get_batch().new_job(
+            'Frequencies',
+            (self.get_job_attrs() or {}) | {'tool': 'hail query'},
         )
+        j.image(image_path('cpg_workflows'))
+
+        j.command(
+            query_command(
+                frequencies,
+                frequencies.run.__name__,
+                str(inputs.as_path(cohort, Combiner)),
+                str(inputs.as_path(cohort, SampleQC)),
+                str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
+                str(self.expected_outputs(cohort)),
+                setup_gcp=True,
+            ),
+        )
+
+        # j = dataproc_job(
+        #     job_name=self.__class__.__name__,
+        #     function=run,
+        #     function_path_args=dict(
+        #         vds_path=inputs.as_path(cohort, stage=Combiner),
+        #         sample_qc_ht_path=inputs.as_path(cohort, stage=SampleQC),
+        #         relateds_to_drop_ht_path=inputs.as_path(
+        #             cohort, stage=Relatedness, key='relateds_to_drop'
+        #         ),
+        #         out_ht_path=self.expected_outputs(cohort),
+        #     ),
+        #     depends_on=inputs.get_jobs(cohort),
+        # )
         return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=[j])

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -295,43 +295,27 @@ class LoadVqsr(CohortStage):
 @stage(required_stages=[Combiner, SampleQC, Relatedness])
 class Frequencies(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return self.tmp_prefix / 'dp_frequencies.ht'
+        return get_workflow().prefix / 'frequencies.ht'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        # from cpg_workflows.large_cohort import frequencies
+        from cpg_workflows.large_cohort import frequencies
 
-        from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
-        from cpg_workflows.large_cohort.frequencies import run
-
-        # j = get_batch().new_job(
-        #     'Frequencies', (self.get_job_attrs() or {}) | {'tool': 'hail query'}
-        # )
-        # j.image(image_path('cpg_workflows'))
-        # j.command(
-        #     query_command(
-        #         frequencies,
-        #         frequencies.run.__name__,
-        #         str(inputs.as_path(cohort, Combiner)),
-        #         str(inputs.as_path(cohort, SampleQC)),
-        #         str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
-        #         str(self.expected_outputs(cohort)),
-        #         setup_gcp=True,
-        #     )
-        # )
-
-        j = dataproc_job(
-            job_name=self.__class__.__name__,
-            function=run,
-            function_path_args=dict(
-                vds_path=inputs.as_path(cohort, stage=Combiner),
-                sample_qc_ht_path=inputs.as_path(cohort, stage=SampleQC),
-                relateds_to_drop_ht_path=inputs.as_path(
-                    cohort,
-                    stage=Relatedness,
-                    key='relateds_to_drop',
-                ),
-                out_ht_path=self.expected_outputs(cohort),
-            ),
-            depends_on=inputs.get_jobs(cohort),
+        j = get_batch().new_job(
+            'Frequencies',
+            (self.get_job_attrs() or {}) | {'tool': 'hail query'},
         )
+        j.image(image_path('cpg_workflows'))
+
+        j.command(
+            query_command(
+                frequencies,
+                frequencies.run.__name__,
+                str(inputs.as_path(cohort, Combiner)),
+                str(inputs.as_path(cohort, SampleQC)),
+                str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
+                str(self.expected_outputs(cohort)),
+                setup_gcp=True,
+            ),
+        )
+
         return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=[j])


### PR DESCRIPTION
Similar to https://github.com/populationgenomics/production-pipelines/pull/621 and https://github.com/populationgenomics/production-pipelines/pull/626

Part of a larger effort to remove reliance on dataproc from stages of the Large Cohort pipeline