### PR TITLE
Standalone PCA dataproc runner

### DIFF
--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -1,0 +1,39 @@
+import csv
+
+import hail as hl
+from cpg_utils.hail_batch import output_path
+from cpg_utils import to_path
+
+
+def pca_runner(vds_path, sample_id_file_path):
+    vds = hl.vds.read_vds(str(vds_path))
+    mt = vds.variant_data
+
+    mt = mt.annotate_entries(GT=hl.vds.lgt_to_gt(mt.LGT, mt.LA))
+    if sample_id_file_path:
+        with to_path(str(sample_id_file_path)).open('r') as f:
+            sample_ids = list(csv.reader(f))[0]
+        mt = mt.filter_cols(hl.literal(sample_ids).contains(mt.s))
+
+    # subset to sites table
+    sites_table = "gs://cpg-common-main/references/ancestry/pruned_variants.ht"
+    qc_variants_ht = hl.read_table(sites_table)
+    qc_variants_ht = qc_variants_ht.key_by('locus')
+
+    mt = mt.annotate_rows(sites_locus=hl.is_defined(qc_variants_ht[mt.locus]))
+    mt = mt.filter_rows(mt.sites_locus == True)
+
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
+
+    scores_output_path = output_path('scores.tsv')
+    scores.export(str(scores_output_path))
+
+    loadings_output_path = output_path('loadings.tsv')
+    loadings.export(str(loadings_output_path))
+
+    # Convert the list to a regular Python list
+    eigenvalues_list = hl.eval(eigenvalues)
+    # write the eigenvalues to a file
+    with to_path(output_path('eigenvalues.txt')).open('w') as f:
+        for item in eigenvalues_list:
+            f.write(f'{item}\n')

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -26,7 +26,7 @@ def pca_runner(vds_path, sample_id_file_path):
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
 
     scores_output_path = output_path('scores.tsv', 'analysis')
-    scores.export(str(scores_output_path))
+    scores.export(scores_output_path)
 
     loadings_output_path = output_path('loadings.tsv', 'analysis')
     loadings.export(str(loadings_output_path))

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -23,7 +23,7 @@ def pca_runner(vds_path, sample_id_file_path):
 
     mt = mt.filter_rows(hl.is_defined(qc_variants_ht[mt.locus]))
 
-    mt = mt.checkpoint(output_path('checkpoint.mt', 'tmp')
+    mt = mt.checkpoint(output_path('checkpoint.mt', 'tmp'))
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
 
     scores_output_path = output_path('scores.tsv', 'analysis')

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -1,8 +1,9 @@
 import csv
 
 import hail as hl
-from cpg_utils.hail_batch import output_path
+
 from cpg_utils import to_path
+from cpg_utils.hail_batch import output_path
 
 
 def pca_runner(vds_path, sample_id_file_path):
@@ -25,15 +26,15 @@ def pca_runner(vds_path, sample_id_file_path):
 
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
 
-    scores_output_path = output_path('scores.tsv')
+    scores_output_path = output_path('scores.tsv', 'analysis')
     scores.export(str(scores_output_path))
 
-    loadings_output_path = output_path('loadings.tsv')
+    loadings_output_path = output_path('loadings.tsv', 'analysis')
     loadings.export(str(loadings_output_path))
 
     # Convert the list to a regular Python list
     eigenvalues_list = hl.eval(eigenvalues)
     # write the eigenvalues to a file
-    with to_path(output_path('eigenvalues.txt')).open('w') as f:
+    with to_path(output_path('eigenvalues.txt', 'analysis')).open('w') as f:
         for item in eigenvalues_list:
             f.write(f'{item}\n')

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -24,7 +24,7 @@ def pca_runner(vds_path, sample_id_file_path):
     mt = mt.filter_rows(hl.is_defined(qc_variants_ht[mt.locus]))
 
     mt = mt.checkpoint(output_path('checkpoint.mt', 'tmp'))
-    eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=2, compute_loadings=True)
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
 
     scores_output_path = output_path('scores.tsv', 'analysis')
     scores.export(scores_output_path)

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -23,6 +23,7 @@ def pca_runner(vds_path, sample_id_file_path):
 
     mt = mt.filter_rows(hl.is_defined(qc_variants_ht[mt.locus]))
 
+    mt = mt.checkpoint(output_path('checkpoint.mt', 'tmp')
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
 
     scores_output_path = output_path('scores.tsv', 'analysis')

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -21,8 +21,7 @@ def pca_runner(vds_path, sample_id_file_path):
     qc_variants_ht = hl.read_table(sites_table)
     qc_variants_ht = qc_variants_ht.key_by('locus')
 
-    mt = mt.annotate_rows(sites_locus=hl.is_defined(qc_variants_ht[mt.locus]))
-    mt = mt.filter_rows(mt.sites_locus == True)
+    mt = mt.filter_rows(hl.is_defined(qc_variants_ht[mt.locus]))
 
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
 

--- a/cpg_workflows/dataproc_scripts/pca_runner.py
+++ b/cpg_workflows/dataproc_scripts/pca_runner.py
@@ -24,7 +24,7 @@ def pca_runner(vds_path, sample_id_file_path):
     mt = mt.filter_rows(hl.is_defined(qc_variants_ht[mt.locus]))
 
     mt = mt.checkpoint(output_path('checkpoint.mt', 'tmp'))
-    eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=10, compute_loadings=True)
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(mt.GT, k=2, compute_loadings=True)
 
     scores_output_path = output_path('scores.tsv', 'analysis')
     scores.export(scores_output_path)

--- a/pca_dataproc_runner.py
+++ b/pca_dataproc_runner.py
@@ -6,6 +6,7 @@ Script to submit a dataproc job to run a SNP PCA
 
 """
 import click
+
 from cpg_utils.hail_batch import get_batch
 
 

--- a/pca_dataproc_runner.py
+++ b/pca_dataproc_runner.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-function-docstring,no-member
+
+"""
+Script to submit a dataproc job to run a SNP PCA
+
+"""
+import click
+from cpg_utils.hail_batch import get_batch
+
+
+@click.option('--vds-path', help='Path to the VDS file', required=True)
+@click.option('--sample-id-file-path', help='Path to the sample id file', default=None)
+@click.command()
+def main(vds_path, sample_id_file_path):
+    from cpg_workflows.dataproc_scripts.pca_runner import pca_runner
+    from cpg_workflows.large_cohort.dataproc_utils import dataproc_job
+
+    dataproc_job(
+        function=pca_runner,
+        function_path_args=dict(vds_path=vds_path, sample_id_file_path=sample_id_file_path),
+        job_name='SNP-PCA',
+        num_workers=5,
+    )
+
+    get_batch(name='SNP PCA Data proc job').run(wait=False)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Basic PCA runner that 
- subsets the VDS to the sites table 
- runs hwe_normalized_pca

option to specify sample file to filter sample IDs in the VDS prior to running PCA

outputs the loadings, scores, and eigenvalues as TSV, TSV, and txt files respectively. 

Interim solution to get some plots going; will delete scripts after filtering is incorporated into the LC pipeline. 