### PR TITLE
No need to run gsutil inside the job

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.11
+current_version = 1.24.12
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.11
+  VERSION: 1.24.12
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -322,9 +322,11 @@ def postprocess_calls(
     model_shard_args = ''
     calls_shard_args = ''
 
-    # forced ordering here just in case
+    # import with hail batch instead, then unpack in the container. No need to depend on a gcloud/gsutil install
+    # https://batch.hail.populationgenomics.org.au/batches/454143/jobs/1
     for name, path in [(shard, shard_paths[shard]) for shard in shard_basenames()]:
-        gcp_related_commands.append(f'gsutil cat {path} | tar -xz -C $BATCH_TMPDIR/inputs')
+        shard_tar = get_batch().read_input(str(path))
+        gcp_related_commands.append(f'tar -xzf {shard_tar} -C $BATCH_TMPDIR/inputs')
         model_shard_args += f' --model-shard-path $BATCH_TMPDIR/inputs/{name}-model'
         calls_shard_args += f' --calls-shard-path $BATCH_TMPDIR/inputs/{name}-calls'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.11',
+    version='1.24.12',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Authentication is breaking when gsutil runs. That's an issue we should solve more generally, but for this process there's no need to use gsutil (we do a read_input/un-tar just a few lines before, that works fine)