### PR TITLE
Use AIP report splitting, config dependent

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.2
+current_version = 1.24.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.2
+  VERSION: 1.24.3
 
 jobs:
   docker:

--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -431,15 +431,19 @@ class CreateAIPHTML(DatasetStage):
         local_ped = get_batch().read_input(str(pedigree))
 
         expected_out = self.expected_outputs(dataset)
-        job.command(
+        command_string = (
             f'python3 reanalysis/html_builder.py '
             f'--results "{moi_inputs}" '
             f'--panelapp "{panel_input}" '
             f'--pedigree "{local_ped}" '
             f'--output "{expected_out["results_html"]}" '
             f'--latest "{expected_out["latest_html"]}" '
-            f'--dataset "{dataset.name}" ',
+            f'--dataset "{dataset.name}" '
         )
+        if report_splitting := config_retrieve(['workflow', 'report_splitting', dataset.name], False):
+            command_string += f' --split_samples {report_splitting}'
+
+        job.command(command_string)
 
         return self.make_outputs(dataset, data=expected_out, jobs=job)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.2',
+    version='1.24.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Utilises the functionality in https://github.com/populationgenomics/automated-interpretation-pipeline/pull/403

An example config structure would be:

```toml
[workflow.report_splitting]
PROJECT = 2
```

Meaning that reports generated in project `PROJECT` would be generated as normal, then 2 smaller sub-reports would be generated.

This granularity should enable each project to be either published un-split, or to be split into an arbitrary number of partitions, depending on scale of cohort.