### PR TITLE
Re-work lengthy job names

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.3
+current_version = 1.22.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.3
+  VERSION: 1.22.4
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -218,10 +218,10 @@ def run_exomiser_batches(content_dict: dict[str, dict[str, Path | dict[str, Path
     # now chunk the jobs - load resources, then run a bunch of families
     families = sorted(content_dict.keys())
     all_jobs = []
-    for family_chunk in chunks(families, get_config()['workflow'].get('exomiser_chunk_size', 8)):
+    for chunk_number, family_chunk in enumerate(chunks(families, get_config()['workflow'].get('exomiser_chunk_size', 8))):
         # create a new job, reference the resources in a config file
         # see https://exomiser.readthedocs.io/en/latest/installation.html#linux-install
-        job = get_batch().new_bash_job(f'Run Exomiser for {family_chunk}')
+        job = get_batch().new_bash_job(f'Run Exomiser for chunk {chunk_number}')
         all_jobs.append(job)
         job.storage(get_config()['workflow'].get('exomiser_storage', '200Gi'))
         job.memory(get_config()['workflow'].get('exomiser_memory', '60Gi'))
@@ -240,6 +240,8 @@ def run_exomiser_batches(content_dict: dict[str, dict[str, Path | dict[str, Path
         """,
         )
 
+        # number of chunks should match cpu, accessible in config
+        # these will all run simultaneously using backgrounded tasks and a wait
         for parallel_chunk in chunks(
             family_chunk,
             chunk_size=get_config()['workflow'].get('exomiser_parallel_chunks', 4),

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -240,6 +240,8 @@ def run_exomiser_batches(content_dict: dict[str, dict[str, Path | dict[str, Path
         """,
         )
 
+        job.command(f'echo "This job contains families {" ".join(family_chunk)}"')
+
         # number of chunks should match cpu, accessible in config
         # these will all run simultaneously using backgrounded tasks and a wait
         for parallel_chunk in chunks(

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -218,7 +218,9 @@ def run_exomiser_batches(content_dict: dict[str, dict[str, Path | dict[str, Path
     # now chunk the jobs - load resources, then run a bunch of families
     families = sorted(content_dict.keys())
     all_jobs = []
-    for chunk_number, family_chunk in enumerate(chunks(families, get_config()['workflow'].get('exomiser_chunk_size', 8))):
+    for chunk_number, family_chunk in enumerate(
+        chunks(families, get_config()['workflow'].get('exomiser_chunk_size', 8)),
+    ):
         # create a new job, reference the resources in a config file
         # see https://exomiser.readthedocs.io/en/latest/installation.html#linux-install
         job = get_batch().new_bash_job(f'Run Exomiser for chunk {chunk_number}')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.3',
+    version='1.22.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
See https://batch.hail.populationgenomics.org.au/batches/440652

The Exomiser batches are made cost-effective by slamming a ton of families into the same VM. To track this I was adding all the families in a job into the job's name. An unforeseen (by me) consequence is that Hail includes the full job name in its temp folders/paths, and this is hitting a maximum file length of 255 Bytes, causing the job to fail. 

```
mkdir: cannot create directory '/io/batch/batch_hash/Run_Exomiser_for___FAM1____FAM2____...____FAMN: File name too long
```

I've solved this by moving the families out of the job name and into the logging. Instead the jobs have a simplified "Run exomiser for chunk n" name, and the families contained are written into the logging.


On the plus side... this seems super stable, so we may be able to stack 100+ jobs into a container (unless there are memory leaks), bringing the costs down to ~nothing per family