### PR TITLE
Exom-nicer

### DIFF
--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -48,7 +48,7 @@ def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_path
         copy_common_env(family_job)
         family_job.image(get_config()['workflow']['driver_image'])
         family_job.command(
-            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --out {str(out_paths[family])}'
+            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --vcf_out {str(out_paths[family])} --family {family}'
         )
         jobs.append(family_job)
     return jobs

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -48,7 +48,7 @@ def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_path
         copy_common_env(family_job)
         family_job.image(get_config()['workflow']['driver_image'])
         family_job.command(
-            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --vcf_out {str(out_paths[family])} --family {family}'
+            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --out {str(out_paths[family])} --family {family}'
         )
         jobs.append(family_job)
     return jobs

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -3,17 +3,25 @@ jobs required for the exomiser workflow
 """
 
 import json
+from typing import TYPE_CHECKING
 
 import pandas as pd
-from hailtop.batch.job import Job
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, copy_common_env, get_batch, image_path, reference_path
+from cpg_utils.hail_batch import (
+    authenticate_cloud_credentials_in_job,
+    copy_common_env,
+    get_batch,
+    image_path,
+    reference_path,
+)
 from cpg_workflows.scripts import extract_vcf_from_mt, gvcfs_to_vcf
 from cpg_workflows.targets import SequencingGroup
 from cpg_workflows.utils import chunks, exists
 
+if TYPE_CHECKING:
+    from hailtop.batch.job import Job
 
 HPO_KEY: str = 'HPO Terms (present)'
 
@@ -48,7 +56,7 @@ def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_path
         copy_common_env(family_job)
         family_job.image(get_config()['workflow']['driver_image'])
         family_job.command(
-            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --out {str(out_paths[family])} --family {family}'
+            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --out {str(out_paths[family])} --family {family}',
         )
         jobs.append(family_job)
     return jobs

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -5,73 +5,53 @@ jobs required for the exomiser workflow
 import json
 
 import pandas as pd
+from hailtop.batch.job import Job
 
 from cpg_utils import Path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path, reference_path
-from cpg_workflows.scripts import extract_vcf_from_mt, vds_from_gvcfs
-from cpg_workflows.scripts import mt_from_vds as vds2mt
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, copy_common_env, get_batch, image_path, reference_path
+from cpg_workflows.scripts import extract_vcf_from_mt, gvcfs_to_vcf
 from cpg_workflows.targets import SequencingGroup
 from cpg_workflows.utils import chunks, exists
+
 
 HPO_KEY: str = 'HPO Terms (present)'
 
 
-def create_vds_jobs(sgids: list[SequencingGroup], out_path: str):
+def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_paths: dict[str, Path]):
     """
-    Create VDS from a number of SG IDs
-    At larger cohort sizes this won't work, as the number of
-    arguments may hit a threshold
-
-    Mitigate by writing a temp file and reading into script container
+    Create Joint VCFs for families of SG IDs
 
     Args:
