### PR TITLE
Point to GATK image with gCNV bugfix

### DIFF
--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -16,7 +16,7 @@ gncv_max_pass_events = 30
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
 gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
-sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-08-11-v0.28.2-beta-9fe9694e"
+sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/gatk-sv_issue_661:n_a"
 
 [references.gatk_sv]
 # a couple of annotation arguments are not files


### PR DESCRIPTION
Not sure if this is a great idea...

See https://github.com/populationgenomics/images/pull/137

This updates the gCNV standard workflow config to use the homebrewed version of the GATK sv-pipeline image with the updated version of a problemmatic script.

We can solve this by adding this change into the batch-specific config files, or getting a proper upstream fix in place. This is a stop-gap, and I'm not 💯% sure it needs to be in the main default.