### PR TITLE
Various tweaks relating to metamist

### DIFF
--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -8,9 +8,9 @@ from cpg_utils.config import get_config, update_dict
 
 from cpg_workflows.filetypes import CramPath, GvcfPath
 
-from .metamist import AnalysisType, Assay, MetamistError, get_metamist, parse_reads
-from .targets import Cohort, PedigreeInfo, SequencingGroup, Sex
-from .utils import exists
+from cpg_workflows.metamist import Assay, MetamistError, get_metamist, parse_reads
+from cpg_workflows.targets import Cohort, PedigreeInfo, SequencingGroup, Sex
+from cpg_workflows.utils import exists
 
 _cohort: Cohort | None = None
 
@@ -129,12 +129,12 @@ def _populate_analysis(cohort: Cohort) -> None:
     for dataset in cohort.get_datasets():
         gvcf_by_sgid = get_metamist().get_analyses_by_sgid(
             dataset.get_sequencing_group_ids(),
-            analysis_type=AnalysisType.GVCF,
+            analysis_type='gvcf',
             dataset=dataset.name,
         )
         cram_by_sgid = get_metamist().get_analyses_by_sgid(
             dataset.get_sequencing_group_ids(),
-            analysis_type=AnalysisType.CRAM,
+            analysis_type='cram',
             dataset=dataset.name,
         )
 
@@ -146,7 +146,7 @@ def _populate_analysis(cohort: Cohort) -> None:
                     analysis.output,
                 )
                 sequencing_group.gvcf = GvcfPath(path=analysis.output)
-            elif exists(sequencing_group.make_gvcf_path()):
+            elif exists(sequencing_group.make_gvcf_path().path):
                 logging.warning(
                     f'We found a gvcf file in the expected location {sequencing_group.make_gvcf_path()},'
                     'but it is not logged in metamist. Skipping. You may want to update the metadata and try again. '
@@ -162,7 +162,7 @@ def _populate_analysis(cohort: Cohort) -> None:
                     crai_path = None
                 sequencing_group.cram = CramPath(analysis.output, crai_path)
 
-            elif exists(sequencing_group.make_cram_path()):
+            elif exists(sequencing_group.make_cram_path().path):
                 logging.warning(
                     f'We found a cram file in the expected location {sequencing_group.make_cram_path()},'
                     'but it is not logged in metamist. Skipping. You may want to update the metadata and try again. '

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -10,7 +10,6 @@ from hailtop.batch import Batch
 
 from ..metamist import get_metamist, AnalysisStatus
 
-from cpg_workflows.workflow import SequencingGroup
 from cpg_utils import to_path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import fasta_res_group, image_path, query_command

--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -63,9 +63,8 @@ from cpg_utils.hail_batch import (
     get_batch,
     image_path,
 )
-from metamist.graphql import gql
+from metamist.graphql import gql, query
 
-from cpg_workflows.metamist import gql_query_optional_logging
 from cpg_workflows.resources import STANDARD
 from cpg_workflows.workflow import (
     Dataset,
@@ -94,13 +93,13 @@ MTA_QUERY = gql(
 
 
 @lru_cache(maxsize=None)
-def query_for_sv_mt(dataset: str, type: str = 'sv') -> str | None:
+def query_for_sv_mt(dataset: str, analysis_type: str = 'sv') -> str | None:
     """
     query for the latest SV MT for a dataset
 
     Args:
         dataset (str): project to query for
-        type (str): type of analysis entry to query for
+        analysis_type (str): type of analysis entry to query for
 
     Returns:
         str, the path to the latest MT for the given type
@@ -115,9 +114,7 @@ def query_for_sv_mt(dataset: str, type: str = 'sv') -> str | None:
     ):
         query_dataset += '-test'
 
-    result = gql_query_optional_logging(
-        MTA_QUERY, query_params={'dataset': query_dataset, 'type': type}
-    )
+    result = query(MTA_QUERY, variables={'dataset': query_dataset, 'type': analysis_type})
     mt_by_date = {}
     for analysis in result['project']['analyses']:
         if (
@@ -158,8 +155,8 @@ def query_for_latest_mt(dataset: str, type: str = 'custom') -> str:
         and 'test' not in query_dataset
     ):
         query_dataset += '-test'
-    result = gql_query_optional_logging(
-        MTA_QUERY, query_params={'dataset': query_dataset, 'type': type}
+    result = query(
+        MTA_QUERY, variables={'dataset': query_dataset, 'type': type}
     )
     mt_by_date = {}
 


### PR DESCRIPTION
1. Removes the no-logging query wrapper, now pointless since the implementation of https://github.com/populationgenomics/metamist/pull/650
2. Removes the Enum for analysis types in cpg_workflows - this is not viable now that new analysis types can be created at will in metamist. This list is out of date and not worth maintaining
3. Removes all uses of the above that I can find

This is unbelievably low priority, I just found some dodgy things