-        sgids (list[SequencingGroup])
-        out_path (str):
+        families (): dict of family ID to list of SG IDs
+        out_paths (): dict of family ID to output path
     """
 
-    if exists(out_path):
-        return []
+    jobs: list[Job] = []
 
-    gvcf_paths = " ".join([str(s.gvcf.path) for s in sgids if s.gvcf])
-    sequencing_group_names = " ".join([s.id for s in sgids])
+    script_path = gvcfs_to_vcf.__file__.removeprefix('/production-pipelines')
 
-    # need a sexier way of doing this... currently there's a disconnect
-    # between how the cpg_workflows image is built, compared with
-    # how this driver image git checkout is done, meaning a different filepath
-    vds_script = str(vds_from_gvcfs.__file__).removeprefix('/production-pipelines')
+    # take each family
+    for family, members in families.items():
 
-    job = get_batch().new_job('Make VDS from gVCFs')
-    authenticate_cloud_credentials_in_job(job)
-    job.image(get_config()['workflow']['driver_image'])
-    job.command(f'python3 {vds_script} --gvcfs {gvcf_paths} --sgids {sequencing_group_names} --out {out_path}')
-    job.storage('10Gi')
-    job.cpu(4)
-    job.memory('standard')
-    return job
+        # skip if already done
+        if exists(out_paths[family]):
+            continue
 
-
-def mt_from_vds(vds_path: str, out_path: str):
-    """
-    create the MT from the VDS
-
-    Args:
-        vds_path (str): path to the VDS
-        out_path (str): path to the MT
-    """
-
-    if exists(out_path):
-        return []
-
-    # find the path to the script in _this_ container
-    script_path = str(vds2mt.__file__).removeprefix('/production-pipelines')
-    job = get_batch().new_job('Make MT from VDS')
-    job.image(get_config()['workflow']['driver_image'])
-    job.command(f'python3 {script_path} --vds {vds_path} --mt {out_path}')
-    job.storage('10Gi')
-    job.cpu(4)
-    job.memory('standard')
-    return job
+        # get sorted members
+        sorted_members = sorted(members, key=lambda x: x.id)
+        member_ids = [sg.id for sg in sorted_members]
+        member_gvcfs = [str(sg.gvcf) for sg in sorted_members]
+        # get their gVCF paths
+        family_job = get_batch().new_job(f'Create Joint VCF for {family}')
+        authenticate_cloud_credentials_in_job(family_job)
+        copy_common_env(family_job)
+        family_job.image(get_config()['workflow']['driver_image'])
+        family_job.command(
+            f'python3 {script_path} --sgids {" ".join(member_ids)} --gvcfs {" ".join(member_gvcfs)} --out {str(out_paths[family])}'
+        )
+        jobs.append(family_job)
+    return jobs
 
 
 def extract_mini_ped_files(family_dict: dict[str, list[SequencingGroup]], out_paths: dict[str, Path]):

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -60,7 +60,7 @@ def single_sample_vcf_from_gvcf(sg: SequencingGroup, out_path: str) -> Job:
     job.command(
         f'bcftools view -m3 {gvcf_input} | bcftools norm -m -any | grep -v NON_REF | bgzip -c  > {job.output["vcf.bgz"]}',
     )
-    job.command(f'tabix {job.output["vcf"]}')
+    job.command(f'tabix {job.output["vcf.bgz"]}')
     get_batch().write_output(job.output, out_path.removesuffix('.vcf.bgz'))
     return job
 

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -48,8 +48,8 @@ def single_sample_vcf_from_gvcf(sg: SequencingGroup, out_path: str) -> Job:
     # declare a resource group
     job.declare_resource_group(
         output={
-            'vcf': '{root}.vcf.bgz',
-            'vcf_index': '{root}.vcf.bgz.tbi',
+            'vcf.bgz': '{root}.vcf.bgz',
+            'vcf.bgz.tbi': '{root}.vcf.bgz.tbi',
         },
     )
 
@@ -58,7 +58,7 @@ def single_sample_vcf_from_gvcf(sg: SequencingGroup, out_path: str) -> Job:
     # grep -v NON_REF to remove the NON_REF sites
     # bgzip -c to write to a compressed file
     job.command(
-        f'bcftools view -m3 {gvcf_input} | bcftools norm -m -any | grep -v NON_REF | bgzip -c  > {job.output["vcf"]}',
+        f'bcftools view -m3 {gvcf_input} | bcftools norm -m -any | grep -v NON_REF | bgzip -c  > {job.output["vcf.bgz"]}',
     )
     job.command(f'tabix {job.output["vcf"]}')
     get_batch().write_output(job.output, out_path.removesuffix('.vcf.bgz'))

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -132,6 +132,8 @@ if __name__ == '__main__':
 
     vcf_fragments_tmp = output_path(f'fragments_{args.family}.vcf.bgz', category='tmp')
 
+    vds_to_vcf(vds_path=args.vds_out, output=vcf_fragments_tmp)
+
     get_logger(__file__).info('Creating single VCF from fragments')
 
     squash_fragments_to_vcf(vcf_fragment_dir=vcf_fragments_tmp, vcf_out=args.vcf_out)

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -1,0 +1,137 @@
+#! /usr/bin/env python3
+
+"""
+all the steps from gvcfs to vcf
+required gcloud authentication
+"""
+
+
+from argparse import ArgumentParser
+from subprocess import run
+from os.path import join
+
+import hail as hl
+
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch, image_path, init_batch, output_path
+from cpg_workflows.utils import chunks, get_logger
+
+
+MAX_COMPOSE: int = 30
+
+
+def gvcfs_to_vds(gvcfs: list[str], vds_out: str, sgids: list[str], family: str):
+    """
+    start up a combiner instance, and combine the gVCFs
+
+    Args:
+        gvcfs (list[str]):
+        vds_out (str):
+        sgids (list[str]):
+        family (str):
+    """
+
+    tmp_prefix = output_path(f'{family}.vds', category='tmp')
+
+    if get_config()['workflow']['sequencing_type'] == 'exome':
+        params = {'use_exome_default_intervals': True}
+    else:
+        params = {'use_genome_default_intervals': True}
+
+    combiner = hl.vds.new_combiner(
+        gvcf_paths=gvcfs,
+        gvcf_sample_names=sgids,
+        gvcf_external_header=gvcfs[0],
+        output_path=vds_out,
+        reference_genome='GRCh38',
+        temp_path=tmp_prefix,
+        **params,
+    )
+    combiner.run()
+
+
+def vds_to_vcf(vds_path: str, output: str):
+    vds = hl.vds.read_vds(vds_path)
+    vds = hl.vds.split_multi(vds)
+    mt = hl.vds.to_dense_mt(vds)
+    hl.export_vcf(mt, output, parallel='separate_header')
+    get_logger().info(f'Exported VCF fragments to {output}')
+
+
+def squash_fragments_to_vcf(vcf_fragment_dir: str, vcf_out: str):
+    """
+    Squash VCF fragments into a single VCF file
+
+    Args:
+        vcf_fragment_dir ():
+        vcf_out ():
+
+    Returns:
+
+    """
+
+    get_logger().info(
+        'Parsing the manifest file and generating a bash script for concatenating the VCF files'
+    )
+    manifest = hl.hadoop_open(join(vcf_fragment_dir, 'shard-manifest.txt')).readlines()
+
+    # prefix these shard names to get full GCP path for each
+    manifest_paths = [join(vcf_fragment_dir, str(fragment).strip()) for fragment in manifest]
+
+    # maybe don't do this
+    if len(manifest) <= MAX_COMPOSE:
+        run(['gcloud', 'storage', 'objects', 'compose', *manifest_paths, vcf_out])
+        get_logger().info(f'Composed {len(manifest)} VCF fragments into {vcf_out}')
+        return
+
+    # rolling squash of the chunks, should enable infinite-ish scaling
+    temp_chunk_prefix_num = 1
+    while len(manifest_paths) > 1:
+
+        # ordering is super important
+        chunks_this_round = []
+        condense_temp = join(vcf_fragment_dir, f'temp_chunk_{temp_chunk_prefix_num}')
+        temp_chunk_prefix_num += 1
+
+        for i, sub_chunk in chunks(manifest_paths, MAX_COMPOSE):
+            sub_chunk_out = join(condense_temp, f'chunk_{i}.vcf.bgz')
+            run(['gcloud', 'storage', 'objects', 'compose', *sub_chunk, sub_chunk_out])
+            chunks_this_round.append(sub_chunk_out)
+
+        manifest_paths = chunks_this_round
+
+    # tabix the results - read the final vcf in, index it, move the index, and write it out
+    input_vcf = get_batch().read_input(manifest_paths[0])
+    final_job = get_batch().new_bash_job(name='index_final_vcf')
+    final_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
+    final_job.image(image_path('bcftools'))
+    final_job.storage('10Gi')  # make this configurable
+    final_job.command(f'mv {input_vcf} {final_job.output["vcf.bgz"]} && tabix {final_job.output["vcf.bgz"]}')
+    get_batch().write_output(final_job.output, vcf_out.removesuffix('.vcf.bgz'))
+    get_batch().run(wait=False)
+
+
+if __name__ == '__main__':
+
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('--gvcfs', help='Input gVCFs', nargs='+')
+    parser.add_argument('--sgids', help='Family Member IDs', nargs='+')
+    parser.add_argument('--vcf_out', help='Output VCF path')
+    parser.add_argument('--family', help='Family Name/Number')
+    args = parser.parse_args()
+
+    assert len(args.gvcfs) == len(args.sgids)
+
+    init_batch()
+
+    get_logger(__file__).info(f'Creating VDS {args.out} from {len(args.gvcfs)} gVCFs')
+
+    gvcfs_to_vds(gvcfs=args.gvcfs, sgids=args.sgids, vds_out=args.vds_out, family='family')
+
+    get_logger(__file__).info('Creating VCF fragments from VDS')
+
+    vcf_fragments_tmp = output_path(f'fragments_{args.family}.vcf.bgz', category='tmp')
+
+    get_logger(__file__).info('Creating single VCF from fragments')
+
+    squash_fragments_to_vcf(vcf_fragment_dir=vcf_fragments_tmp, vcf_out=args.vcf_out)

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--gvcfs', help='Input gVCFs', nargs='+')
     parser.add_argument('--sgids', help='Family Member IDs', nargs='+')
-    parser.add_argument('--vcf_out', help='Output VCF path')
+    parser.add_argument('--out', help='Output VCF path')
     parser.add_argument('--family', help='Family Name/Number')
     args = parser.parse_args()
 
@@ -128,15 +128,17 @@ if __name__ == '__main__':
 
     init_batch()
 
+    vds_path = output_path(f'{args.family}.vds', category='tmp')
+
     get_logger(__file__).info(f'Creating VDS {args.out} from {len(args.gvcfs)} gVCFs')
 
-    gvcfs_to_vds(gvcfs=args.gvcfs, sgids=args.sgids, vds_out=args.vds_out, family='family')
+    gvcfs_to_vds(gvcfs=args.gvcfs, sgids=args.sgids, vds_out=vds_path, family=args.family)
 
     get_logger(__file__).info('Creating VCF fragments from VDS')
 
     vcf_fragments_tmp = output_path(f'fragments_{args.family}.vcf.bgz', category='tmp')
 
-    vds_to_vcf(vds_path=args.vds_out, output=vcf_fragments_tmp)
+    vds_to_vcf(vds_path=vds_path, output=vcf_fragments_tmp)
 
     get_logger(__file__).info('Creating single VCF from fragments')
 

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -55,7 +55,7 @@ def vds_to_vcf(vds_path: str, output: str):
     mt = hl.vds.to_dense_mt(vds)
 
     # gotta drop this (it's a dict)
-    if 'gvcf_info' in mt.row:
+    if 'gvcf_info' in mt.entry:
         mt = mt.drop('gvcf_info')
 
     hl.export_vcf(mt, output, parallel='separate_header')

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -142,4 +142,4 @@ if __name__ == '__main__':
 
     get_logger(__file__).info('Creating single VCF from fragments')
 
-    squash_fragments_to_vcf(vcf_fragment_dir=vcf_fragments_tmp, vcf_out=args.vcf_out)
+    squash_fragments_to_vcf(vcf_fragment_dir=vcf_fragments_tmp, vcf_out=args.out)

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -130,16 +130,18 @@ if __name__ == '__main__':
 
     vds_path = output_path(f'{args.family}.vds', category='tmp')
 
-    get_logger(__file__).info(f'Creating VDS {args.out} from {len(args.gvcfs)} gVCFs')
+    get_logger(__file__).info(f'Creating VCF {args.out} from {len(args.gvcfs)} gVCFs')
 
     gvcfs_to_vds(gvcfs=args.gvcfs, sgids=args.sgids, vds_out=vds_path, family=args.family)
 
-    get_logger(__file__).info('Creating VCF fragments from VDS')
+    get_logger(__file__).info('Creating VCF fragments from VDS...')
 
     vcf_fragments_tmp = output_path(f'fragments_{args.family}.vcf.bgz', category='tmp')
 
     vds_to_vcf(vds_path=vds_path, output=vcf_fragments_tmp)
 
-    get_logger(__file__).info('Creating single VCF from fragments')
+    get_logger(__file__).info('Creating single VCF from fragments...')
 
     squash_fragments_to_vcf(vcf_fragment_dir=vcf_fragments_tmp, vcf_out=args.out)
+
+    get_logger(__file__).info(f'All done writing {args.out}...')

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -95,7 +95,7 @@ def squash_fragments_to_vcf(vcf_fragment_dir: str, vcf_out: str):
         condense_temp = join(vcf_fragment_dir, f'temp_chunk_{temp_chunk_prefix_num}')
         temp_chunk_prefix_num += 1
 
-        for i, sub_chunk in chunks(manifest_paths, MAX_COMPOSE):
+        for i, sub_chunk in enumerate(chunks(manifest_paths, MAX_COMPOSE)):
             sub_chunk_out = join(condense_temp, f'chunk_{i}.vcf.bgz')
             run(['gcloud', 'storage', 'objects', 'compose', *sub_chunk, sub_chunk_out])
             chunks_this_round.append(sub_chunk_out)

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -54,23 +54,24 @@ def find_families(dataset: Dataset) -> dict[str, list[SequencingGroup]]:
     return dict_by_family
 
 
-# @stage
-# class RDCombiner(DatasetStage):
-#     """
-#     it's a gVCF combiner, to be followed by densification
-#     """
-#
-#     def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
-#         return {'vds': self.prefix / 'vds' / f'{get_workflow().output_version}.vds'}
-#
-#     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
-#
-#         sgids = dataset.get_sequencing_groups()
-#         output = self.expected_outputs(dataset)
-#         jobs = create_vds_jobs(sgids=sgids, out_path=str(output['vds']))
-#         return self.make_outputs(dataset, output, jobs=jobs)
-#
-#
+@stage
+class GVCFSToVCF(DatasetStage):
+    """
+    it's a gVCF combiner, densification, Mt -> VCF
+    # todo continue
+    """
+
+    def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
+        return {'vds': self.prefix / 'vds' / f'{get_workflow().output_version}.vds'}
+
+    def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
+
+        sgids = dataset.get_sequencing_groups()
+        output = self.expected_outputs(dataset)
+        jobs = create_vds_jobs(sgids=sgids, out_path=str(output['vds']))
+        return self.make_outputs(dataset, output, jobs=jobs)
+
+
 # @stage(required_stages=RDCombiner, analysis_keys=['mt'], analysis_type='custom')
 # class VDStoMT(DatasetStage):
 #     """

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -45,12 +45,11 @@ def find_families(dataset: Dataset) -> dict[str, list[SequencingGroup]]:
             get_logger(__file__).info(f'Family {family} has no affected individuals, skipping')
             del dict_by_family[family]
 
