### PR TITLE
Run Exomiser 14

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.14
+current_version = 1.23.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.22.14
+  VERSION: 1.23.0
 
 jobs:
   docker:

--- a/configs/defaults/exomiser.toml
+++ b/configs/defaults/exomiser.toml
@@ -7,6 +7,9 @@ exomiser_memory = '60Gi'
 exomiser_storage = '100Gi'
 exomiser_cpu = 4
 
+# change this down to 13 to select the previous version of exomiser
+exomiser_version = 14
+
 # number of exomiser jobs to fit onto each VM
 exomiser_chunk_size = 8
 

--- a/configs/defaults/exomiser.toml
+++ b/configs/defaults/exomiser.toml
@@ -2,8 +2,9 @@
 status_reporter = 'metamist'
 
 # attributes to provision the Exomiser VMs
+# Much lower storage req. - CADD & REMM not in use
 exomiser_memory = '60Gi'
-exomiser_storage = '200Gi'
+exomiser_storage = '100Gi'
 exomiser_cpu = 4
 
 # number of exomiser jobs to fit onto each VM

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -155,7 +155,7 @@ def make_phenopackets(family_dict: dict[str, list[SequencingGroup]], out_path: d
         # arbitrarily select a proband for now
         proband = affected.pop()
 
-        hpo_term_string = proband.meta['phenotypes'].get(HPO_KEY, '')
+        hpo_term_string = proband.meta['phenotypes'].get(HPO_KEY, 'HP:0000520')
 
         hpo_terms = hpo_term_string.split(',')
 

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -329,7 +329,7 @@ def run_exomiser_14(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
         job.image(image_path('exomiser_14'))
 
         # unpack references, see linux-install link above
-        job.command(f'unzip {core_group} {pheno_group} -d {exomiser_dir}/data')
+        job.command(f'unzip "{core_group}" "{pheno_group}" -d "{exomiser_dir}/data"')
 
         job.command(f'echo "This job contains families {" ".join(family_chunk)}"')
 

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -231,7 +231,8 @@ def run_exomiser_13(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
         # see https://exomiser.readthedocs.io/en/latest/installation.html#linux-install
         job = get_batch().new_bash_job(f'Run Exomiser for chunk {chunk_number}')
         all_jobs.append(job)
-        job.storage(get_config()['workflow'].get('exomiser_storage', '100Gi'))
+        # higher requirement for exomiser 13 resources
+        job.storage('200Gi')
         job.memory(get_config()['workflow'].get('exomiser_memory', '60Gi'))
         job.cpu(get_config()['workflow'].get('exomiser_cpu', 4))
         job.image(image_path('exomiser'))

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -311,8 +311,10 @@ def run_exomiser_14(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
     exomiser_dir = f'/exomiser/exomiser-cli-{exomiser_version}'
 
     # localise the compressed exomiser references
-    core_group = get_batch().read_input(reference_path('exomiser_2402_core'))
-    pheno_group = get_batch().read_input(reference_path('exomiser_2402_pheno'))
+    inputs = get_batch().read_input_group(
+        core=reference_path('exomiser_2402_core'),
+        pheno=reference_path('exomiser_2402_pheno')
+    )
 
     # now chunk the jobs - load resources, then run a bunch of families
     families = sorted(content_dict.keys())
@@ -329,7 +331,7 @@ def run_exomiser_14(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
         job.image(image_path('exomiser_14'))
 
         # unpack references, see linux-install link above
-        job.command(f'unzip "{core_group}" "{pheno_group}" -d "{exomiser_dir}/data"')
+        job.command(f'unzip {inputs}/\* -d "{exomiser_dir}/data"')
 
         job.command(f'echo "This job contains families {" ".join(family_chunk)}"')
 

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -74,7 +74,6 @@ def family_vcf_from_gvcf(family_members: list[SequencingGroup], out_path: str) -
     # -0 to replace missing with WT (potentially inaccurate, but predictable parsing in exomiser)
     # --threads 4 to use 4 threads
     # -Oz to write a compressed VCF
-    # type: ignore
     job.command(f'bcftools merge {" ".join(paths)} -Oz -o {job.output["vcf.bgz"]} --threads 4 -m all -0')
     job.command(f'tabix {job.output["vcf.bgz"]}')
     get_batch().write_output(job.output, out_path.removesuffix('.vcf.bgz'))

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -74,10 +74,10 @@ def find_families(dataset: Dataset) -> dict[str, list[SequencingGroup]]:
             get_logger(__file__).info(f'Family {family} has no affected individuals, skipping')
             continue
 
-        # check that the affected members have HPO terms - required for exomiser
-        if any([sg.meta['phenotypes'].get(HPO_KEY, '') == '' for sg in affected]):
-            get_logger(__file__).info(f'Family {family} has affected individuals with no HPO terms, skipping')
-            continue
+        # # check that the affected members have HPO terms - required for exomiser
+        # if any([sg.meta['phenotypes'].get(HPO_KEY, '') == '' for sg in affected]):
+        #     get_logger(__file__).info(f'Family {family} has affected individuals with no HPO terms, skipping')
+        #     continue
 
         # key up those badbois using an affected external ID
         dict_by_ext_id[affected[0].external_id] = members

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -17,7 +17,7 @@ from cpg_workflows.jobs.exomiser import (
     extract_mini_ped_files,
     generate_seqr_summary,
     make_phenopackets,
-    run_exomiser_batches,
+    run_exomiser_14,
 )
 from cpg_workflows.utils import get_logger
 from cpg_workflows.workflow import Dataset, DatasetStage, SequencingGroup, StageInput, StageOutput, get_workflow, stage
@@ -197,7 +197,7 @@ class RunExomiser(DatasetStage):
             for family in output_dict.keys()
         }
 
-        jobs = run_exomiser_batches(single_dict)
+        jobs = run_exomiser_14(single_dict)
 
         return self.make_outputs(dataset, data=output_dict, jobs=jobs)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.22.14',
+    version='1.23.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This implements Exomiser 14, married up with these PRs.

- https://github.com/populationgenomics/references/pull/55
- https://github.com/populationgenomics/images/pull/142

Based on developer input we're dropping CADD and REMM for default running, though code to implement these is still present in the exomiser_13 method if we need the template for the future. I've segregated the input and output folders for exomiser 13/14 so that we don't accidentally mix up results.

Test run:
https://batch.hail.populationgenomics.org.au/batches/444875/jobs/1