### PR TITLE
gCNV joint call dataset stages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.20.0
+current_version = 1.21.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.20.0
+  VERSION: 1.21.0
 
 jobs:
   docker:

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -25,3 +25,12 @@ external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
 external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
 noncoding_bed = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed'
 strvctvre_phylop = 'gs://cpg-common-test/references/hg38.phyloP100way.bw'
+
+[elasticsearch]
+# Configure access to ElasticSearch server
+port = '9243'
+host = 'elasticsearch.es.australia-southeast1.gcp.elastic-cloud.com'
+username = 'seqr'
+# Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
+password_secret_id = 'seqr-es-password'
+password_project_id = 'seqr-308602'

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -718,7 +718,7 @@ def annotate_dataset_jobs_cnv(
     annotate_j.command(
         query_command(
             seqr_loader_cnv,
-            seqr_loader_cnv.annotate_dataset_sv.__name__,
+            seqr_loader_cnv.annotate_dataset_gcnv.__name__,
             str(subset_mt_path),
             str(out_mt_path),
             setup_gcp=True,

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -62,18 +62,16 @@ def annotate_cohort_gcnv(
         sampleType='WES'
     )
 
-    # apply variant_qc annotations
-    mt = hl.variant_qc(mt)
-
     # reimplementation of
     # github.com/populationgenomics/seqr-loading-pipelines..luigi_pipeline/lib/model/gcnv_mt_schema.py
     mt = mt.annotate_rows(
         contig=mt.locus.contig.replace('^chr', ''),
         start=mt.locus.position,
         pos=mt.locus.position,
-        sc=mt.variant_qc.AC[0],
-        sf=mt.variant_qc.AF[0],
-        sn=mt.variant_qc.AN,
+        # todo @MattWellie - review use of AC_Orig vs. AC (post-qc)
+        sc=mt.AC_Orig[0],
+        sf=mt.AF_Orig[0],
+        sn=mt.AN_Orig,
         end=mt.info.END,
         sv_callset_Het=mt.info.N_HET,
         sv_callset_Hom=mt.info.N_HOMALT,
@@ -88,9 +86,6 @@ def annotate_cohort_gcnv(
         xstop=get_expr_for_xpos(hl.struct(contig=mt.locus.contig, position=mt.info.END)),
         num_exon=hl.agg.max(mt.NP)
     )
-
-    # drop the variant_qc. Can't trust its NAN values
-    mt = mt.drop('variant_qc')
 
     # save those changes
     mt = checkpoint_hail(mt, 'initial_annotation_round.mt', checkpoint_prefix)

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -69,9 +69,9 @@ def annotate_cohort_gcnv(
         start=mt.locus.position,
         pos=mt.locus.position,
         # todo @MattWellie - review use of AC_Orig vs. AC (post-qc)
-        sc=mt.AC_Orig[0],
-        sf=mt.AF_Orig[0],
-        sn=mt.AN_Orig,
+        sc=mt.info.AC_Orig[0],
+        sf=mt.info.AF_Orig[0],
+        sn=mt.info.AN_Orig,
         end=mt.info.END,
         sv_callset_Het=mt.info.N_HET,
         sv_callset_Hom=mt.info.N_HOMALT,

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -197,7 +197,7 @@ def annotate_dataset_sv(mt_path: str, out_mt_path: str):
         genotypes=hl.agg.collect(
             hl.struct(
                 sample_id=mt.s,
-                gq=mt.CNQ,
+                gq=mt.QA,
                 cn=mt.CN,
                 end=mt.end,
                 num_exon=mt.NP,

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -456,7 +456,7 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
     analysis_keys=['mt'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )
-class AnnotateGCNVCohortForSeqr(CohortStage):
+class AnnotateCohortgCNV(CohortStage):
     """
     Rearrange the annotations across the cohort to suit Seqr
     """
@@ -505,7 +505,7 @@ class AnnotateGCNVCohortForSeqr(CohortStage):
 
 
 @stage(
-    required_stages=AnnotateGCNVCohortForSeqr,
+    required_stages=AnnotateCohortgCNV,
     analysis_type='cnv',
     analysis_keys=['mt']
 )
@@ -539,7 +539,7 @@ class AnnotateDatasetCNV(DatasetStage):
 
         assert dataset.cohort
         mt_path = inputs.as_path(
-            target=dataset.cohort, stage=AnnotateGCNVCohortForSeqr, key='mt'
+            target=dataset.cohort, stage=AnnotateCohortgCNV, key='mt'
         )
 
         checkpoint_prefix = (

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -3,7 +3,7 @@ Stages that implement GATK-gCNV.
 """
 
 from cpg_utils import to_path, Path
-from cpg_utils.config import try_get_ar_guid, AR_GUID_NAME
+from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch, image_path, query_command, reference_path
 from cpg_workflows.inputs import get_cohort
 from cpg_workflows.jobs import gcnv
@@ -15,8 +15,11 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
 )
 from cpg_workflows.targets import SequencingGroup, Cohort
 from cpg_workflows.workflow import (
+    get_workflow,
     stage,
     CohortStage,
+    Dataset,
+    DatasetStage,
     SequencingGroupStage,
     StageInput,
     StageOutput,
@@ -331,7 +334,7 @@ class FastCombineGCNVs(CohortStage):
 
 @stage(
     required_stages=FastCombineGCNVs,
-    analysis_type='sv',
+    analysis_type='cnv',
     analysis_keys=['annotated_vcf'],
     update_analysis_meta=_gcnv_annotated_meta,
 )
@@ -390,7 +393,7 @@ def _gcnv_srvctvre_meta(
 
 @stage(
     required_stages=AnnotateCNV,
-    analysis_type='sv',
+    analysis_type='cnv',
     analysis_keys=['strvctvre_vcf'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )
@@ -449,7 +452,7 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
 
 @stage(
     required_stages=AnnotateCNVVcfWithStrvctvre,
-    analysis_type='sv',
+    analysis_type='cnv',
     analysis_keys=['mt'],
     update_analysis_meta=_gcnv_srvctvre_meta,
 )
@@ -499,3 +502,162 @@ class AnnotateGCNVCohortForSeqr(CohortStage):
             data=self.expected_outputs(cohort),
             jobs=j,
         )
+
+
+@stage(
+    required_stages=AnnotateGCNVCohortForSeqr,
+    analysis_type='cnv',
+    analysis_keys=['mt']
+)
+class AnnotateDatasetCNV(DatasetStage):
+    """
+    Subset the MT to be this Dataset only
+    Then work up all the genotype values
+    """
+
+    def expected_outputs(self, dataset: Dataset) -> dict:
+        """
+        Expected to generate a matrix table
+        """
+        return {
+            'tmp_prefix': str(self.tmp_prefix / dataset.name),
+            'mt': (
+                dataset.prefix()
+                / 'mt'
+                / f'gCNV-{get_workflow().output_version}-{dataset.name}.mt'
+            ),
+        }
+
+    def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:
+        """
+        Subsets the whole MT to this cohort only
+        Then brings a range of genotype data into row annotations
+        Args:
+            dataset (Dataset): SGIDs specific to this dataset/project
+            inputs ():
+        """
+
+        assert dataset.cohort
+        mt_path = inputs.as_path(
+            target=dataset.cohort, stage=AnnotateGCNVCohortForSeqr, key='mt'
+        )
+
+        checkpoint_prefix = (
+            to_path(self.expected_outputs(dataset)['tmp_prefix']) / 'checkpoints'
+        )
+
+        jobs = gcnv.annotate_dataset_jobs_cnv(
+            mt_path=mt_path,
+            sgids=dataset.get_sequencing_group_ids(),
+            out_mt_path=self.expected_outputs(dataset)['mt'],
+            tmp_prefix=checkpoint_prefix,
+            job_attrs=self.get_job_attrs(dataset),
+            depends_on=inputs.get_jobs(dataset),  # todo is this necessary?
+        )
+
+        return self.make_outputs(
+            dataset, data=self.expected_outputs(dataset), jobs=jobs
+        )
+
+
+def _gatk_gcnv_index_meta(
+    output_path: str,  # pylint: disable=W0613:unused-argument
+) -> dict[str, str]:
+    """
+    Add meta.type to custom analysis object
+    https://github.com/populationgenomics/metamist/issues/539
+    """
+    return {'seqr-dataset-type': 'CNV'}
+
+
+@stage(
+    required_stages=[AnnotateDatasetCNV],
+    analysis_type='es-index',  # specific type of es index
+    analysis_keys=['index_name'],
+    update_analysis_meta=_gatk_gcnv_index_meta,
+)
+class MtToEsCNV(DatasetStage):
+    """
+    Create a Seqr index
+    """
+
+    def expected_outputs(self, dataset: Dataset) -> dict[str, str | Path]:
+        """
+        Expected to generate a Seqr index, which is not a file
+        """
+        sequencing_type = get_config()['workflow']['sequencing_type']
+        index_name = f'{dataset.name}-{sequencing_type}-gCNV-{get_workflow().run_timestamp}'.lower()
+        return {
+            'index_name': index_name,
+            'done_flag': dataset.prefix() / 'es' / f'{index_name}.done',
+        }
+
+    def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:
+        """
+        Uses analysis-runner's dataproc helper to run a hail query script
+        """
+        if (
+            es_datasets := get_config()['workflow'].get('create_es_index_for_datasets')
+        ) and dataset.name not in es_datasets:
+            # Skipping dataset that wasn't explicitly requested to upload to ES
+            return self.make_outputs(dataset)
+
+        dataset_mt_path = inputs.as_path(
+            target=dataset, stage=AnnotateDatasetCNV, key='mt'
+        )
+        index_name = self.expected_outputs(dataset)['index_name']
+        done_flag_path = self.expected_outputs(dataset)['done_flag']
+
+        if 'elasticsearch' not in get_config():
+            raise ValueError(
+                f'"elasticsearch" section is not defined in config, cannot create '
+                f'Elasticsearch index for dataset {dataset}'
+            )
+
+        from analysis_runner import dataproc
+        from cpg_workflows.stages.seqr_loader import es_password
+
+        # transformation is the same, just use the same methods file?
+        script = (
+            f'cpg_workflows/dataproc_scripts/mt_to_es.py '
+            f'--mt-path {dataset_mt_path} '
+            f'--es-index {index_name} '
+            f'--done-flag-path {done_flag_path} '
+            f'--es-password {es_password()}'
+        )
+        pyfiles = ['seqr-loading-pipelines/hail_scripts']
+        job_name = f'{dataset.name}: create ES index'
+
+        if cluster_id := get_config()['hail'].get('dataproc', {}).get('cluster_id'):
+            # noinspection PyProtectedMember
+            j = dataproc._add_submit_job(
+                batch=get_batch(),
+                cluster_id=cluster_id,
+                script=script,
+                pyfiles=pyfiles,
+                job_name=job_name,
+                region='australia-southeast1',
+            )
+        else:
+            j = dataproc.hail_dataproc_job(
+                get_batch(),
+                script,
+                max_age='48h',
+                packages=[
+                    'cpg_workflows',
+                    'elasticsearch==8.*',
+                    'google',
+                    'fsspec',
+                    'gcloud',
+                ],
+                num_workers=2,
+                num_secondary_workers=0,
+                job_name=job_name,
+                depends_on=inputs.get_jobs(dataset),
+                scopes=['cloud-platform'],
+                pyfiles=pyfiles,
+            )
+        j._preemptible = False
+        j.attributes = (j.attributes or {}) | {'tool': 'hailctl dataproc'}
+        jobs = [j]
+        return self.make_outputs(dataset, data=index_name, jobs=jobs)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,11 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 )
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import AnnotateGCNVCohortForSeqr
+from cpg_workflows.stages.gcnv import (
+    AnnotateGCNVCohortForSeqr,
+    AnnotateDatasetCNV,
+    MtToEsCNV
+)
 from cpg_workflows.stages.aip import (
     GeneratePanelData,
     QueryPanelapp,
@@ -65,7 +69,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [AnnotateGCNVCohortForSeqr],
+    'gcnv': [AnnotateGCNVCohortForSeqr, AnnotateDatasetCNV, MtToEsCNV],
 }
 
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import AnnotateVcf, AnnotateDatasetSv, MtToEsSv
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
 from cpg_workflows.stages.gcnv import (
-    AnnotateGCNVCohortForSeqr,
+    AnnotateCohortgCNV,
     AnnotateDatasetCNV,
     MtToEsCNV
 )
@@ -69,7 +69,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     ],  # stage to run between FilterBatch & GenotypeBatch
     'gatk_sv_multisample_2': [AnnotateVcf, AnnotateDatasetSv, MtToEsSv],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [AnnotateGCNVCohortForSeqr, AnnotateDatasetCNV, MtToEsCNV],
+    'gcnv': [AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV],
 }
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ bump2version
 black
 pytest
 pytest_mock
-mypy==1.9.0
+mypy==1.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pre-commit
+pre-commit>=3.5.0
 pylint
 bump2version
 black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ bump2version
 black
 pytest
 pytest_mock
-mypy
+mypy==1.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ bump2version
 black
 pytest
 pytest_mock
-mypy==1.8.0
+mypy==1.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-pre-commit>=3.5.0
+pre-commit
 pylint
 bump2version
 black
 pytest
 pytest_mock
-mypy==1.7.0
+mypy

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.20.0',
+    version='1.21.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Corrected version of https://github.com/populationgenomics/production-pipelines/pull/614

This version follows on from the joint-called CNV data instead of the wrongly processed Intervals VCFs

Currently loaded into AC Exomes in Seqr staging, could do with prettying up, but the results at least load this time around

Most of the MtToEsCNV stage is common to MtToEs and MtToEsSv, so that should probably be abstracted out into a varianttype-independent Dataproc wrapper. Feels outside of the scope here, but a candidate for a tidy-up PR to shed some lines