### PR TITLE
Adjust pipeline for quality filtered samples

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.19.0
+current_version = 1.20.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.19.0
+  VERSION: 1.20.0
 
 jobs:
   docker:

--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -19,6 +19,8 @@ disk_gb = 200
 
 [resource_overrides.MakeCohortVcf]
 run_module_metrics = false
+[resource_overrides.MakeCohortVcf.runtime_override_plot_qc_per_family]
+mem_gb = 32
 
 # resource overrides for indirect workflows
 

--- a/cpg_workflows/jobs/seqr_loader.py
+++ b/cpg_workflows/jobs/seqr_loader.py
@@ -7,12 +7,11 @@ from hailtop.batch.job import Job
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import image_path, query_command
+from cpg_utils.hail_batch import get_batch, image_path, query_command
 from cpg_workflows.query_modules import seqr_loader
 
 
 def annotate_dataset_jobs(
-    b: Batch,
     mt_path: Path,
     sequencing_group_ids: list[str],
     out_mt_path: Path,
@@ -31,7 +30,7 @@ def annotate_dataset_jobs(
 
     subset_mt_path = tmp_prefix / 'cohort-subset.mt'
 
-    subset_j = b.new_job(
+    subset_j = get_batch().new_job(
         'Subset cohort to dataset', (job_attrs or {}) | {'tool': 'hail query'}
     )
     subset_j.image(image_path('cpg_workflows'))
@@ -49,7 +48,7 @@ def annotate_dataset_jobs(
     if depends_on:
         subset_j.depends_on(*depends_on)
 
-    annotate_j = b.new_job(
+    annotate_j = get_batch().new_job(
         'Annotate dataset', (job_attrs or {}) | {'tool': 'hail query'}
     )
     annotate_j.image(image_path('cpg_workflows'))

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -80,7 +80,7 @@ def annotate_dataset_jobs_sv(
             str(mt_path),
             sgids,
             str(subset_mt_path),
-            exclusion_file,
+            exclusion_file if exclusion_file else '',
             setup_gcp=True,
         )
     )

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -80,7 +80,7 @@ def annotate_dataset_jobs_sv(
             str(mt_path),
             sgids,
             str(subset_mt_path),
-            exclusion_file if exclusion_file else '',
+            exclusion_file,
             setup_gcp=True,
         )
     )

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -48,11 +48,18 @@ def annotate_dataset_jobs_sv(
     out_mt_path: Path,
     tmp_prefix: Path,
     job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None
+    depends_on: list[Job] | None = None,
+    exclusion_file: str | None = None
 ) -> list[Job]:
     """
     Split mt by dataset and annotate dataset-specific fields (only for those datasets
     that will be loaded into Seqr).
+
+    exclusion_file: str | None - this is a file path in GCP which will contain
+        all SG IDs which are to be removed from consideration in this run. i.e.
+        we anticipate that they will have been removed from the joint-call, and
+        we will not find them, so this subsetting code will fail if it attempts
+        to find them in the callset
     """
     assert sgids
     sgids_list_path = tmp_prefix / 'sgid-list.txt'

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -209,7 +209,7 @@ def subset_mt_to_samples(mt_path, sample_ids, out_mt_path, exclusion_file: str |
     # this executes in a query command, by execution time the file should exist
     if exclusion_file:
         with hl.hadoop_open(exclusion_file) as f:
-            exclusion_ids = set(f.read().decode().splitlines())
+            exclusion_ids = set(f.read().splitlines())
         logging.info(f'Excluding {len(exclusion_ids)} samples from the subset')
         sample_ids -= exclusion_ids
 

--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -67,7 +67,6 @@ from metamist.graphql import gql
 
 from cpg_workflows.metamist import gql_query_optional_logging
 from cpg_workflows.resources import STANDARD
-from cpg_workflows.utils import ExpectedResultT
 from cpg_workflows.workflow import (
     Dataset,
     DatasetStage,

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -14,7 +14,7 @@ from analysis_runner.cromwell import (
 )
 from cpg_utils import Path, to_path
 from cpg_utils.config import ConfigError, get_config
-from cpg_utils.hail_batch import Batch, command, image_path, reference_path
+from cpg_utils.hail_batch import command, get_batch, image_path, reference_path
 from hailtop.batch.job import Job
 
 from cpg_workflows.batch import make_job_name
@@ -145,7 +145,6 @@ def get_references(keys: list[str | dict[str, str]]) -> dict[str, str | list[str
 
 
 def add_gatk_sv_jobs(
-    batch: Batch,
     dataset: Dataset,
     wfl_name: str,
     # "dict" is invariant (supports updating), "Mapping" is covariant (read-only)
@@ -221,7 +220,7 @@ def add_gatk_sv_jobs(
     copy_outputs = get_config()['workflow'].get('copy_outputs', False)
 
     submit_j, output_dict = run_cromwell_workflow_from_repo_and_get_outputs(
-        b=batch,
+        b=get_batch(),
         job_prefix=job_prefix,
         dataset=get_config()['workflow']['dataset'],
         repo='gatk-sv',
@@ -239,7 +238,7 @@ def add_gatk_sv_jobs(
         max_watch_poll_interval=polling_maximum,
     )
 
-    copy_j = batch.new_job(f'{job_prefix}: copy outputs')
+    copy_j = get_batch().new_job(f'{job_prefix}: copy outputs')
     copy_j.image(driver_image)
     cmds = []
     for key, resource in output_dict.items():
@@ -337,7 +336,6 @@ def make_combined_ped(cohort: Cohort, prefix: Path) -> Path:
 
 
 def queue_annotate_sv_jobs(
-    batch,
     cohort,
     cohort_prefix: Path,
     input_vcf: Path,
@@ -380,7 +378,6 @@ def queue_annotate_sv_jobs(
         ]
     )
     jobs = add_gatk_sv_jobs(
-        batch=batch,
         dataset=cohort.analysis_dataset,
         wfl_name='AnnotateVcf',
         input_dict=input_dict,

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -9,7 +9,9 @@ from random import randint
 from typing import Any
 
 from analysis_runner.cromwell import (
-    CromwellOutputType, run_cromwell_workflow_from_repo_and_get_outputs)
+    CromwellOutputType,
+    run_cromwell_workflow_from_repo_and_get_outputs,
+)
 from cpg_utils import Path, to_path
 from cpg_utils.config import ConfigError, get_config
 from cpg_utils.hail_batch import command, get_batch, image_path, reference_path

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -77,7 +77,6 @@ def _sv_batch_meta(
     return {'type': 'gatk-sv-batch-calls'}
 
 
-
 def _sv_individual_meta(
     output_path: str,  # pylint: disable=W0613:unused-argument
 ) -> dict[str, Any]:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -77,14 +77,6 @@ def _sv_batch_meta(
     return {'type': 'gatk-sv-batch-calls'}
 
 
-def _sv_filtered_meta(
-    output_path: str,  # pylint: disable=W0613:unused-argument
-) -> dict[str, Any]:
-    """
-    Callable, add meta[type] to custom analysis object
-    """
-    return {'type': 'gatk-sv-filtered-calls'}
-
 
 def _sv_individual_meta(
     output_path: str,  # pylint: disable=W0613:unused-argument

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -9,9 +9,7 @@ from random import randint
 from typing import Any
 
 from analysis_runner.cromwell import (
-    CromwellOutputType,
-    run_cromwell_workflow_from_repo_and_get_outputs,
-)
+    CromwellOutputType, run_cromwell_workflow_from_repo_and_get_outputs)
 from cpg_utils import Path, to_path
 from cpg_utils.config import ConfigError, get_config
 from cpg_utils.hail_batch import command, get_batch, image_path, reference_path

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from cpg_utils import Path
 from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
-from cpg_utils.hail_batch import get_batch
 
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     CromwellJobSizes,
@@ -185,7 +184,6 @@ class GatherBatchEvidence(CohortStage):
 
         # this step runs for approximately 15 hours
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -275,7 +273,6 @@ class ClusterBatch(CohortStage):
 
         # runs for approx 1 hour
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -355,7 +352,6 @@ class GenerateBatchMetrics(CohortStage):
 
         # runs for approx 4-5 hours
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -452,7 +448,6 @@ class FilterBatch(CohortStage):
 
         # runs for over an hour
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -525,7 +520,6 @@ class MergeBatchSites(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -653,7 +647,6 @@ class GenotypeBatch(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -9,27 +9,18 @@ across batches between FilterBatch and GenotypeBatch
 from typing import Any
 
 from cpg_utils import Path
-from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
+from cpg_utils.config import AR_GUID_NAME, get_config, try_get_ar_guid
 
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    CromwellJobSizes,
-    SV_CALLERS,
-    _sv_batch_meta,
-    add_gatk_sv_jobs,
-    get_fasta,
-    get_images,
-    get_ref_panel,
-    get_references,
-    make_combined_ped,
-)
-from cpg_workflows.workflow import (
-    Cohort,
-    CohortStage,
-    StageInput,
-    StageOutput,
-    get_workflow,
-    stage,
-)
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import (SV_CALLERS,
+                                                         CromwellJobSizes,
+                                                         _sv_batch_meta,
+                                                         add_gatk_sv_jobs,
+                                                         get_fasta, get_images,
+                                                         get_ref_panel,
+                                                         get_references,
+                                                         make_combined_ped)
+from cpg_workflows.workflow import (Cohort, CohortStage, StageInput,
+                                    StageOutput, get_workflow, stage)
 
 
 @stage

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -11,16 +11,25 @@ from typing import Any
 from cpg_utils import Path
 from cpg_utils.config import AR_GUID_NAME, get_config, try_get_ar_guid
 
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import (SV_CALLERS,
-                                                         CromwellJobSizes,
-                                                         _sv_batch_meta,
-                                                         add_gatk_sv_jobs,
-                                                         get_fasta, get_images,
-                                                         get_ref_panel,
-                                                         get_references,
-                                                         make_combined_ped)
-from cpg_workflows.workflow import (Cohort, CohortStage, StageInput,
-                                    StageOutput, get_workflow, stage)
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
+    SV_CALLERS,
+    CromwellJobSizes,
+    _sv_batch_meta,
+    add_gatk_sv_jobs,
+    get_fasta,
+    get_images,
+    get_ref_panel,
+    get_references,
+    make_combined_ped,
+)
+from cpg_workflows.workflow import (
+    Cohort,
+    CohortStage,
+    StageInput,
+    StageOutput,
+    get_workflow,
+    stage,
+)
 
 
 @stage

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -54,14 +54,14 @@ EXCLUSION_FILE = join(
 )
 
 
-def _exclusion_callable(output_path: str):
+def _exclusion_callable(output_path: str) -> dict[str, set[str]]:
     from cpg_utils import to_path
 
-    excluded_ids = set()
+    excluded_ids: set[str] = set()
 
     if not to_path(output_path).exists():
         print(f'No exclusion list found: {output_path}')
-        return excluded_ids
+        return {'filtered_sgids': excluded_ids}
 
     with to_path(output_path).open() as f:
         for line in f.readlines():

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -882,6 +882,7 @@ class MtToEsSv(DatasetStage):
 
         if cluster_id := get_config()['hail'].get('dataproc', {}).get('cluster_id'):
             # noinspection PyProtectedMember
+
             j = dataproc._add_submit_job(
                 batch=get_batch(),
                 cluster_id=cluster_id,
@@ -889,6 +890,7 @@ class MtToEsSv(DatasetStage):
                 pyfiles=pyfiles,
                 job_name=job_name,
                 region='australia-southeast1',
+                hail_version=dataproc.DEFAULT_HAIL_VERSION
             )
         else:
             j = dataproc.hail_dataproc_job(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -295,7 +295,6 @@ class MakeCohortVcf(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -345,7 +344,6 @@ class FormatVcfForGatk(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -415,7 +413,6 @@ class JoinRawCalls(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -465,7 +462,6 @@ class SVConcordance(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -591,7 +587,6 @@ class FilterGenotypes(CohortStage):
         }
 
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -648,7 +643,6 @@ class AnnotateVcf(CohortStage):
             AR_GUID_NAME: try_get_ar_guid(),
         }
         job_or_none = queue_annotate_sv_jobs(
-            batch=get_batch(),
             cohort=cohort,
             cohort_prefix=self.prefix,
             input_vcf=inputs.as_dict(cohort, FilterGenotypes)['filtered_vcf'],
@@ -738,7 +732,6 @@ class AnnotateCohortSv(CohortStage):
         )
 
         job = annotate_cohort_jobs_sv(
-            b=get_batch(),
             vcf_path=vcf_path,
             out_mt_path=self.expected_outputs(cohort)['mt'],
             checkpoint_prefix=checkpoint_prefix,
@@ -806,7 +799,6 @@ class AnnotateDatasetSv(DatasetStage):
         )
 
         jobs = annotate_dataset_jobs_sv(
-            b=get_batch(),
             mt_path=mt_path,
             sgids=dataset.get_sequencing_group_ids(),
             out_mt_path=self.expected_outputs(dataset)['mt'],

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -10,19 +10,38 @@ from typing import Any
 
 from cpg_utils import Path, to_path
 from cpg_utils.config import AR_GUID_NAME, get_config, try_get_ar_guid
-from cpg_utils.hail_batch import (authenticate_cloud_credentials_in_job,
-                                  get_batch, image_path)
+from cpg_utils.hail_batch import (
+    authenticate_cloud_credentials_in_job,
+    get_batch,
+    image_path,
+)
 
 from cpg_workflows.jobs import ploidy_table_from_ped
-from cpg_workflows.jobs.seqr_loader_sv import (annotate_cohort_jobs_sv,
-                                               annotate_dataset_jobs_sv)
+from cpg_workflows.jobs.seqr_loader_sv import (
+    annotate_cohort_jobs_sv,
+    annotate_dataset_jobs_sv,
+)
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    SV_CALLERS, CromwellJobSizes, add_gatk_sv_jobs, get_fasta, get_images,
-    get_references, make_combined_ped, queue_annotate_sv_jobs)
+    SV_CALLERS,
+    CromwellJobSizes,
+    add_gatk_sv_jobs,
+    get_fasta,
+    get_images,
+    get_references,
+    make_combined_ped,
+    queue_annotate_sv_jobs,
+)
 from cpg_workflows.stages.seqr_loader import es_password
-from cpg_workflows.workflow import (Cohort, CohortStage, Dataset, DatasetStage,
-                                    StageInput, StageOutput, get_workflow,
-                                    stage)
+from cpg_workflows.workflow import (
+    Cohort,
+    CohortStage,
+    Dataset,
+    DatasetStage,
+    StageInput,
+    StageOutput,
+    get_workflow,
+    stage,
+)
 
 # create the file path outside Stages, so that
 # we can pass this to the metadata update function
@@ -31,13 +50,19 @@ EXCLUSION_FILE = join(
     get_config()['storage']['default']['default'],
     'gatk_sv',
     RUN_DATETIME,
-    'combined_exclusion_list.txt'
+    'combined_exclusion_list.txt',
 )
 
 
 def _exclusion_callable(output_path: str):
     from cpg_utils import to_path
+
     excluded_ids = set()
+
+    if not to_path(output_path).exists():
+        print(f'No exclusion list found: {output_path}')
+        return excluded_ids
+
     with to_path(output_path).open() as f:
         for line in f.readlines():
             excluded_ids.add(line.strip())
@@ -47,7 +72,7 @@ def _exclusion_callable(output_path: str):
 @stage(
     analysis_type='sv',
     analysis_keys=['exclusion_list'],
-    update_analysis_meta=_exclusion_callable
+    update_analysis_meta=_exclusion_callable,
 )
 class CombineExclusionLists(CohortStage):
     """
@@ -76,10 +101,7 @@ class CombineExclusionLists(CohortStage):
         batch_prefix = cohort.analysis_dataset.prefix() / 'gatk_sv'
 
         all_filter_lists = [
-            batch_prefix
-            / batch_name
-            / 'FilterBatch'
-            / 'outliers.samples.list'
+            batch_prefix / batch_name / 'FilterBatch' / 'outliers.samples.list'
             for batch_name in batch_names
         ]
 
@@ -873,7 +895,7 @@ class MtToEsSv(DatasetStage):
                 pyfiles=pyfiles,
                 job_name=job_name,
                 region='australia-southeast1',
-                hail_version=dataproc.DEFAULT_HAIL_VERSION
+                hail_version=dataproc.DEFAULT_HAIL_VERSION,
             )
         else:
             j = dataproc.hail_dataproc_job(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -4,42 +4,25 @@ results of the per-batch workflows into a joint-call across the entire cohort
 """
 
 import logging
+from datetime import datetime
 from os.path import join
 from typing import Any
 
 from cpg_utils import Path, to_path
-from cpg_utils.hail_batch import get_batch
 from cpg_utils.config import AR_GUID_NAME, get_config, try_get_ar_guid
-from cpg_utils.hail_batch import image_path, authenticate_cloud_credentials_in_job
+from cpg_utils.hail_batch import (authenticate_cloud_credentials_in_job,
+                                  get_batch, image_path)
 
 from cpg_workflows.jobs import ploidy_table_from_ped
-from cpg_workflows.jobs.seqr_loader_sv import (
-    annotate_cohort_jobs_sv,
-    annotate_dataset_jobs_sv,
-)
+from cpg_workflows.jobs.seqr_loader_sv import (annotate_cohort_jobs_sv,
+                                               annotate_dataset_jobs_sv)
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    CromwellJobSizes,
-    SV_CALLERS,
-    add_gatk_sv_jobs,
-    get_fasta,
-    get_images,
-    get_references,
-    make_combined_ped,
-    queue_annotate_sv_jobs,
-)
+    SV_CALLERS, CromwellJobSizes, add_gatk_sv_jobs, get_fasta, get_images,
+    get_references, make_combined_ped, queue_annotate_sv_jobs)
 from cpg_workflows.stages.seqr_loader import es_password
-from cpg_workflows.workflow import (
-    Cohort,
-    CohortStage,
-    Dataset,
-    DatasetStage,
-    StageInput,
-    StageOutput,
-    get_workflow,
-    stage,
-)
-from datetime import datetime
-
+from cpg_workflows.workflow import (Cohort, CohortStage, Dataset, DatasetStage,
+                                    StageInput, StageOutput, get_workflow,
+                                    stage)
 
 # create the file path outside Stages, so that
 # we can pass this to the metadata update function

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -52,7 +52,20 @@ EXCLUSION_FILE = join(
 )
 
 
-@stage(analysis_type='sv', analysis_keys=['exclusion_list'])
+def _exclusion_callable(output_path: str):
+    from cpg_utils import to_path
+    excluded_ids = set()
+    with to_path(output_path).open() as f:
+        for line in f.readlines():
+            excluded_ids.add(line.strip())
+    return {'filtered_sgids': excluded_ids}
+
+
+@stage(
+    analysis_type='sv',
+    analysis_keys=['exclusion_list'],
+    update_analysis_meta=_exclusion_callable
+)
 class CombineExclusionLists(CohortStage):
     """
     Takes the per-batch lists of excluded sample IDs and combines

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -503,6 +503,7 @@ def _sv_filtered_meta(
     """
     return {'type': 'gatk-sv-filtered-calls', 'remove_sgids': EXCLUSION_FILE}
 
+
 @stage(
     required_stages=[GeneratePloidyTable, SVConcordance],
     analysis_type='sv',

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -150,7 +150,6 @@ class GatherSampleEvidence(SequencingGroupStage):
         # we alter the per-sample maximum to be between 5 and 30 minutes for this
         # long-running job, so samples poll on different intervals, spreading load
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=sequencing_group.dataset,
             wfl_name=self.name,
             input_dict=input_dict,
@@ -221,7 +220,6 @@ class EvidenceQC(CohortStage):
 
         # runs for approx 5 hours, depending on sample count
         jobs = add_gatk_sv_jobs(
-            batch=get_batch(),
             dataset=cohort.analysis_dataset,
             wfl_name=self.name,
             input_dict=input_dict,

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -5,28 +5,19 @@ import logging
 from typing import Any
 
 from cpg_utils import Path
+from cpg_utils.config import AR_GUID_NAME, get_config, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch
-from cpg_utils.config import get_config, try_get_ar_guid, AR_GUID_NAME
 
 from cpg_workflows.jobs import sample_batching
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    CromwellJobSizes,
-    SV_CALLERS,
-    _sv_individual_meta,
-    add_gatk_sv_jobs,
-    get_fasta,
-    get_images,
-    get_references,
-)
-from cpg_workflows.workflow import (
-    Cohort,
-    CohortStage,
-    SequencingGroup,
-    SequencingGroupStage,
-    StageInput,
-    StageOutput,
-    stage,
-)
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import (SV_CALLERS,
+                                                         CromwellJobSizes,
+                                                         _sv_individual_meta,
+                                                         add_gatk_sv_jobs,
+                                                         get_fasta, get_images,
+                                                         get_references)
+from cpg_workflows.workflow import (Cohort, CohortStage, SequencingGroup,
+                                    SequencingGroupStage, StageInput,
+                                    StageOutput, stage)
 
 
 @stage(

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -9,15 +9,24 @@ from cpg_utils.config import AR_GUID_NAME, get_config, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch
 
 from cpg_workflows.jobs import sample_batching
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import (SV_CALLERS,
-                                                         CromwellJobSizes,
-                                                         _sv_individual_meta,
-                                                         add_gatk_sv_jobs,
-                                                         get_fasta, get_images,
-                                                         get_references)
-from cpg_workflows.workflow import (Cohort, CohortStage, SequencingGroup,
-                                    SequencingGroupStage, StageInput,
-                                    StageOutput, stage)
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
+    SV_CALLERS,
+    CromwellJobSizes,
+    _sv_individual_meta,
+    add_gatk_sv_jobs,
+    get_fasta,
+    get_images,
+    get_references,
+)
+from cpg_workflows.workflow import (
+    Cohort,
+    CohortStage,
+    SequencingGroup,
+    SequencingGroupStage,
+    StageInput,
+    StageOutput,
+    stage,
+)
 
 
 @stage(

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -370,7 +370,6 @@ class AnnotateCNV(CohortStage):
         billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
 
         job_or_none = queue_annotate_sv_jobs(
-            batch=get_batch(),
             cohort=cohort,
             cohort_prefix=self.prefix,
             input_vcf=inputs.as_dict(cohort, FastCombineGCNVs)['combined_calls'],

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -166,7 +166,6 @@ class AnnotateDataset(DatasetStage):
         )
 
         jobs = annotate_dataset_jobs(
-            b=get_batch(),
             mt_path=mt_path,
             sequencing_group_ids=dataset.get_sequencing_group_ids(),
             out_mt_path=self.expected_outputs(dataset)['mt'],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.19.0',
+    version='1.20.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #636

Issue:

- Samples are filtered during the GATK-SV pipeline for quality reasons (no dispute there). The list of excluded identifiers per batch is stored in GCP, but we have so far not read that file or done anything with the contents.
- The excluded samples then are 'silently' filtered from the joint-calls (e.g. by a `bcftools -S ^<ID list>`, so the SG IDs in the cohort/dataset becomes disconnected from the SG IDs remaining in the data/VCFs)
- Stage output files are registered as metamist analysis entries, linked to all the SG IDs in the cohort - including SG IDs/samples removed from the VCFs/MTs. This creates misleading analysis entries: "SG ID CPGXX should be included in this joint-call, the metamist entry claims they are present, why can't we find their data in Seqr"
- Fatal: SG ID subsetting (from cohort-level joint call to dataset-level joint call) fails, because not all required SG IDs are present

Solution:

- Create a Stage-independent file path (`gs://<BUCKET>/gatk_sv/<DATE>/combined_exclusion_list.txt`) so that we can reference this file in both stages and metamist annotators
- Collect all per-batch files containing SG IDs which were removed for quality reasons. This is done using a `gcloud object compose` - this is a `cat` between cloud objects without having to localise them first. This is written to the path from the previous point.
- Read this file during the AnnotateDataset stage when subsetting - we parse the list of all filtered IDs and adjust the expectation of samples present in the callset, rather than failing because we can't find quality-filtered samples.
- Add the name/path of this file to the metamist registration calls (the `update_analysis_meta` Callables, with a specific key a specific key `remove_sgids`) - during the metamist file registration take the list of SG IDs generated by `target.get_sequencing_group_ids()`, read in the excluded SG ID file, and do a set subtraction - this should make the analysis object's `sequencing_group_ids` accurate to the data files.