### PR TITLE
Castrate aneuploidies

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.8
+current_version = 1.24.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.8
+  VERSION: 1.24.9
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -43,7 +43,8 @@ def upgrade_ped_file(local_ped: ResourceFile, new_output: str, aneuploidies: str
 
 def prepare_intervals(job_attrs: dict[str, str], output_paths: dict[str, Path]) -> Job:
     j = get_batch().new_job(
-        'Prepare intervals', job_attrs | {'tool': 'gatk PreprocessIntervals/AnnotateIntervals'},
+        'Prepare intervals',
+        job_attrs | {'tool': 'gatk PreprocessIntervals/AnnotateIntervals'},
     )
     j.image(image_path('gatk_gcnv'))
 
@@ -544,13 +545,15 @@ def trim_sex_chromosomes(sgid: str, sg_vcf: str, no_xy_vcf: str, job_attrs: dict
     job.image(image_path('bcftools'))
     job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
     localised_vcf = get_batch().read_input(sg_vcf)
-    job.command(f"""
+    job.command(
+        f"""
     bcftools view {localised_vcf} \
     chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 \
     chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chr20 chr21 chr22 \
     | bgzip -c > {job.output['vcf.bgz']}
     tabix {job.output['vcf.bgz']}
-    """)
+    """
+    )
     get_batch().write_output(job.output, no_xy_vcf.removesuffix('.vcf.bgz'))
     return job
 

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -1,13 +1,14 @@
 """
 Jobs that implement GATK-gCNV.
 """
+
 from collections.abc import Iterable
 
 from hailtop.batch.job import BashJob, Job
-from hailtop.batch.resource import JobResourceFile, ResourceFile, ResourceGroup, Resource
+from hailtop.batch.resource import JobResourceFile, Resource, ResourceFile, ResourceGroup
 
 from cpg_utils import Path
-from cpg_utils.config import get_config, image_path, config_retrieve
+from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import command, fasta_res_group, get_batch, query_command
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.query_modules import seqr_loader, seqr_loader_cnv
@@ -394,7 +395,7 @@ def postprocess_calls(
             echo "EXCESSIVE_NUMBER_OF_EVENTS" >> {j.qc_file}
         fi
         cat {j.qc_file}
-        """
+        """,
         )
         get_batch().write_output(j.qc_file, qc_file)
 
@@ -668,7 +669,7 @@ def annotate_dataset_jobs_cnv(
     sgids: list[str],
     out_mt_path: Path,
     tmp_prefix: Path,
-    job_attrs: dict | None = None
+    job_attrs: dict | None = None,
 ) -> list[Job]:
     """
     Split mt by dataset and annotate dataset-specific fields (only for those datasets

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -15,8 +15,7 @@ def annotate_cohort_jobs_sv(
     vcf_path: Path,
     out_mt_path: Path,
     checkpoint_prefix: Path,
-    job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None,
+    job_attrs: dict | None = None
 ) -> Job:
     """
     Annotate cohort for seqr loader, SV style.
@@ -35,8 +34,6 @@ def annotate_cohort_jobs_sv(
             setup_gcp=True,
         ),
     )
-    if depends_on:
-        j.depends_on(*depends_on)
     return j
 
 
@@ -46,7 +43,6 @@ def annotate_dataset_jobs_sv(
     out_mt_path: Path,
     tmp_prefix: Path,
     job_attrs: dict | None = None,
-    depends_on: list[Job] | None = None,
     exclusion_file: str | None = None,
 ) -> list[Job]:
     """
@@ -82,8 +78,6 @@ def annotate_dataset_jobs_sv(
             setup_gcp=True,
         ),
     )
-    if depends_on:
-        subset_j.depends_on(*depends_on)
 
     annotate_j = get_batch().new_job('annotate dataset', (job_attrs or {}) | {'tool': 'hail query'})
     annotate_j.image(image_path('cpg_workflows'))

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -15,7 +15,7 @@ def annotate_cohort_jobs_sv(
     vcf_path: Path,
     out_mt_path: Path,
     checkpoint_prefix: Path,
-    job_attrs: dict | None = None
+    job_attrs: dict | None = None,
 ) -> Job:
     """
     Annotate cohort for seqr loader, SV style.

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_2.py
@@ -777,7 +777,6 @@ class AnnotateCohortSv(CohortStage):
             out_mt_path=self.expected_outputs(cohort)['mt'],
             checkpoint_prefix=checkpoint_prefix,
             job_attrs=self.get_job_attrs(cohort),
-            depends_on=inputs.get_jobs(cohort),
         )
 
         return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=job)
