### PR TITLE
Another fix 

### DIFF
--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -154,19 +154,11 @@ class GermlineCNVCalls(SequencingGroupStage):
 
     def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
         return {
-            'intervals': seqgroup.dataset.prefix()
-            / 'gcnv'
-            / f'{seqgroup.id}.intervals.vcf.gz',
-            'intervals_index': seqgroup.dataset.prefix()
-            / 'gcnv'
-            / f'{seqgroup.id}.intervals.vcf.gz.tbi',
-            'segments': seqgroup.dataset.prefix()
-            / 'gcnv'
-            / f'{seqgroup.id}.segments.vcf.gz',
-            'segments_index': seqgroup.dataset.prefix()
-            / 'gcnv'
-            / f'{seqgroup.id}.segments.vcf.gz.tbi',
-            'ratios': seqgroup.dataset.prefix() / 'gcnv' / f'{seqgroup.id}.ratios.tsv',
+            'intervals': self.prefix / f'{seqgroup.id}.intervals.vcf.gz',
+            'intervals_index': self.prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'segments': self.prefix / f'{seqgroup.id}.segments.vcf.gz',
+            'segments_index': self.prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'ratios': self.prefix / f'{seqgroup.id}.ratios.tsv',
         }
 
     def queue_jobs(self, seqgroup: SequencingGroup, inputs: StageInput) -> StageOutput:


### PR DESCRIPTION
Late in development the path of the GermlineCNVCalls stage was changed from the dataset bucket to the cohort bucket (so that we can potentially call CNVs across SG IDs in mutliple projects). This also changed the output from

`PROJECT-BUCKET/exome/gcnv/SGID.segments.vcf.gz`

to 

`COHORT-BUCKET/exome/gcnv/COHORT-HASH/GermlineCNVCalls/SGID.intervals.vcf.gz`

to reflect that these results were generated when this COHORT of samples were processed together.


I mangled this late in testing by copying a bunch of files around in GCP so as to not have to re-run this expensive stage, meaning that this code path wasn't tested.

TL; DR

I cocked up file paths. These output files are generated at the correct path already, but the next stage is looking in the wrong place, e.g. [here](https://batch.hail.populationgenomics.org.au/batches/436250/jobs/148)