### PR TITLE
Remove '--merge-input-intervals' args from seqr load job commands

### DIFF
--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -249,7 +249,7 @@ def genomicsdb(
         #   using the --merge-input-intervals arg. There's no data in between since we
         #   didn't run HaplotypeCaller over those loci, so we're not wasting any
         #   compute.
-        '--merge-input-intervals',
+        # '--merge-input-intervals', # Removed because of issues when excluding intervals - EddieLF 2024-04-06
         '--consolidate',
         # The Broad:
         # > The batch_size value was carefully chosen here as it is the optimal value
@@ -367,8 +367,8 @@ def _add_joint_genotyper_job(
     --create-output-variant-index
     """
     else:
+        # --merge-input-intervals \\  # Removed from cmd because of issues when excluding intervals - EddieLF 2024-04-06
         cmd += f"""\
-    --merge-input-intervals \\
     -G AS_StandardAnnotation
 
     if [[ ! -e {j.output_vcf['vcf.gz.tbi']} ]]; then


### PR DESCRIPTION
Removes the `--merge-input-intervals` flag from the GenomicsDBImport and GenotypeGVCFs commands used by the joint genotyping jobs in the seqr loader pipeline.

#### Rationale: 
The genomes input into this pipeline had gVCF files created before we decided to exclude telomeres and centromeres from the joint genotyping stage. This means the individual gVCFs have genotypes in the excluded regions. 

When we use the `--merge-input-intervals` flag, we are merging the interval_list that **excludes** telomeres and centromeres with the intervals from the gVCFs that **include** telomeres and centromeres. The end product is an interval_list that includes telomeres and centromeres, meaning these regions are still being traversed. 

We don't want this, so hopefully removing these args from the GenomicsDB creation and GenotypeGVCFs jobs will work to prevent this.