### PR TITLE
Issue 660 - non-deterministic unpacking of SGID data

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.0
+current_version = 1.22.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.0
+  VERSION: 1.22.1
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -295,11 +295,7 @@ def postprocess_calls(
     qc_file: str | None = None,
 ) -> Job:
     if any([clustered_vcf, intervals_vcf, qc_file]):
-        assert all([clustered_vcf, intervals_vcf, qc_file]), [
-            clustered_vcf,
-            intervals_vcf,
-            qc_file
-        ]
+        assert all([clustered_vcf, intervals_vcf, qc_file]), [clustered_vcf, intervals_vcf, qc_file]
 
     j = get_batch().new_job(
         'Postprocess gCNV calls',

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -20,6 +20,7 @@ from cpg_workflows.filetypes import CramPath
 from cpg_workflows.query_modules import seqr_loader, seqr_loader_cnv
 from cpg_workflows.resources import HIGHMEM
 from cpg_workflows.utils import can_reuse, chunks
+from cpg_workflows.workflow import Cohort
 
 
 def prepare_intervals(
@@ -297,7 +298,7 @@ def postprocess_calls(
         assert all([clustered_vcf, intervals_vcf, qc_file]), [
             clustered_vcf,
             intervals_vcf,
-            qc_file,
+            qc_file
         ]
 
     j = get_batch().new_job(
@@ -322,7 +323,9 @@ def postprocess_calls(
 
     model_shard_args = ''
     calls_shard_args = ''
-    for name, path in shard_paths.items():
+
+    # forced ordering here just in case
+    for name, path in [(shard, shard_paths[shard]) for shard in shard_basenames()]:
         gcp_related_commands.append(f'gsutil cat {path} | tar -xz -C $BATCH_TMPDIR/inputs')
         model_shard_args += f' --model-shard-path $BATCH_TMPDIR/inputs/{name}-model'
         calls_shard_args += f' --calls-shard-path $BATCH_TMPDIR/inputs/{name}-calls'

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -92,10 +92,10 @@ class CollectReadCounts(SequencingGroupStage):
             raise ValueError(f'No CRAM file found for {seqgroup}')
 
         jobs = gcnv.collect_read_counts(
-            inputs.as_path(get_cohort(), PrepareIntervals, 'preprocessed'),
-            seqgroup.cram,
-            self.get_job_attrs(seqgroup),
-            seqgroup.dataset.prefix() / 'gcnv' / seqgroup.id,
+            intervals_path=inputs.as_path(get_cohort(), PrepareIntervals, 'preprocessed'),
+            cram_path=seqgroup.cram,
+            job_attrs=self.get_job_attrs(seqgroup),
+            output_base_path=seqgroup.dataset.prefix() / 'gcnv' / seqgroup.id,
         )
         return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -1,6 +1,7 @@
 """
 Stages that implement GATK-gCNV.
 """
+
 import json
 
 from cpg_utils import Path, to_path
@@ -254,13 +255,7 @@ class GCNVJointSegmentation(CohortStage):
 
 
 @stage(
-    required_stages=[
-        SetSGIDOrdering,
-        GCNVJointSegmentation,
-        GermlineCNV,
-        GermlineCNVCalls,
-        DeterminePloidy
-    ],
+    required_stages=[SetSGIDOrdering, GCNVJointSegmentation, GermlineCNV, GermlineCNVCalls, DeterminePloidy],
 )
 class RecalculateClusteredQuality(SequencingGroupStage):
     """
@@ -332,7 +327,7 @@ class FastCombineGCNVs(CohortStage):
             sg_vcfs=all_vcfs,
             docker_image=pipeline_image,
             job_attrs=self.get_job_attrs(cohort),
-            output_path=outputs['combined_calls']
+            output_path=outputs['combined_calls'],
         )
         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.0',
+    version='1.22.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #660 

... see #660 


This creates a new first stage for gCNV, taking the list of all SGIDs in the cohort and writing to a JSON file

Stages in the workflow which have a need to unpack a list of SGIDs in consistent order now read this file and unpack/set indices relative to this fixed order. This JSON of ordered SGIDs is set for the pipeline hash, so new sample list == new sample order.