### PR TITLE
Bump all other gCNV processes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.21.0
+current_version = 1.21.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   
 env:
-  VERSION: 1.21.0
+  VERSION: 1.21.1
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -156,6 +156,15 @@ def filter_and_determine_ploidy(
     )
     j.image(image_path('gatk_gcnv'))
 
+    # set highmem resources for this job
+    job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
+    job_res.set_to_job(j)
+    resource_string = (
+        '--java-options '
+        f'"-Xms{job_res.get_java_mem_mb()}m '
+        f'-Xmx{job_res.get_java_mem_mb()}m"'
+    )
+
     counts_input_args = _counts_input_args(counts_paths)
     cmd = ''
 
@@ -171,7 +180,7 @@ def filter_and_determine_ploidy(
         annotated_intervals = get_batch().read_input(str(annotated_intervals_path))
 
         cmd += f"""
-        gatk FilterIntervals \\
+        gatk {resource_string} FilterIntervals \\
           --interval-merging-rule OVERLAPPING_ONLY \\
           --intervals {preprocessed_intervals} --annotated-intervals {annotated_intervals} \\
           {counts_input_args} \\
@@ -186,7 +195,7 @@ def filter_and_determine_ploidy(
     ploidy_priors = get_batch().read_input(ploidy_priors_path)
 
     cmd += f"""
-    gatk DetermineGermlineContigPloidy \\
+    gatk {resource_string} DetermineGermlineContigPloidy \\
       --interval-merging-rule OVERLAPPING_ONLY \\
       --intervals {filtered} --contig-ploidy-priors {ploidy_priors} \\
       {counts_input_args} \\
@@ -253,14 +262,22 @@ def shard_gcnv(
             },
         )
         j.image(image_path('gatk_gcnv'))
-        j.memory('16Gi')  # TODO revisit limits
+
+        # set highmem resources for this job
+        job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
+        job_res.set_to_job(j)
+        resource_string = (
+            '--java-options '
+            f'"-Xms{job_res.get_java_mem_mb()}m '
+            f'-Xmx{job_res.get_java_mem_mb()}m"'
+        )
 
         cmd = f"""
         tar -xzf {ploidy_calls_tarball} -C $BATCH_TMPDIR
 
         {select_cmd} < {filtered_intervals} > {j.shard_intervals}
 
-        gatk GermlineCNVCaller \\
+        gatk {resource_string} GermlineCNVCaller \\
           --run-mode COHORT --interval-merging-rule OVERLAPPING_ONLY \\
           --intervals {j.shard_intervals} --annotated-intervals {annotated_intervals} \\
           {counts_input_args} \\
@@ -308,7 +325,15 @@ def postprocess_calls(
         },
     )
     j.image(image_path('gatk_gcnv'))
-    j.storage('12Gi')  # TODO revisit limits
+
+    # set highmem resources for this job
+    job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=20)
+    job_res.set_to_job(j)
+    resource_string = (
+        '--java-options '
+        f'"-Xms{job_res.get_java_mem_mb()}m '
+        f'-Xmx{job_res.get_java_mem_mb()}m"'
+    )
 
     reference = fasta_res_group(get_batch())
 
@@ -365,7 +390,7 @@ def postprocess_calls(
     OUTS=$(dirname {j.output['intervals.vcf.gz']})
     BATCH_OUTS=$(dirname $OUTS)
     mkdir $OUTS
-    gatk PostprocessGermlineCNVCalls \\
+    gatk {resource_string} PostprocessGermlineCNVCalls \\
       --sequence-dictionary {reference.dict} {allosomal_contigs_args} \\
       --contig-ploidy-calls $BATCH_TMPDIR/inputs/ploidy-calls \\
       {model_shard_args} {calls_shard_args} \\
@@ -439,7 +464,16 @@ def joint_segment_vcfs(
         output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'}
     )
     job.image(image_path('gatk_gcnv'))
-    job.memory('8Gi')
+
+    # set highmem resources for this job
+    job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
+    job_res.set_to_job(job)
+    resource_string = (
+        '--java-options '
+        f'"-Xms{job_res.get_java_mem_mb()}m '
+        f'-Xmx{job_res.get_java_mem_mb()}m"'
+    )
+
     vcf_string = ''
     for each_vcf in segment_vcfs:
         vcf_string += f' -V {each_vcf}'
@@ -448,7 +482,7 @@ def joint_segment_vcfs(
     job.command(
         f"""
     set -e
-    gatk --java-options "-Xmx6000m" JointGermlineCNVSegmentation \\
+    gatk {resource_string} JointGermlineCNVSegmentation \\
         -R {reference.base} \\
         -O {job.output["vcf.gz"]} \\
         {vcf_string} \\

--- a/scripts/find_exomes_by_capture.py
+++ b/scripts/find_exomes_by_capture.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env python3
+
+
+"""
+find all the exome samples, and group by capture kit
+to be used in generating capture-specific batch config files
+"""
+
+
+from metamist.graphql import gql, query
+import toml
+
+
+meta_query = gql("""
+query SampleMetaQuery($name: String!) {
+  project(name: $name) {
+    sequencingGroups {
+      id
+      type
+      technology
+      sample {
+        assays {
+          meta
+        }
+      }
+    }
+  }
+}""")
+
+
+# the structure we want is
+# {
+#   capture: {
+#       project: [IDs]
+#   }
+# }
+
+# nb. SSQXTCREV2 is the Agilent SureSelect Clinical Research Exome V2
+# but V1 was only for GRCh37, so it's implied that unspecified versions
+# are likely also V2 and can be grouped together
+known_captures = ['_SSQXTCREV2_', '_TwistWES1VCGS1_', '_SSXTLICREV2_', '_NEXTERAFLEXWGS_']
+
+capture_dict: dict = dict()
+projects = ['acute-care']
+for project in projects:
+    print(f'project: {project}')
+    project_json = query(meta_query, {'name': project})
+    for seq_group in project_json['project']['sequencingGroups']:
+        sgid = seq_group['id']
+        if seq_group['type'] != 'exome':
+            continue
+
+        capture_found = False
+        for assay in seq_group['sample']['assays']:
+            if seq_type := assay['meta'].get('library_type'):
+                capture_dict.setdefault(seq_type, dict()).setdefault(project, set()).add(sgid)
+                capture_found = True
+                break
+
+        if not capture_found:
+            for assay in seq_group['sample']['assays']:
+                if 'reads' in assay['meta']:
+                    for capture in known_captures:
+                        if capture in assay['meta']['reads']:
+                            capture_dict.setdefault(capture, dict()).setdefault(project, set()).add(sgid)
+                            capture_found = True
+                            break
+
+# write the result to a local file
+with open('../exome_capture.toml', 'w') as handle:
+    toml.dump(capture_dict, handle)
+print(capture_dict)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.21.0',
+    version='1.21.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The previous change took the gCNV initial variant calling stage from [all failed/stalled after 4 hours](https://batch.hail.populationgenomics.org.au/batches/435653), to [<1 hour and all completed](https://batch.hail.populationgenomics.org.au/batches/435947). This presumptively bumps resources all other Stages/tasks before running the remainder of the pipeline.

Also adding a metamist script I used to query for alike-samples for batching