### PR TITLE
Allow GB hash override

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -170,7 +170,8 @@ class MakeCohortVcf(CohortStage):
 
         Replacing this nasty mess with nested/fancy cohorts would be ace
         """
-        cohort_partial_hash = cohort.alignment_inputs_hash()[-10:]
+        genotypebatch_hash = get_config()['workflow'].get('genotypebatch_hash') or cohort.alignment_inputs_hash()
+        cohort_partial_hash = genotypebatch_hash[-10:]
 
         batch_names = get_config()['workflow']['batch_names']
         batch_prefix = cohort.analysis_dataset.prefix() / 'gatk_sv'


### PR DESCRIPTION
Until Spicy cohorts land: 

- we have to run GenotypeBatch once per batch, using a MergeBatchSites output file
- that can be a lot of batches
- If the hash was set wrongly at any point during the multisample1a-sandwich-multisample1b-mutisample2, we would have go to back and recreate all the files with different names
- This patch allows us to override the filename expectations to match what was actually used, preventing the need to re-run ~20 workflows

This fix should be removed when multicohorts land