### PR TITLE
Temporarily pin hail 0.2.126 until we update to a job-groups-capable hail

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.4
+current_version = 1.24.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.4
+  VERSION: 1.24.5
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -16,16 +16,16 @@ setup(
         'cpg-utils>=5.0.4',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        'hail!=0.2.120',  # Temporarily work around hail-is/hail#13337
+        'hail==0.2.126',  # Temporarily pin a pre-job-groups Hail version
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
-        'grpcio-status>=1.62',  # Avoid dependency resolution backtracking
+        'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking
         'onnx',
         'onnxruntime',
         'skl2onnx',
         'metamist>=6.9.0',
         'pandas',
-        'peddy',
+        'peddy>=0.4.8',  # Avoid 0.4.7, which is incompatible
         'fsspec',
         'slack_sdk',
         'elasticsearch==8.*',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.4',
+    version='1.24.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Also temporarily update a couple of other pinnings, so that pip gets a **correct** solution in a **finite amount** of time. Specifically:

* Revert grpcio-status to a version that is compatible with hail 0.2.126 (this matches 1.48.2, which was in the previous working cpg-workflows 1.24.3 container), but keep bounds on it to help pip runtime.
* Ensure we get the usual version of peddy. Unassisted pip selects 0.4.7, which is incompatible with other packages in the set.

Aarrrggghh.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1715914091168629?thread_ts=1715819263.267179&cid=C030X7WGFCL