### PR TITLE
Reblock gvcf storage option

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.4
+current_version = 1.22.5
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.3
+current_version = 1.22.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.4
+  VERSION: 1.22.5
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.3
+  VERSION: 1.22.4
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -108,6 +108,9 @@ delete_scratch_on_exit = false
 # Use highmem machine type for alignment step
 # align_use_highmem = true
 
+# Use additional storage in postproc_gvcf job for large gVCFs
+# postproc_gvcf_storage = 50
+
 [mito_snv]
 # Example config for broad wdl found here:
 # https://raw.githubusercontent.com/broadinstitute/gatk/master/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -322,7 +322,8 @@ def postproc_gvcf(
     # meaning we have more than enough disk (265/8=33.125G).
     # Enough to fit a pre-reblocked GVCF, which can be as big as 10G,
     # the reblocked result (1G), and ref data (5G).
-    job_res = STANDARD.set_resources(j, ncpu=2, storage_gb=20)
+    storage_gb = get_config()['workflow']['resources']['Genotype'].get('postproc_gvcf_storage', 20)
+    job_res = STANDARD.set_resources(j, ncpu=2, storage_gb=storage_gb)
 
     j.declare_resource_group(
         output_gvcf={

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -322,10 +322,7 @@ def postproc_gvcf(
     # meaning we have more than enough disk (265/8=33.125G).
     # Enough to fit a pre-reblocked GVCF, which can be as big as 10G,
     # the reblocked result (1G), and ref data (5G).
-    if (postproc_gvcf_storage := get_config()['resource_overrides'].get('postproc_gvcf_storage')) is not None:
-        storage_gb = postproc_gvcf_storage
-    else:
-        storage_gb = 20
+    storage_gb = get_config()['resource_overrides'].get('postproc_gvcf_storage', 20)
     job_res = STANDARD.set_resources(j, ncpu=2, storage_gb=storage_gb)
 
     j.declare_resource_group(

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -322,7 +322,11 @@ def postproc_gvcf(
     # meaning we have more than enough disk (265/8=33.125G).
     # Enough to fit a pre-reblocked GVCF, which can be as big as 10G,
     # the reblocked result (1G), and ref data (5G).
-    storage_gb = get_config()['workflow']['resources']['Genotype'].get('postproc_gvcf_storage', 20)
+    try:
+        # Overwrite the default storage if it is set in the config - for really large GVCFs
+        storage_gb = get_config()['workflow']['resources']['Genotype']['postproc_gvcf_storage']
+    except KeyError:
+        storage_gb = 20
     job_res = STANDARD.set_resources(j, ncpu=2, storage_gb=storage_gb)
 
     j.declare_resource_group(

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -322,10 +322,9 @@ def postproc_gvcf(
     # meaning we have more than enough disk (265/8=33.125G).
     # Enough to fit a pre-reblocked GVCF, which can be as big as 10G,
     # the reblocked result (1G), and ref data (5G).
-    try:
-        # Overwrite the default storage if it is set in the config - for really large GVCFs
-        storage_gb = get_config()['workflow']['resources']['Genotype']['postproc_gvcf_storage']
-    except KeyError:
+    if (postproc_gvcf_storage := get_config()['resource_overrides'].get('postproc_gvcf_storage')) is not None:
+        storage_gb = postproc_gvcf_storage
+    else:
         storage_gb = 20
     job_res = STANDARD.set_resources(j, ncpu=2, storage_gb=storage_gb)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.4',
+    version='1.22.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.3',
+    version='1.22.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds resource_overrides config option for Postproc gvcf job. 

Prompted by [a recent failed job](https://batch.hail.populationgenomics.org.au/batches/440331/jobs/1) which ran out of storage. The HaplotypeCaller output for this sample is really large and it needs more than the default storage to finish the Genotype stage.