@@ -826,7 +825,6 @@ class AnnotateDatasetSv(DatasetStage):
             out_mt_path=self.expected_outputs(dataset)['mt'],
             tmp_prefix=checkpoint_prefix,
             job_attrs=self.get_job_attrs(dataset),
-            depends_on=inputs.get_jobs(dataset),
             exclusion_file=str(exclusion_file),
         )
 
@@ -904,11 +902,9 @@ class MtToEsSv(DatasetStage):
                 num_workers=2,
                 num_secondary_workers=0,
                 job_name=job_name,
-                depends_on=inputs.get_jobs(dataset),
                 scopes=['cloud-platform'],
                 pyfiles=pyfiles,
             )
         j._preemptible = False
         j.attributes = (j.attributes or {}) | {'tool': 'hailctl dataproc'}
-        jobs = [j]
-        return self.make_outputs(dataset, data=index_name, jobs=jobs)
+        return self.make_outputs(dataset, data=index_name, jobs=j)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -15,7 +15,7 @@ from cpg_workflows.query_modules import seqr_loader_cnv
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_images, get_references, queue_annotate_sv_jobs
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.targets import Cohort, SequencingGroup
-from cpg_workflows.utils import get_logger, ExpectedResultT
+from cpg_workflows.utils import ExpectedResultT, get_logger
 from cpg_workflows.workflow import (
     CohortStage,
     Dataset,
@@ -270,8 +270,9 @@ class TrimOffSexChromosomes(CohortStage):
         return self.make_outputs(cohort, data=expected, jobs=jobs)  # type: ignore
 
 
-
-@stage(required_stages=[TrimOffSexChromosomes, SetSGIDOrdering, GermlineCNVCalls, PrepareIntervals, UpgradePedWithInferred])
+@stage(
+    required_stages=[TrimOffSexChromosomes, SetSGIDOrdering, GermlineCNVCalls, PrepareIntervals, UpgradePedWithInferred],
+)
 class GCNVJointSegmentation(CohortStage):
     """
     various config elements scavenged from https://github.com/broadinstitute/gatk/blob/cfd4d87ec29ac45a68f13a37f30101f326546b7d/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json#L26

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -586,7 +586,7 @@ class AnnotateDatasetCNV(DatasetStage):
             sgids=dataset.get_sequencing_group_ids(),
             out_mt_path=self.expected_outputs(dataset)['mt'],
             tmp_prefix=checkpoint_prefix,
-            job_attrs=self.get_job_attrs(dataset)
+            job_attrs=self.get_job_attrs(dataset),
         )
 
         return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=jobs)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -15,7 +15,7 @@ from cpg_workflows.query_modules import seqr_loader_cnv
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_images, get_references, queue_annotate_sv_jobs
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.targets import Cohort, SequencingGroup
-from cpg_workflows.utils import ExpectedResultT, get_logger
+from cpg_workflows.utils import get_logger
 from cpg_workflows.workflow import (
     CohortStage,
     Dataset,

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -248,6 +248,10 @@ class TrimOffSexChromosomes(CohortStage):
                     # find the SGID
                     sgid = line.strip()
 
+                    # could be an empty newline
+                    if not sgid:
+                        continue
+
                     # log an expected output
                     return_dict[sgid] = self.prefix / f'{sgid}.segments.vcf.bgz'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.8',
+    version='1.24.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR needs a new name. 

The issue: We have data which identifies sex-aneuploidies, gCNV/GATK can only tolerate XX/XY data, and we have no way to remove the data which will cause failures.

The solution? A solution?

- When we update the pedigree file with inferred sex, keep a list of all samples which are not XX/XY
- For each of those SGIDs identified, generate a version of the VCF (& index) with chrX & chrY removed entirely
- When running joint-segmentation, if the VCF was stripped of sex chr data, use the trimmed version, otherwise use the default version

Note: because the workflow needs to be defined in advance in Hail Batch, this design means that a run will need to fail once:

- run for the first time, including generating the updated pedigree and finding any sex-aneuploid samples
- if the samples can't all be processed, the run will die
- upon re-running, the sex-aneuploidy file will be read, new trimmed VCFs will be generated for the relevant samples, and the GCNVJointSegmentation stage will run with the trimmed VCFs as appropriate