### PR TITLE
Enable pre-commit mypy checks to typecheck cpg_utils usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,5 @@ repos:
     rev: "v1.9.0"
     hooks:
       - id: mypy
+        additional_dependencies: [cpg_utils, hail]
         args: [--pretty, --show-error-codes, --install-types, --non-interactive]


### PR DESCRIPTION
Our pre-commit hooks do not detect the error in 

```python
   input_vcf = get_batch().read_input(inputs.as_dict(cohort, FilterGenotypes)['filtered_vcf'])
   reveal_types(get_batch())
```

because the (pre-commit-local) environment in which the hooks run does not have `cpg_utils` installed, so the type returned by `get_batch()` is known only as `Any` so the first line does not get type-checked.

So the missing `read_input(str(…))` is not detected — but see also populationgenomics/cpg-utils#166 which suggests rendering that particular `str(…)` unnecessary.

Note that there are lots of minor type-checking errors lurking in the code that would have to be fixed before we can merge this PR and enable this checking!