### PR TITLE
Pin Hail to the version deployed in CPG's installation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.9
+current_version = 1.24.10
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.9
+  VERSION: 1.24.10
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.9',
+    version='1.24.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -16,16 +16,16 @@ setup(
         'cpg-utils>=5.0.4',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        'hail==0.2.126',  # Temporarily pin a pre-job-groups Hail version
+        'hail==0.2.130',  # Pin Hail at CPG's installed version
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
-        'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking
+        'grpcio-status>=1.62',  # Avoid dependency resolution backtracking
         'onnx',
         'onnxruntime',
         'skl2onnx',
         'metamist>=6.9.0',
         'pandas',
-        'peddy>=0.4.8',  # Avoid 0.4.7, which is incompatible
+        'peddy',
         'fsspec',
         'slack_sdk',
         'elasticsearch==8.*',


### PR DESCRIPTION
Followup to PRs #749 and #750: Pin this major dependency to avoid ever picking up an incompatible version. Change grpcio-status pinning to versions that are compatible with hail 0.2.130, but keep bounds on it to help pip runtime. We should no longer need anything special for peddy.