### PR TITLE
Separate families-per-vm and concurrent families

### DIFF
--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -283,7 +283,10 @@ def run_exomiser_batches(content_dict: dict[str, dict[str, Path]]):
         #     'cat results/Pfeiffer-quartet-hiphive-exome-PASS_ONLY.json'
         # )
 
-        for parallel_chunk in chunks(family_chunk, chunk_size=get_config()['workflow'].get('exomiser_parallel_chunks', 4)):
+        for parallel_chunk in chunks(
+            family_chunk,
+            chunk_size=get_config()['workflow'].get('exomiser_parallel_chunks', 4),
+        ):
             for family in parallel_chunk:
                 # read in VCF & index
                 vcf = get_batch().read_input_group(

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -283,7 +283,7 @@ def run_exomiser_batches(content_dict: dict[str, dict[str, Path]]):
         #     'cat results/Pfeiffer-quartet-hiphive-exome-PASS_ONLY.json'
         # )
 
-        for parallel_chunk in chunks(family_chunk, chunk_size=get_config()['workflow'].get('exomiser_chunk_size', 8)):
+        for parallel_chunk in chunks(family_chunk, chunk_size=get_config()['workflow'].get('exomiser_parallel_chunks', 4)):
             for family in parallel_chunk:
                 # read in VCF & index
                 vcf = get_batch().read_input_group(


### PR DESCRIPTION
Accidentally pointed both these to the same variable in config. The default configuration should support any number of families per VM, and 4 families concurrently.