### PR TITLE
Delay cpg_workflows.stages.* imports until after main() starts

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,54 +11,57 @@ import coloredlogs
 from cpg_utils import to_path
 from cpg_utils.config import set_config_paths
 from cpg_workflows import defaults_config_path
-from cpg_workflows.stages.aip import CreateAIPHTML, GenerateSeqrFile, ValidateMOI
-from cpg_workflows.stages.cram_qc import CramMultiQC
-from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, RunExomiser
-from cpg_workflows.stages.fastqc import FastQCMultiQC
-from cpg_workflows.stages.fraser import Fraser
-from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
-    FilterBatch,
-    GenotypeBatch,
-    MergeBatchSites,
-)
-from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import MtToEsSv
-from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV
-from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
-from cpg_workflows.stages.happy_validation import (
-    ValidationHappyOnVcf,
-    ValidationMtToVcf,
-    ValidationParseHappy,
-)
-from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
-from cpg_workflows.stages.mito import MitoReport
-from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
-from cpg_workflows.stages.stripy import Stripy
 from cpg_workflows.workflow import StageDecorator, run_workflow
 
-WORKFLOWS: dict[str, list[StageDecorator]] = {
-    'aip': [ValidateMOI, CreateAIPHTML, GenerateSeqrFile],
-    'exomiser': [RunExomiser, ExomiserSeqrTSV],
-    'pre_alignment': [FastQCMultiQC],
-    'seqr_loader': [
-        DatasetVCF,
-        AnnotateDataset,
-        MtToEs,
-        GvcfMultiQC,
-        CramMultiQC,
-        Stripy,
-        MitoReport,
-    ],
-    'validation': [ValidationMtToVcf, ValidationHappyOnVcf, ValidationParseHappy],
-    'large_cohort': [LoadVqsr, Frequencies, AncestryPlots, GvcfMultiQC, CramMultiQC],
-    'gatk_sv_singlesample': [CreateSampleBatches],
-    'gatk_sv_multisample_1': [FilterBatch, GenotypeBatch],
-    'gatk_sv_sandwich': [MergeBatchSites],  # stage to run between FilterBatch & GenotypeBatch
-    'gatk_sv_multisample_2': [MtToEsSv],
-    'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV],
-}
+
+def get_workflows() -> dict[str, list[StageDecorator]]:
+    from cpg_workflows.stages.aip import CreateAIPHTML, GenerateSeqrFile, ValidateMOI
+    from cpg_workflows.stages.cram_qc import CramMultiQC
+    from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, RunExomiser
+    from cpg_workflows.stages.fastqc import FastQCMultiQC
+    from cpg_workflows.stages.fraser import Fraser
+    from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_1 import (
+        FilterBatch,
+        GenotypeBatch,
+        MergeBatchSites,
+    )
+    from cpg_workflows.stages.gatk_sv.gatk_sv_multisample_2 import MtToEsSv
+    from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
+    from cpg_workflows.stages.gcnv import AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV
+    from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
+    from cpg_workflows.stages.happy_validation import (
+        ValidationHappyOnVcf,
+        ValidationMtToVcf,
+        ValidationParseHappy,
+    )
+    from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
+    from cpg_workflows.stages.mito import MitoReport
+    from cpg_workflows.stages.outrider import Outrider
+    from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
+    from cpg_workflows.stages.stripy import Stripy
+
+    return {
+        'aip': [ValidateMOI, CreateAIPHTML, GenerateSeqrFile],
+        'exomiser': [RunExomiser, ExomiserSeqrTSV],
+        'pre_alignment': [FastQCMultiQC],
+        'seqr_loader': [
+            DatasetVCF,
+            AnnotateDataset,
+            MtToEs,
+            GvcfMultiQC,
+            CramMultiQC,
+            Stripy,
+            MitoReport,
+        ],
+        'validation': [ValidationMtToVcf, ValidationHappyOnVcf, ValidationParseHappy],
+        'large_cohort': [LoadVqsr, Frequencies, AncestryPlots, GvcfMultiQC, CramMultiQC],
+        'gatk_sv_singlesample': [CreateSampleBatches],
+        'gatk_sv_multisample_1': [FilterBatch, GenotypeBatch],
+        'gatk_sv_sandwich': [MergeBatchSites],  # stage to run between FilterBatch & GenotypeBatch
+        'gatk_sv_multisample_2': [MtToEsSv],
+        'rare_disease_rnaseq': [Outrider, Fraser],
+        'gcnv': [AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV],
+    }
 
 
 @click.command(no_args_is_help=True)
