### PR TITLE
Spiced Up ID analysis entries needs to be consistent

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -720,8 +720,8 @@ class SpiceUpSVIDs(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
-            'new_id_vcf': self.prefix / 'fresh_ids_post_annotation.vcf.bgz',
-            'new_id_index': self.prefix / 'fresh_ids_post_annotation.vcf.bgz.tbi',
+            'new_id_vcf': self.prefix / 'fresh_ids.vcf.bgz',
+            'new_id_index': self.prefix / 'fresh_ids.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:


### PR DESCRIPTION
I changed the SpicyVCF output name to differentiate the files before/after the latest change. That was silly, the database query relies on the files having the same names, so we'd lose the connection to previous runs. 

Forcing a re-run can be accomplished instead through deactivating the dodgy analysis entries, and/or forcing stages where the execution order has now been changed to rerun in the latest callset (through config)