### PR TITLE
Move SV ID updates to post annotation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.7
+current_version = 1.24.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.7
+  VERSION: 1.24.8
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -420,7 +420,7 @@ def joint_segment_vcfs(
     segment_vcfs: list[ResourceFile],
     pedigree: ResourceFile,
     reference: ResourceGroup,
-    intervals: ResourceFile,  # hmm,
+    intervals: ResourceFile,
     title: str,
     job_attrs: dict,
 ) -> tuple[Job, ResourceGroup]:
@@ -475,9 +475,6 @@ def run_joint_segmentation(
     Depending on the config setting workflow.num_samples_per_scatter_block
     this may be conducted in hierarchical 2-step, with intermediate merges
     being conducted, then a merge of those intermediates
-
-    Returns:
-
     """
 
     if can_reuse(output_path):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.7',
+    version='1.24.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
AnnotateVcf rearranges the variants by ID. I think it does some splitting weirdness to annotate each different variant type separately, then re-join, and at some point during that process there's a sort on ID.

The process we currently have:
  - FilterGenotypes produces the final VCF
  - If a prior VCF is available, `UpdateStructuralVariantIDs` runs on that result, otherwise it does not run
  - `SpiceUpSVIDs` runs, updating IDs to match a corresponding variant in a prior dataset - it either runs on the output of `FilterGenotypes` or `UpdateStructuralVariantIDs`, depending if the latter was invoked
  - Annotation, etc.

The process we need:

  - FilterGenotypes produces the final VCF
  - If a prior VCF is available, `UpdateStructuralVariantIDs` runs on that result, otherwise it does not run
  - Annotation, etc. - either runs on the output of `FilterGenotypes` or `UpdateStructuralVariantIDs`, depending if the latter was invoked
  - `SpiceUpSVIDs` runs, updating IDs to match a corresponding variant in a prior dataset - it runs on the output of `AnnotateVcfWithStrvctvre`, and either uses the 'truth IDs' embedded in the VCF info (if `UpdateStructuralVariantIDs` was run), or it generates new IDs based on variant attributes. If `UpdateStructuralVariantIDs` runs and there was no 'Truth ID' found for a variant, an ID is generated for it deterministically based on variant attributes, following the same logic for that variant as if there had been no update/concordance test

Basically, update the `TRUTH_VID` variant annotations before passing through annotation, but only update the actual VCF ID field with that information post-annotation.

Note to future self: an optimised version of this process could be - run the whole SV workflow through to annotation as normal, then (based on a sites-only version of the spicy VCF for `super` optimisation) run the SV concordance check, then update the VCF IDs. 

This version which updates the `TRUTH_VID` attributes pre-annotation but doesn't apply them until post-annotation is disjointed, but operates each stage on the smallest data possible. 99% of the VCF 'weight' is in the genotypes rather than the annotation, so I don't think there's much benefit to this PR's implementation, other than it ensures that we don't in any way interfere with VCF annotations until the consequence annotation has taken place
