### PR TITLE
Specify columns to be dropped after unioning background datasets

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.11
+current_version = 1.22.12
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.11
+  VERSION: 1.22.12
 
 jobs:
   docker:

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -61,6 +61,8 @@ inferred_ancestry = false
 
 # Set whether to allow column discrepancies when unioning background dataset tables
 #allow_missing_columns = false
+# Columns to be dropped from the final unioned background table
+#drop_columns = ['autosomal_mean_dp']
 
 # Parameters for sample QC. The default values for soft filtering taken from gnomAD QC:
 # https://macarthurlab.org/2019/10/16/gnomad-v3-0, with `max_n_snps` and

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -24,6 +24,7 @@ def add_background(
     """
     sites_table = get_config()['references']['ancestry']['sites_table']
     allow_missing_columns = get_config()['large_cohort']['pca_background'].get('allow_missing_columns', False)
+    drop_columns = get_config()['large_cohort']['pca_background'].get('drop_columns')
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
     for dataset in get_config()['large_cohort']['pca_background']['datasets']:
@@ -57,6 +58,9 @@ def add_background(
         # combine dense dataset with background population dataset
         dense_mt = dense_mt.union_cols(background_mt)
         sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
+
+    if drop_columns:
+        sample_qc_ht = sample_qc_ht.drop(drop_columns)
     return dense_mt, sample_qc_ht
 
 

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -60,7 +60,7 @@ def add_background(
         sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
 
     if drop_columns:
-        sample_qc_ht = sample_qc_ht.drop(drop_columns)
+        sample_qc_ht = sample_qc_ht.drop(*drop_columns)
     return dense_mt, sample_qc_ht
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.11',
+    version='1.22.12',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Another experiment to fix unioning differing background datasets, as a followup to PR #685:

For data generated at different times, the tables being unioned in `add_background()` may have slightly differing sets of columns. Using `unify=True` continues to a final union table with mismatched columns a mixture of values and missing.

This may confuse later processing, so add another config item to enable configuring such columns to be dropped from the final table.