### PR TITLE
Remove metrics from GB workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.5
+current_version = 1.22.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.5
+  VERSION: 1.22.6
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample_1.toml
+++ b/configs/defaults/gatk_sv_multisample_1.toml
@@ -3,3 +3,7 @@ name = 'gatk_sv'
 dataset_gcp_project = 'seqr-308602'
 dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+
+
+[resource_overrides.GenotypeBatch]
+run_module_metrics = false

--- a/configs/defaults/gatk_sv_multisample_2.toml
+++ b/configs/defaults/gatk_sv_multisample_2.toml
@@ -54,3 +54,7 @@ username = 'seqr'
 # Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
 password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
+
+[resource_overrides.MakeCohortVcf]
+run_module_metrics = false
+

--- a/configs/defaults/gatk_sv_multisample_2.toml
+++ b/configs/defaults/gatk_sv_multisample_2.toml
@@ -57,4 +57,3 @@ password_project_id = 'seqr-308602'
 
 [resource_overrides.MakeCohortVcf]
 run_module_metrics = false
-

--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -19,6 +19,10 @@ disk_gb = 200
 
 [resource_overrides.MakeCohortVcf]
 run_module_metrics = false
+
+[resource_overrides.GenotypeBatch]
+run_module_metrics = false
+
 [resource_overrides.MakeCohortVcf.runtime_override_plot_qc_per_family]
 mem_gb = 32
 

--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -17,12 +17,6 @@ disk_gb = 40
 [resource_overrides.EvidenceQC.runtime_attr_mediancov]
 disk_gb = 200
 
-[resource_overrides.MakeCohortVcf]
-run_module_metrics = false
-
-[resource_overrides.GenotypeBatch]
-run_module_metrics = false
-
 [resource_overrides.MakeCohortVcf.runtime_override_plot_qc_per_family]
 mem_gb = 32
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -556,7 +556,7 @@ class GenotypeBatch(CohortStage):
 
         # if we don't run metrics, don't expect the outputs
         # on by default in the WDL file, so expect this to run unless overridden
-        if override := get_config()['resource_overrides'].get('MakeCohortVcf'):
+        if override := get_config()['resource_overrides'].get('GenotypeBatch'):
             if not override.get('run_module_metrics', True):
                 _metrics_path = str(ending_by_key.pop('metrics_file_genotypebatch'))
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -554,6 +554,12 @@ class GenotypeBatch(CohortStage):
             'metrics_file_genotypebatch': 'metrics.tsv',
         }
 
+        # if we don't run metrics, don't expect the outputs
+        # on by default in the WDL file, so expect this to run unless overridden
+        if override := get_config()['resource_overrides'].get('MakeCohortVcf'):
+            if not override.get('run_module_metrics', True):
+                _metrics_path = str(ending_by_key.pop('metrics_file_genotypebatch'))
+
         for mode in ['pesr', 'depth']:
             ending_by_key |= {
                 f'trained_genotype_{mode}_pesr_sepcutoff': f'{mode}.pesr_sepcutoff.txt',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.5',
+    version='1.22.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Metrics are not required during standard running - off by default.

Also moves these standard overrides into the workflow default - the override will become running, instead of disabling