### PR TITLE
Reduce pass threshold for medium SVs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.6
+current_version = 1.22.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.6
+  VERSION: 1.22.7
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample_2.toml
+++ b/configs/defaults/gatk_sv_multisample_2.toml
@@ -43,7 +43,7 @@ recalibrate_gq_args = [
 # FilterGenotypes - stringent end of [0.3, 0.5] range
 fmax_beta = 0.3
 
-sl_filter_args = '--small-del-threshold 93 --medium-del-threshold 150 --small-dup-threshold -51 --medium-dup-threshold -4 --ins-threshold -13 --inv-threshold -19'
+sl_filter_args = '--small-del-threshold 93 --medium-del-threshold 100 --small-dup-threshold -51 --medium-dup-threshold -4 --ins-threshold -13 --inv-threshold -19'
 noncoding_bed = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed'
 
 [elasticsearch]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.6',
+    version='1.22.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Changes the filtering threshold for medium DEL variants, following discussion with the GATK team. We are missing a couple of known variants due to this filtering stringency, and we're happy to relax this threshold.

The previous run of this stage is running here - https://batch.hail.populationgenomics.org.au/batches/441360

Once that finishes we can run these changes on the latest data and compare the plots for each