### PR TITLE
SGID ordering patch

### DIFF
--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -397,7 +397,8 @@ class AnnotateCNVVcfWithStrvctvre(CohortStage):
 
         # read vcf and index into the batch
         input_vcf = get_batch().read_input_group(
-            vcf=str(input_dict['annotated_vcf']), vcf_index=str(input_dict['annotated_vcf_index'])
+            vcf=str(input_dict['annotated_vcf']),
+            vcf_index=str(input_dict['annotated_vcf_index']),
         )['vcf']
 
         strv_job.declare_resource_group(output_vcf={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})


### PR DESCRIPTION
I inserted an upstream stage in the gCNV pipeline which sets a specific sample ordering, so that all joint-calling and unpacking is done using a fixed SG ID order. 

This stage didn't return the expected output paths, so during the first run for a group of samples, the SGID ordering is set, but the rest of the setup fails. The gCNV pipeline has to be started twice. This should patch that...

I've chucked a bunch of reformatting here, but the meaningful change is on line 41. The rest is just line-length changes