### PR TITLE
WC -l causing job failures

### DIFF
--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -418,6 +418,8 @@ def postprocess_calls(
             f"""
         #use wc instead of grep -c so zero count isn't non-zero exit
         #use grep -P to recognize tab character
+        VARIANTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']})
+        echo "Num Variants: $VARIANTS"
         NUM_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep '' | wc -l)
         NUM_PASS_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep 'PASS' | wc -l)
         if [ $NUM_SEGMENTS -lt {max_events} ]; then
@@ -429,6 +431,7 @@ def postprocess_calls(
         else
             echo "EXCESSIVE_NUMBER_OF_EVENTS" >> {j.qc_file}
         fi
+        cat {j.qc_file}
         """
         )
         get_batch().write_output(j.qc_file, qc_file)

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -416,12 +416,13 @@ def postprocess_calls(
         # do some additional stuff to determine pass/fail
         j.command(
             f"""
+        # allow pipefailures here (grep returning 0 lines)
+        set +o pipefail
         #use wc instead of grep -c so zero count isn't non-zero exit
         #use grep -P to recognize tab character
-        VARIANTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']})
         echo "Num Variants: $VARIANTS"
-        NUM_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep '' | wc -l | xargs)
-        NUM_PASS_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep 'PASS' | wc -l | xargs)
+        NUM_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep '' | wc -l)
+        NUM_PASS_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep 'PASS' | wc -l)
         if [ $NUM_SEGMENTS -lt {max_events} ]; then
             if [ $NUM_PASS_SEGMENTS -lt {max_pass_events} ]; then
               echo "PASS" >> {j.qc_file}

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -414,6 +414,7 @@ def postprocess_calls(
         max_events = get_config()['workflow']['gncv_max_events']
         max_pass_events = get_config()['workflow']['gncv_max_pass_events']
         # do some additional stuff to determine pass/fail
+        # flake8: noqa
         j.command(
             f"""
         #use wc instead of grep -c so zero count isn't non-zero exit

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -419,7 +419,7 @@ def postprocess_calls(
             f"""
         #use wc instead of grep -c so zero count isn't non-zero exit
         #use grep -P to recognize tab character
-        NUM_SEGMENTS=$(zcat {j.output['segments.vcf.gz']} | awk '!/^#/ && !/0\/0/ && !/\t0:1:/ {{count++}} END {{print count}})
+        NUM_SEGMENTS=$(zcat {j.output['segments.vcf.gz']} | awk '!/^#/ && !/0\/0/ && !/\t0:1:/ {{count++}} END {{print count}}')
         NUM_PASS_SEGMENTS=$(zcat {j.output['segments.vcf.gz']} | awk '!/^#/ && !/0\/0/ && !/\t0:1:/ && /PASS/ {{count++}} END {{print count}}')
         if [ $NUM_SEGMENTS -lt {max_events} ]; then
             if [ $NUM_PASS_SEGMENTS -lt {max_pass_events} ]; then

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -420,8 +420,8 @@ def postprocess_calls(
         #use grep -P to recognize tab character
         VARIANTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']})
         echo "Num Variants: $VARIANTS"
-        NUM_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep '' | wc -l)
-        NUM_PASS_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep 'PASS' | wc -l)
+        NUM_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep '' | wc -l | xargs)
+        NUM_PASS_SEGMENTS=$(zgrep '^[^#]' {j.output['segments.vcf.gz']} | grep -v '0/0' | grep -v -P '\t0:1:' | grep 'PASS' | wc -l | xargs)
         if [ $NUM_SEGMENTS -lt {max_events} ]; then
             if [ $NUM_PASS_SEGMENTS -lt {max_pass_events} ]; then
               echo "PASS" >> {j.qc_file}

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -417,8 +417,7 @@ def postprocess_calls(
         # flake8: noqa
         j.command(
             f"""
-        #use wc instead of grep -c so zero count isn't non-zero exit
-        #use grep -P to recognize tab character
+        #use awk instead of grep - grep returning no lines causes a pipefailure
         NUM_SEGMENTS=$(zcat {j.output['segments.vcf.gz']} | awk '!/^#/ && !/0\/0/ && !/\t0:1:/ {{count++}} END {{print count}}')
         NUM_PASS_SEGMENTS=$(zcat {j.output['segments.vcf.gz']} | awk '!/^#/ && !/0\/0/ && !/\t0:1:/ && /PASS/ {{count++}} END {{print count}}')
         if [ $NUM_SEGMENTS -lt {max_events} ]; then


### PR DESCRIPTION
See https://batch.hail.populationgenomics.org.au/batches/436642/jobs/373

The final bash section of this job seems to fail when the number of PASS events is 0. There are 2 failing jobs in 2 different batches, both appear to be the only 0-pass samples. I can't really find a good explanation for this.

I can't recreate this failure locally...

```bash
─➤  touch afile.txt
─➤  THIS=$(grep "something" afile.txt | grep foo | wc -l)
─➤  echo $?
0
─➤  echo $THIS
         0
```

The exit code is fine, and the leading spaces are an apple-specific thing (see [here](https://apple.stackexchange.com/questions/370366/why-is-wc-c-printing-spaces-before-the-number))

Here I'm having a go at passing the output through xargs, which should succeed and prevent failure.