-        # todo reinstate this rule
-        # # check that the affected members have HPO terms - required for exomiser
-        # if any([sg.meta['phenotypes'].get(HPO_KEY, '') == '' for sg in affected]):
-        #     get_logger(__file__).info(f'Family {family} has affected individuals with no HPO terms, skipping')
-        #     del dict_by_family[family]
-        #     continue
+        # check that the affected members have HPO terms - required for exomiser
+        if any([sg.meta['phenotypes'].get(HPO_KEY, '') == '' for sg in affected]):
+            get_logger(__file__).info(f'Family {family} has affected individuals with no HPO terms, skipping')
+            del dict_by_family[family]
+            continue
 
     return dict_by_family
 

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -24,7 +24,7 @@ from cpg_utils.config import get_config
 LOGGER: logging.Logger | None = None
 
 
-def get_logger(logger_name: str | None, log_level: int = logging.INFO) -> logging.Logger:
+def get_logger(logger_name: str | None = None, log_level: int = logging.INFO) -> logging.Logger:
     """
     creates a logger instance (so as not to use the root logger)
     Args:


### PR DESCRIPTION
It's Exomiser, but nicer. See #665

Most of the cost in the first production run was in extracting the VCFs from the MT. This implements a different strategy - 

- If the Sample family size is 1, do a skinny command to translate from gVCF to VCF (strip out ref lines, split out real genotypes from `NON_REF`, write the file back to GCP).
- If the family size is > 1, do a gVCF -> VDS -> MT -> VCF for just this family. This implements the gCloud Compose syntax from [here](https://github.com/populationgenomics/production-pipelines/pull/639) to try and optimise the parallelisation of the MT -> VCF extraction, whilst having all family members in a single VCF. 
- The new Family VCFs are stored in the dataset bucket, so that it is independent of joint call
  - We could probably dodge this completely and do a gVCF -> VCF for each member, and a naive bcftools merge for samples in a family? That would be much cheaper and easier

In test I've only been able to run on Genomes, but the cost of doing the gVCF -> VDS -> MT -> VCF for a family of 2 was just around 3c ([here](https://batch.hail.populationgenomics.org.au/batches/438215)), and the cost of a single sample gVCF -> VCF was almost nothing ([here](https://batch.hail.populationgenomics.org.au/batches/438306))