### PR TITLE
added environment attr to the docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,6 +20,7 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    environment: production
     defaults:
       run:
         shell: bash -l {0}
@@ -31,13 +32,13 @@ jobs:
       DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
       DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - id: "google-cloud-auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"


### PR DESCRIPTION
## Description
In a bid to introduce better security permissions, we have replaced the use of SA keys to workload identity providers. This change will also implement the use of environments to ensure deployments are going through the right channels.

## Changes
- [x]  Added `environment` attribute to the `docker` workflow