### PR TITLE
Force sex-unknown pedigree in gCNV

### DIFF
--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -232,7 +232,7 @@ class GCNVJointSegmentation(CohortStage):
 
         expected_out = self.expected_outputs(cohort)
 
-        ped_path = cohort.write_ped_file(expected_out['pedigree'])
+        ped_path = cohort.write_ped_file(expected_out['pedigree'], set_sex_unknown=True)
 
         jobs = gcnv.run_joint_segmentation(
             segment_vcfs=all_vcfs,

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -118,14 +118,30 @@ class Cohort(Target):
         """Unique target ID"""
         return self.name
 
-    def write_ped_file(self, out_path: Path | None = None, use_participant_id: bool = False) -> Path:
+    def write_ped_file(
+        self,
+        out_path: Path | None = None,
+        use_participant_id: bool = False,
+        set_sex_unknown: bool = False,
+    ) -> Path:
         """
         Create a PED file for all samples in the whole cohort
         PED is written with no header line to be strict specification compliant
+
+        Args:
+            out_path (Path): destination for new PED file
+            use_participant_id (bool): use participant instead of SG ID
+            set_sex_unknown (bool): if set, the pedigree entries will have unknown sex (gCNV)
+
+        Returns:
+            Path: path to the written PED file
         """
         datas = []
         for sequencing_group in self.get_sequencing_groups():
-            datas.append(sequencing_group.pedigree.get_ped_dict(use_participant_id=use_participant_id))
+            ped_data = sequencing_group.pedigree.get_ped_dict(use_participant_id=use_participant_id)
+            if set_sex_unknown:
+                ped_data['Sex'] = '0'
+            datas.append(ped_data)
         if not datas:
             raise ValueError(f'No pedigree data found for {self.name}')
         df = pd.DataFrame(datas)


### PR DESCRIPTION
We've been having a number of issues in gCNV at the Stage `GCNVJointSegmentation`

Up until this stage Ploidy is derived from the model created in `DeterminePloidy`, which runs a ploidy inference based on sequence data. This looks to be accurate.

In this stage sex/ploidy is read from a Pedigree, created from the Metamist entities. This contains the occasional sample swap/mis-assigned sex, such that the Pedigree sex isn't always accurate.

We would like to allow an override when generating the PED file, so that the sex column can be overridden to '0' for all samples. There isn't an expected requirement for using this outside of gCNV, and our preference is for updating Metamist sex with inferred sex where possible, so this is more of a patch than a long term solution.