### PR TITLE
Joint genotyping fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.12
+current_version = 1.24.13
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.12
+  VERSION: 1.24.13
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -123,6 +123,7 @@ def make_joint_genotyping_jobs(
             b,
             genomicsdb_path=genomicsdb_path,
             interval=interval,
+            exclude_intervals_path=exclude_intervals_path,
             tool=tool,
             output_vcf_path=jc_vcf_path,
             job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
@@ -249,7 +250,7 @@ def genomicsdb(
         #   using the --merge-input-intervals arg. There's no data in between since we
         #   didn't run HaplotypeCaller over those loci, so we're not wasting any
         #   compute.
-        # '--merge-input-intervals', # Removed because of issues when excluding intervals - EddieLF 2024-04-06
+        '--merge-input-intervals',
         '--consolidate',
         # The Broad:
         # > The batch_size value was carefully chosen here as it is the optimal value
@@ -291,6 +292,7 @@ def _add_joint_genotyper_job(
     b: hb.Batch,
     genomicsdb_path: Path,
     interval: hb.Resource | None = None,
+    exclude_intervals_path: Path | None = None,
     output_vcf_path: Path | None = None,
     tool: JointGenotyperTool = JointGenotyperTool.GnarlyGenotyper,
     job_attrs: dict | None = None,
@@ -359,6 +361,7 @@ def _add_joint_genotyper_job(
     -D {reference_path('broad/dbsnp_vcf')} \\
     -V $WORKSPACE \\
     {f'-L {interval} ' if interval else ''} \\
+    -XL {exclude_intervals_path} \\
     --only-output-calls-starting-in-intervals \\
     """
     if tool == JointGenotyperTool.GnarlyGenotyper:

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -123,7 +123,6 @@ def make_joint_genotyping_jobs(
             b,
             genomicsdb_path=genomicsdb_path,
             interval=interval,
-            exclude_intervals_path=exclude_intervals_path,
             tool=tool,
             output_vcf_path=jc_vcf_path,
             job_attrs=(job_attrs or {}) | dict(part=f'{idx + 1}/{scatter_count}'),
@@ -292,7 +291,6 @@ def _add_joint_genotyper_job(
     b: hb.Batch,
     genomicsdb_path: Path,
     interval: hb.Resource | None = None,
-    exclude_intervals_path: Path | None = None,
     output_vcf_path: Path | None = None,
     tool: JointGenotyperTool = JointGenotyperTool.GnarlyGenotyper,
     job_attrs: dict | None = None,
@@ -361,7 +359,6 @@ def _add_joint_genotyper_job(
     -D {reference_path('broad/dbsnp_vcf')} \\
     -V $WORKSPACE \\
     {f'-L {interval} ' if interval else ''} \\
-    -XL {exclude_intervals_path} \\
     --only-output-calls-starting-in-intervals \\
     """
     if tool == JointGenotyperTool.GnarlyGenotyper:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.12',
+    version='1.24.13',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR adds the `--merge-input-intervals` flag back in for the `GenomicsDB` jobs, and leaves it commented out for the `GenotypeGVCFs` jobs.

---

Recently we made some changes to this pipeline to allow the GenotypeGVCFs jobs to skip over centromeres and telomeres. This included removing the `--merge-input-intervals` flag from the commands used by the `GenomicsDB` and `GenotypeGVCFs` jobs. 

The reason this needed to be removed was because our GVCFs were created by genotyping all intervals, including centromeres and telomeres. So when the jobs "merged input intervals", the final interval list included those regions. 

This has inadvertendly caused the `GenomicsDB` jobs to take an extremely long time to run. See the recent batch: https://batch.hail.populationgenomics.org.au/batches/454669 - the jobs are not even close to completing after several hours. There are also warnings at the top of the logs:
```
03:18:00.835 WARN  GenomicsDBImport - A large number of intervals were specified. Using more than 100 intervals in a single import is not recommended and can cause performance to suffer. If GVCF data only exists within those intervals, performance can be improved by aggregating intervals with the merge-input-intervals argument.
03:18:01.080 WARN  GenomicsDBImport - GenomicsDBImport cannot use multiple VCF reader threads for initialization when the number of intervals is greater than 1. Falling back to serial VCF reader initialization.
```

Contrast this with the previous run, where the `GenomicsDB` jobs took only a few minutes to run: https://batch.hail.populationgenomics.org.au/batches/444407

---


I'm not really sure if this change will be enough to prevent the telomeres / centromeres flowing into the `GenotypeGVCFs` jobs that come after the `GenomicsDB` ones. One other possible change is to use the `--exclude-intervals / -XL` flag in the `GenotypeGVCFs` jobs. This way, we can pass our list of excluded regions (`hg38.telomeresAndMergedCentromeres.interval_list`) to each `GenotypeGVCFs` job, hard excluding the regions for every job. Maybe this part is not necessary, and all that's needed is the change to the GenomicsDB command. Throwing it out there for discussion. [Link to GATK docs](https://gatk.broadinstitute.org/hc/en-us/articles/360037057852-GenotypeGVCFs), cmd + f for "--exclude-intervals"