### PR TITLE
Removing the necessity of having large_cohorts.output_versions in config files

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -64,7 +64,7 @@ class Combiner(CohortStage):
 @stage(required_stages=[Combiner])
 class SampleQC(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> Path:
-        if sample_qc_version := get_config()['large_cohort'].get('output_versions').get('sample_qc'):
+        if sample_qc_version := config_retrieve(['large_cohort', 'output_versions', 'sample_qc'], default=None):
             sample_qc_version = slugify(sample_qc_version)
 
         sample_qc_version = sample_qc_version or get_workflow().output_version
@@ -95,7 +95,7 @@ class SampleQC(CohortStage):
 @stage(required_stages=[Combiner])
 class DenseSubset(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> Path:
-        if dense_subset_version := get_config()['large_cohort'].get('output_versions').get('dense_subset'):
+        if dense_subset_version := config_retrieve(['large_cohort', 'output_versions', 'dense_subset'], default=None):
             dense_subset_version = slugify(dense_subset_version)
 
         dense_subset_version = dense_subset_version or get_workflow().output_version
@@ -128,7 +128,7 @@ class DenseSubset(CohortStage):
 @stage(required_stages=[SampleQC, DenseSubset])
 class Relatedness(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        if relatedness_version := get_config()['large_cohort'].get('output_versions').get('relatedness'):
+        if relatedness_version := config_retrieve(['large_cohort', 'output_versions', 'relatedness'], default=None):
             relatedness_version = slugify(relatedness_version)
 
         relatedness_version = relatedness_version or get_workflow().output_version


### PR DESCRIPTION
Fixes issue https://github.com/populationgenomics/production-pipelines/issues/737

Have added the new `config_retrieve()` function with a `default=None` instead of nested `.get()` methods.

Batch that succeeded: https://batch.hail.populationgenomics.org.au/batches/447653/jobs/1 (I cancelled the subsequent batch but the driver kicked). Compared to failed batch linked in the issue https://batch.hail.populationgenomics.org.au/batches/445312/jobs/1 that has the same config