### PR TITLE
Make srtipy print verbose logging 

### DIFF
--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -72,6 +72,7 @@ def stripy(
     # quick an dirty edit of the default config on the fly and cat to the job log.
     sed 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' config.json \
         | sed 's/"output_json": false/"output_json": true/' \
+        | sed 's/]/],\n"verbose": true/' \
         > $BATCH_TMPDIR/config.json
     cat $BATCH_TMPDIR/config.json
 


### PR DESCRIPTION
By default Stripy will swallow errors making trouble shooting errors impossible. Setting verbose to true in the config results in exceptions being printed to stderr - a helpful thing.

Even with verbose set, logging volume is low.