### PR TITLE
Remove all metrics sub workflows

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.9
+current_version = 1.22.10
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.9
+  VERSION: 1.22.10
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample_1.toml
+++ b/configs/defaults/gatk_sv_multisample_1.toml
@@ -4,6 +4,27 @@ dataset_gcp_project = 'seqr-308602'
 dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
+# switches to deactivate all Metrics workflows
+# "GatherBatchEvidenceMetrics and the other metrics routines at the end of the main workflows are
+# primarily for development and testing purposes, so you don’t need to run them as a user"
+# https://centrepopgen.slack.com/archives/C02E83V5JSF/p1705547576042719
+
+# these metrics workflows are typically running svtest (https://github.com/broadinstitute/gatk-sv/blob/d37e453038e425acba9683da503218fe3d4b1033/src/svtest/setup.py)
+# on each output of the stage, producing output files containing a count/distribution of different variants
+# and sizes. The workflow files we use do not (and can not) copy these result files into permanent storage, so
+# even if we run them, we will lose the results
+[resource_overrides.GatherBatchEvidence]
+# defaults to false due to runtime/expense
+run_module_metrics = false
+
+[resource_overrides.ClusterBatch]
+run_module_metrics = false
+
+[resource_overrides.GenerateBatchMetrics]
+run_module_metrics = false
+
+[resource_overrides.FilterBatch]
+run_module_metrics = false
 
 [resource_overrides.GenotypeBatch]
 run_module_metrics = false

--- a/configs/defaults/gatk_sv_multisample_2.toml
+++ b/configs/defaults/gatk_sv_multisample_2.toml
@@ -55,5 +55,18 @@ username = 'seqr'
 password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
 
+# switch off metrics workflows
 [resource_overrides.MakeCohortVcf]
+# this is passed to CleanVcf
 run_module_metrics = false
+
+# if you have to do it, bump the resources
+#[resource_overrides.MakeCohortVcf.runtime_override_plot_qc_per_family]
+#mem_gb = 32
+
+[resource_overrides.FilterGenotypes]
+run_module_metrics = false
+
+# if you have to do it, bump the resources
+#[resource_overrides.FilterGenotypes.runtime_override_plot_qc_per_family]
+#mem_gb = 32

--- a/configs/defaults/gatk_sv_singlesample.toml
+++ b/configs/defaults/gatk_sv_singlesample.toml
@@ -3,3 +3,10 @@ name = 'gatk_sv'
 dataset_gcp_project = 'seqr-308602'
 dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+
+# these workflows take a VCF result from a GatherSampleEvidence stage, and optionally a baseline VCF
+# from the same caller, and runs a VCFMetrics comparison of the two
+# we don't have like-for-like baselines for any of our samples (AFAIK), and the workflows don't allow
+# us to recover these results
+[resource_overrides.GatherSampleEvidence]
+run_module_metrics = false

--- a/configs/gatk_sv/config_overrides.toml
+++ b/configs/gatk_sv/config_overrides.toml
@@ -16,16 +16,3 @@ disk_gb = 40
 
 [resource_overrides.EvidenceQC.runtime_attr_mediancov]
 disk_gb = 200
-
-[resource_overrides.MakeCohortVcf.runtime_override_plot_qc_per_family]
-mem_gb = 32
-
-# resource overrides for indirect workflows
-
-[sub_workflow_overrides.EXAMPLE.SubWorkflow.runtime_attr_overrides]
-
-## during MakeCohortVcf, we need to override the resource requirements for the
-## MakeCohortVcfMetrics sub-workflow
-#[sub_workflow_overrides.MakeCohortVcf.MakeCohortVcfMetrics.runtime_attr_vcf_metrics]
-#mem_gb = 20
-#disk_gb = 40

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -192,14 +192,6 @@ def add_gatk_sv_jobs(
         else:
             paths_as_strings[f'{wfl_name}.{key}'] = value
 
-    # sometimes we need to pass inputs on to a sub-workflow, rather than the top
-    # level. See the config_overrides toml for an example of how to use this
-    if 'sub_workflow_overrides' in get_config():
-        if sub_wfl_inputs := get_config()['sub_workflow_overrides'].get(wfl_name):
-            for sub_wf, sub_section in sub_wfl_inputs.items():
-                for key, value in sub_section.items():
-                    paths_as_strings[f'{sub_wf}.{key}'] = value
-
     job_prefix = make_job_name(wfl_name, sequencing_group=sequencing_group_id, dataset=dataset.name)
 
     # config toggle decides if outputs are copied out

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.9',
+    version='1.22.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds default avoidance for all metrics workflows which are not required for production operation - instead of adding these dodges in config_overrides.toml, the default config will now suppress these behaviours.

Closes #689 

Also removes the attempt at overriding config settings directly on sub-workflow WDLs. This did not work in practice.