### PR TITLE
Update stripy logging command

### DIFF
--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -72,7 +72,7 @@ def stripy(
     # quick an dirty edit of the default config on the fly and cat to the job log.
     sed 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' config.json \
         | sed 's/"output_json": false/"output_json": true/' \
-        | sed 's/]/],\n"verbose": true/' \
+        | sed 's|]|],\n"verbose": true|' \
         > $BATCH_TMPDIR/config.json
     cat $BATCH_TMPDIR/config.json
 


### PR DESCRIPTION
Batch job failure message:
```
+ sed 's/"log_flag_threshold": 1/"log_flag_threshold": -1/' config.json
+ sed 's/"output_json": false/"output_json": true/'
+ sed 's/]/],
"verbose": true/'
sed: -e expression #1, char 6: unterminated `s' command
```

I asked Claude 3

> The issue with the command is in the third `sed` command. The problem is that the `/` character is used as the delimiter for the `s` (substitute) command in `sed`, but you also have a `/` character within the replacement string. This confuses `sed` and causes it to think the command is unterminated.
> To fix this, you can use a different delimiter for the `s` command, such as `|`, which is not present in your replacement string.