### PR TITLE
Correction to optionally allow column inconsistencies when unioning background datasets

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.8
+current_version = 1.22.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.8
+  VERSION: 1.22.9
 
 jobs:
   docker:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -56,7 +56,7 @@ def add_background(
         background_mt = background_mt.naive_coalesce(5000)
         # combine dense dataset with background population dataset
         dense_mt = dense_mt.union_cols(background_mt)
-        sample_qc_ht = sample_qc_ht.union(ht)
+        sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
     return dense_mt, sample_qc_ht
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.8',
+    version='1.22.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Correction to the previous PR #685: there is a second call to `hl.Table.union(…)` in the same function — sneakily it looks different as it is being called on a Table object properly, unlike the first pseudo-class-level invocation!

Add `unify=...` to this other `.union()` call too.