### PR TITLE
Optionally allow column inconsistencies when unioning background datasets

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.7
+current_version = 1.22.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.7
+  VERSION: 1.22.8
 
 jobs:
   docker:

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -59,6 +59,9 @@ inferred_ancestry = false
 # function to use reference blocks for ploidy calculations
 # https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C
 
+# Set whether to allow column discrepancies when unioning background dataset tables
+#allow_missing_columns = false
+
 # Parameters for sample QC. The default values for soft filtering taken from gnomAD QC:
 # https://macarthurlab.org/2019/10/16/gnomad-v3-0, with `max_n_snps` and
 # `max_n_singletons` adjusted based on the results we got for the TOB-WGS project.

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -23,6 +23,7 @@ def add_background(
     Add background dataset samples to the dense MT and sample QC HT.
     """
     sites_table = get_config()['references']['ancestry']['sites_table']
+    allow_missing_columns = get_config()['large_cohort']['pca_background'].get('allow_missing_columns', False)
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
     for dataset in get_config()['large_cohort']['pca_background']['datasets']:
@@ -44,7 +45,7 @@ def add_background(
             for path in dataset_dict['metadata_table']:
                 sample_qc_background = hl.read_table(path)
                 metadata_tables.append(sample_qc_background)
-            metadata_tables = hl.Table.union(*metadata_tables)
+            metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.7',
+    version='1.22.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
For data generated at different times, the tables being unioned in `add_background()` may have slightly differing sets of columns. For example, we've encountered a case where one table has an `autosomal_mean_dp` column but other(s) do not. Use `unify=True` to allow the code to continue despite these minor extra columns, but require this to be turned on in the config — so that it is used only when necessary.

(This is the only instance of `hl.Table.union()` in production-pipelines.)

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1712720352383989