### PR TITLE
Moar Memory

### DIFF
--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -264,7 +264,7 @@ def shard_gcnv(
         j.image(image_path('gatk_gcnv'))
 
         # set highmem resources for this job
-        job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
+        job_res = HIGHMEM.request_resources(ncpu=8)
         job_res.set_to_job(j)
         resource_string = (
             '--java-options '

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -264,7 +264,7 @@ def shard_gcnv(
         j.image(image_path('gatk_gcnv'))
 
         # set highmem resources for this job
-        job_res = HIGHMEM.request_resources(ncpu=8)
+        job_res = HIGHMEM.request_resources(ncpu=8, storage_gb=10)
         job_res.set_to_job(j)
         resource_string = (
             '--java-options '

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -264,7 +264,7 @@ def shard_gcnv(
         j.image(image_path('gatk_gcnv'))
 
         # set highmem resources for this job
-        job_res = HIGHMEM.request_resources(ncpu=8, storage_gb=10)
+        job_res = HIGHMEM.request_resources(ncpu=8, mem_gb=52, storage_gb=10)
         job_res.set_to_job(j)
         resource_string = (
             '--java-options '


### PR DESCRIPTION
Despite yesterday's memory bump this is still dying: [here](https://batch.hail.populationgenomics.org.au/batches/435976)

This suggested bump takes us way up, with the expectation that this is too much, and we can revise back down once we have some successful job tracking as evidence. 

Memory attachment is 8cpu * 6.5GB/cpu (profile default) = 52GB. This is way lower than the 16CPU * 6.5GB that the HIGHMEM profile default would provide, but way higher than the 13GB total being provided at the moment (causing failures)