### PR TITLE
GatherBatchMetrics fails expecting metrics files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.13
+current_version = 1.22.14
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.13
+  VERSION: 1.22.14
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -76,10 +76,6 @@ class GatherBatchEvidence(CohortStage):
             'merged_BAF_index': f'{self.name}.baf.txt.gz.tbi',
             'merged_bincov': f'{self.name}.RD.txt.gz',
             'merged_bincov_index': f'{self.name}.RD.txt.gz.tbi',
-            'SR_stats': 'SR.QC_matrix.txt',
-            'PE_stats': 'PE.QC_matrix.txt',
-            'BAF_stats': 'BAF.QC_matrix.txt',
-            'RD_stats': 'RD.QC_matrix.txt',
             'median_cov': 'medianCov.transposed.bed',
             'merged_dels': 'DEL.bed.gz',
             'merged_dups': 'DUP.bed.gz',
@@ -88,7 +84,15 @@ class GatherBatchEvidence(CohortStage):
         # we don't run metrics as standard, only expect the output if we choose to run
         if override := get_config()['resource_overrides'].get(self.name):
             if override.get('run_matrix_qc'):
-                ending_by_key['Matrix_QC_plot'] = '00_matrix_FC_QC.png'
+                ending_by_key.update(
+                    {
+                        'Matrix_QC_plot': '00_matrix_FC_QC.png',
+                        'SR_stats': 'SR.QC_matrix.txt',
+                        'PE_stats': 'PE.QC_matrix.txt',
+                        'BAF_stats': 'BAF.QC_matrix.txt',
+                        'RD_stats': 'RD.QC_matrix.txt',
+                    },
+                )
 
         for caller in SV_CALLERS:
             ending_by_key[f'std_{caller}_vcf_tar'] = f'{caller}.tar.gz'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.13',
+    version='1.22.14',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Some of the metrics files are still being expected when that workflow is disabled

run: [here](https://batch.hail.populationgenomics.org.au/batches/444573)

Definitely my fault 🙃 