### PR TITLE
Pin this random package to avoid pip dependency resolution backtracking

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.3
+current_version = 1.24.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.3
+  VERSION: 1.24.4
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.3',
+    version='1.24.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'hail!=0.2.120',  # Temporarily work around hail-is/hail#13337
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
+        'grpcio-status>=1.62',  # Avoid dependency resolution backtracking
         'onnx',
         'onnxruntime',
         'skl2onnx',


### PR DESCRIPTION
Initialising dataproc jobs is currently timing out, and it appears to be due to pip taking forever to install our suite of packages. 

I've reproduced pip taking forever to install cpg-workflows (alone) on a local Linux VM, and by reading [this pip info](https://pip.pypa.io/en/stable/topics/dependency-resolution/#possible-ways-to-reduce-backtracking) was able to resolve it by pinning to allow only recent versions of the first package that I saw pip trying to download dozens of versions of in its attempts to satisfy vague constraints.

Adding this reduced the time for `pip install cog-workflows` to < 1 minute, but there may be additional problems as well when other packages are added to the mix…

Background: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1715819263267179

This seems to have some similarity to #510, in which we had to add some packages we had never heard of to ensure prerequisites of prerequisites were installed and the tests would run.