### PR TITLE
Pass index into xy removal

### DIFF
--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -535,7 +535,7 @@ def trim_sex_chromosomes(sgid: str, sg_vcf: str, no_xy_vcf: str, job_attrs: dict
     job = get_batch().new_bash_job(f'remove sex chromosomes from {sgid}', job_attrs | {'tool': 'bcftools'})
     job.image(image_path('bcftools'))
     job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-    localised_vcf = get_batch().read_input(sg_vcf)
+    localised_vcf = get_batch().read_input_group(**{'vcf.gz': sg_vcf, 'vcf.gz.tbi': f'{sg_vcf}.tbi'})['vcf.gz']
     autosomes = ' '.join([f'chr{i}' for i in range(1, 23)])
     job.command(f'bcftools view {localised_vcf} {autosomes} | bgzip -c > {job.output["vcf.bgz"]}')  # type: ignore
     job.command(f'tabix {job.output["vcf.bgz"]}')  # type: ignore

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -537,6 +537,7 @@ def trim_sex_chromosomes(sgid: str, sg_vcf: str, no_xy_vcf: str, job_attrs: dict
     job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
     localised_vcf = get_batch().read_input_group(**{'vcf.gz': sg_vcf, 'vcf.gz.tbi': f'{sg_vcf}.tbi'})['vcf.gz']
     autosomes = ' '.join([f'chr{i}' for i in range(1, 23)])
+    job.command('set -euo pipefail')
     job.command(f'bcftools view {localised_vcf} {autosomes} | bgzip -c > {job.output["vcf.bgz"]}')  # type: ignore
     job.command(f'tabix {job.output["vcf.bgz"]}')  # type: ignore
     get_batch().write_output(job.output, no_xy_vcf.removesuffix('.vcf.bgz'))

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -316,14 +316,13 @@ class GCNVJointSegmentation(CohortStage):
         sgid_ordering = json.load(inputs.as_path(get_cohort(), SetSGIDOrdering, 'sgid_order').open())
 
         # for each SGID, either get the sex chrom-trimmed one, or the default
-        # fail if
         all_vcfs: list[str] = []
         for sgid in sgid_ordering:
             if sgid in trimmed_vcfs:
-                get_logger().info(f'Using trimmed VCF for {sgid}')
+                get_logger().info(f'Using XY-trimmed VCF for {sgid}')
                 all_vcfs.append(str(trimmed_vcfs[sgid]))
             elif sgid in cnv_vcfs:
-                get_logger().info(f'Using standard VCF for {sgid}')
+                get_logger().warning(f'Using standard VCF for {sgid}')
                 all_vcfs.append(str(cnv_vcfs[sgid]['segments']))
             else:
                 raise ValueError(f'No VCF found for {sgid}')


### PR DESCRIPTION
A bit of oversight here - we can't do region-specific BCFtools filtering unless we have the index present

- passes in the index file
- sets `pipefail` on the bcftools job (the process failed, but didn't cause a pipeline failure)