### PR TITLE
High memory workers in Combiner stage of Large Cohorts

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -5,7 +5,7 @@ scatter_count_genotype = 50
 status_reporter = 'metamist'
 # define reference fasta. If not specified here, the reference file is pulled from [references.broad][ref_fasta]
 ref_fasta='gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
-
+highmem_workers = true
 # Realign CRAM when available, instead of using FASTQ.
 # The parameter value should correspond to CRAM version
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPGaaa.cram

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -31,6 +31,8 @@ class Combiner(CohortStage):
 
         j = get_batch().new_job('Combiner', (self.get_job_attrs() or {}) | {'tool': 'hail query'})
 
+        init_batch_args = {'worker_memory': 'highmem'} if get_config()['workflow'].get('highmem_works') else None
+
         j.image(image_path('cpg_workflows'))
         j.command(
             query_command(
@@ -39,6 +41,7 @@ class Combiner(CohortStage):
                 str(self.expected_outputs(cohort)),
                 str(self.tmp_prefix),
                 setup_gcp=True,
+                init_batch_args=init_batch_args,
             ),
         )
         return self.make_outputs(cohort, self.expected_outputs(cohort), [j])


### PR DESCRIPTION
The Combiner stage was recently taken off of Dataproc (https://github.com/populationgenomics/production-pipelines/pull/621). 

Outputs from this stage when not using Dataproc were tested for consistency, however only on test-level data. Running on main has produced OOM issues that may be remedied by using high memory workers. Currently, there is a config parameter `highmem_workers` available but is only retrieved when setting up a [dataproc_job](https://github.com/populationgenomics/production-pipelines/blob/a2cdfa4de9d6b178fd285eaca0114ddec1bddb26/cpg_workflows/large_cohort/dataproc_utils.py#L103). This PR retrieves the same parameter for use in the `query_command` function that consequently uses the parameter as a batch override via `init_batch`.