### PR TITLE
Cast somalier_sites reference to path and take the basename

### DIFF
--- a/cpg_workflows/jobs/somalier.py
+++ b/cpg_workflows/jobs/somalier.py
@@ -2,6 +2,7 @@
 Adding jobs for fingerprinting and pedigree checks. Mostly using Somalier.
 """
 
+import os
 from typing import cast
 
 import pandas as pd
@@ -262,7 +263,7 @@ def extract(
     sites = b.read_input(reference_path('somalier_sites'))
 
     cmd = f"""\
-    SITES=$BATCH_TMPDIR/sites/{to_path(reference_path('somalier_sites')).name}
+    SITES=$BATCH_TMPDIR/sites/{os.path.basename(reference_path('somalier_sites'))}
     retry gsutil cp {reference_path('somalier_sites')} $SITES
 
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}

--- a/cpg_workflows/jobs/somalier.py
+++ b/cpg_workflows/jobs/somalier.py
@@ -262,7 +262,7 @@ def extract(
     sites = b.read_input(reference_path('somalier_sites'))
 
     cmd = f"""\
-    SITES=$BATCH_TMPDIR/sites/{reference_path('somalier_sites')}
+    SITES=$BATCH_TMPDIR/sites/{to_path(reference_path('somalier_sites')).name}
     retry gsutil cp {reference_path('somalier_sites')} $SITES
 
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}


### PR DESCRIPTION
The somalier extract jobs are failing ([e.g.](https://batch.hail.populationgenomics.org.au/batches/447718?q=state%3Dfailed)) because of changes to cpg-utils `reference_path` function. The somalier extract job was changed in [this PR](https://github.com/populationgenomics/production-pipelines/commit/c2a30ccf5afd124bf90ec836cfffab5a180ba84e#diff-c52574c0e01c6af6a6a87d93c65e9b7a21f773186cd8cfc806483cc14f52a1f6L267
). 

The `reference_path` function used to be in `cpg_utils.hail_batch`, it would return a `Path` object like so:
```python
def reference_path(key: str) -> Path:
    return to_path(retrieve(['references'] + key.strip('/').split('/')))
```

Following the update, `reference_path` (now in `cpg_utils.config`) returns a string
```python
def reference_path(key: str) -> str:
    return config_retrieve(['references', *key.strip('/').split('/')])
```

---

This change restores the `Pathlike.name` aspect of the `somalier_sites` reference path in the context of the extract job. Without this, the batch job tries to append a full `gs://` path to the batch mounted storage, leading to job failure as it tries to read `/io/batch/hash/sites/gs://cpg-common-main/references/somalier/sites.hg38.vcf.gz`.
