### PR TITLE
Fix Unexpected EoF in gCNV

### DIFF
--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -397,8 +397,7 @@ def postprocess_calls(
       --sample-index {sample_index} \\
       --output-genotyped-intervals {j.output['intervals.vcf.gz']} \\
       --output-genotyped-segments {j.output['segments.vcf.gz']} \\
-      --output-denoised-copy-ratios {j.output['ratios.tsv']} \\
-      {extra_args}
+      --output-denoised-copy-ratios {j.output['ratios.tsv']} {extra_args}
     """
     )
 


### PR DESCRIPTION
Introduced a little bug here during the first round of post-process gCNV calls

- `extra_args` is an empty String (only populated during the second round through this stage)
- Bash command ends with 

```
command ... \
{extra_args}
```

so the run-on line is actually including the `}` which should indicate the end of the command block

affected job https://batch.hail.populationgenomics.org.au/batches/436239/jobs/3