### PR TITLE
WALRUS!

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -568,7 +568,7 @@ class UpdateStructuralVariantIDs(CohortStage):
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
 
         # allow for no prior name/IDs
-        if spicy_vcf := query_for_spicy_vcf(cohort.analysis_dataset.name) is None:
+        if (spicy_vcf := query_for_spicy_vcf(cohort.analysis_dataset.name)) is None:
             get_logger().info('No previous Spicy VCF found for {cohort.analysis_dataset.name}')
             return self.make_outputs(cohort, skipped=True)
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -568,7 +568,7 @@ class UpdateStructuralVariantIDs(CohortStage):
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
 
         # allow for no prior name/IDs
-        if (spicy_vcf := query_for_spicy_vcf(cohort.analysis_dataset.name)) is None:
+        if not (spicy_vcf := query_for_spicy_vcf(cohort.analysis_dataset.name)):
             get_logger().info('No previous Spicy VCF found for {cohort.analysis_dataset.name}')
             return self.make_outputs(cohort, skipped=True)
 


### PR DESCRIPTION
Previous code:

```
if spicy_vcf := query_for_spicy_vcf(cohort.analysis_dataset.name) is None:
   ...
```

result - if a file was returned, `spicy_vcf` is set to False, instead of the file name

Changed to: 

```
if (spicy_vcf := query_for_spicy_vcf(cohort.analysis_dataset.name)) is None:
    ...
```

result - if a file was returned, `spicy_vcf` will, in fact, be the spicy vcf 🌶️ 