@@ -109,6 +112,20 @@ def main(
     fmt = '%(asctime)s %(levelname)s (%(name)s %(lineno)s): %(message)s'
     coloredlogs.install(level='DEBUG' if verbose else 'INFO', fmt=fmt)
 
+    wfl_conf_path = to_path(__file__).parent / f'configs/defaults/{workflow}.toml'
+    assert wfl_conf_path.exists(), wfl_conf_path
+
+    for path in config_paths:
+        assert to_path(path).exists(), path
+
+    config_paths = os.environ['CPG_CONFIG_PATH'].split(',') + list(config_paths)
+    # Assuming the defaults is already loaded in __init__.py:
+    assert to_path(config_paths[0]) == defaults_config_path
+    # Inserting after the "defaults" config, but before user configs:
+    set_config_paths(config_paths[:1] + [str(wfl_conf_path)] + config_paths[1:])
+
+    WORKFLOWS = get_workflows()
+
     if not workflow and not list_workflows:
         click.echo('You must specify WORKFLOW as a first positional command line argument.')
     if not workflow or list_workflows or workflow == 'list':
@@ -124,18 +141,6 @@ def main(
         )
         click.echo(f'{", ".join(s.__name__ for s in WORKFLOWS[workflow])}')
         return
-
-    wfl_conf_path = to_path(__file__).parent / f'configs/defaults/{workflow}.toml'
-    assert wfl_conf_path.exists(), wfl_conf_path
-
-    for path in config_paths:
-        assert to_path(path).exists(), path
-
-    config_paths = os.environ['CPG_CONFIG_PATH'].split(',') + list(config_paths)
-    # Assuming the defaults is already loaded in __init__.py:
-    assert to_path(config_paths[0]) == defaults_config_path
-    # Inserting after the "defaults" config, but before user configs:
-    set_config_paths(config_paths[:1] + [str(wfl_conf_path)] + config_paths[1:])
 
     run_workflow(stages=WORKFLOWS[workflow], dry_run=dry_run)
 

--- a/main.py
+++ b/main.py
@@ -112,8 +112,12 @@ def main(
     fmt = '%(asctime)s %(levelname)s (%(name)s %(lineno)s): %(message)s'
     coloredlogs.install(level='DEBUG' if verbose else 'INFO', fmt=fmt)
 
-    wfl_conf_path = to_path(__file__).parent / f'configs/defaults/{workflow}.toml'
-    assert wfl_conf_path.exists(), wfl_conf_path
+    if workflow:
+        wfl_conf_path = to_path(__file__).parent / f'configs/defaults/{workflow}.toml'
+        assert wfl_conf_path.exists(), wfl_conf_path
+        wfl_conf_path = [str(wfl_conf_path)]
+    else:
+        wfl_conf_path = []
 
     for path in config_paths:
         assert to_path(path).exists(), path
@@ -122,13 +126,13 @@ def main(
     # Assuming the defaults is already loaded in __init__.py:
     assert to_path(config_paths[0]) == defaults_config_path
     # Inserting after the "defaults" config, but before user configs:
-    set_config_paths(config_paths[:1] + [str(wfl_conf_path)] + config_paths[1:])
+    set_config_paths(config_paths[:1] + wfl_conf_path + config_paths[1:])
 
     WORKFLOWS = get_workflows()
 
     if not workflow and not list_workflows:
         click.echo('You must specify WORKFLOW as a first positional command line argument.')
-    if not workflow or list_workflows or workflow == 'list':
+    if not workflow or list_workflows:
         click.echo('Available values for WORKFLOW (and corresponding last stages):')
         for wfl, last_stages in WORKFLOWS.items():
             click.echo(f'\t{wfl} ({", ".join(s.__name__ for s in last_stages)})')


### PR DESCRIPTION
Some of our workflow stages define top-level constants based on config entries accessed via `get_config()` — which is quite reasonable as these are indeed **constants**, and especially where an entry is used multiple times in a pipeline, defining it once at the top-level is a very appropriate pattern.

However this means that config files set via _main.py_'s `--config` option aren't accessible, because the config has already been read during the imports, before `main()` has run. We don't use this in production (where configs are set via analysis runner), but it is a useful knob when dry-run testing locally.

Fix this by moving the stage imports into a new `get_workflows()` function, which delays importing them until the function is called, and finalise the config path before calling `get_workflows()` to initialise `WORKFLOWS`. (~~The config handling now needs an extra wart to handle the existing `list` special case.~~ This now removes the previous `list` special case, which was just an obscure way of saying `--list-workflows`.)

This makes (most of) PR #679 unnecessary.

You're going to want to view this PR's changes with the “Hide whitespace” setting on!