### PR TITLE
Correct inter-stage dependency

### DIFF
--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -79,7 +79,7 @@ class CollectReadCounts(SequencingGroupStage):
             raise ValueError(f'No CRAM file found for {seqgroup}')
 
         jobs = gcnv.collect_read_counts(
-            inputs.as_path(seqgroup.dataset, PrepareIntervals, 'preprocessed'),
+            inputs.as_path(get_cohort(), PrepareIntervals, 'preprocessed'),
             seqgroup.cram,
             self.get_job_attrs(seqgroup),
             seqgroup.dataset.prefix() / 'gcnv' / seqgroup.id,


### PR DESCRIPTION
Just a little fix - the prior stage is a cohortStage, not a dataset stage. This works if both happen to be the same, but won't work if we run under an umbrella project like Seqr (which will be required to generate ES indexes)