### PR TITLE
Bump GATK memory, alter base interval list

### DIFF
--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -1,6 +1,6 @@
 [workflow]
 name = 'gcnv'
-intervals_path = 'gs://cpg-common-main/references/hg38/v0/exome_calling_regions.v1.interval_list'
+intervals_path = 'gs://cpg-common-test/gCNV_resources/SSCRE_V2_intervals.interval_list'
 exclude_intervals = ['chrM']
 # Aim for 10-50Mbp genomic coverage per shard
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]


### PR DESCRIPTION
The first gCNV run in main is stalling out, looks like the jobs are all hitting a low memory ceiling and not completing. This must have worked in test, but looks restrictive...

Also updates the default interval_list to match SSCREv2