### PR TITLE
Refactor dictionary accessing in output_versions

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -47,7 +47,7 @@ class Combiner(CohortStage):
 @stage(required_stages=[Combiner])
 class SampleQC(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> Path:
-        if sample_qc_version := get_config()['large_cohort']['output_versions'].get('sample_qc'):
+        if sample_qc_version := get_config()['large_cohort'].get('output_versions').get('sample_qc'):
             sample_qc_version = slugify(sample_qc_version)
 
         sample_qc_version = sample_qc_version or get_workflow().output_version
@@ -75,7 +75,7 @@ class SampleQC(CohortStage):
 @stage(required_stages=[Combiner])
 class DenseSubset(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> Path:
-        if dense_subset_version := get_config()['large_cohort']['output_versions'].get('dense_subset'):
+        if dense_subset_version := get_config()['large_cohort'].get('output_versions').get('dense_subset'):
             dense_subset_version = slugify(dense_subset_version)
 
         dense_subset_version = dense_subset_version or get_workflow().output_version
@@ -105,7 +105,7 @@ class DenseSubset(CohortStage):
 @stage(required_stages=[SampleQC, DenseSubset])
 class Relatedness(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        if relatedness_version := get_config()['large_cohort']['output_versions'].get('relatedness'):
+        if relatedness_version := get_config()['large_cohort'].get('output_versions').get('relatedness'):
             relatedness_version = slugify(relatedness_version)
 
         relatedness_version = relatedness_version or get_workflow().output_version


### PR DESCRIPTION
During the execution of the Combiner stage in [this batch](https://batch.hail.populationgenomics.org.au/batches/444746/jobs/1), a `KeyError` occurred due to direct key access instead of using the `.get()` method. The `large_cohort.output_versions` parameter is unnecessary in this scenario since the Combiner stage has its own logic for specifying output versions. Therefore, omitting `large_cohort.output_versions` prevents the batch from running properly. This PR addresses the `KeyError` issue by using `.get()` for nested dictionary access and removes the unnecessary `large_cohort.output_versions` parameter from the configuration file for this scenario.

Example, if not using the `.get()` approach, we need to have this awkward empty config parameter in the TOML file:
`[large_cohort.output_versions]`
See example config file [here](https://github.com/populationgenomics/production-pipelines-configuration/pull/31/files)