### PR TITLE
remove "dataset =" from configs

### DIFF
--- a/configs/defaults/gatk_sv_multisample_1.toml
+++ b/configs/defaults/gatk_sv_multisample_1.toml
@@ -1,7 +1,5 @@
 [workflow]
 name = 'gatk_sv'
-dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 status_reporter = 'metamist'
 

--- a/configs/defaults/gatk_sv_multisample_2.toml
+++ b/configs/defaults/gatk_sv_multisample_2.toml
@@ -1,7 +1,5 @@
 [workflow]
 name = 'gatk_sv'
-dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 status_reporter = 'metamist'
 

--- a/configs/defaults/gatk_sv_sandwich.toml
+++ b/configs/defaults/gatk_sv_sandwich.toml
@@ -1,5 +1,3 @@
 [workflow]
 name = 'gatk_sv'
-dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 status_reporter = 'metamist'

--- a/configs/defaults/gatk_sv_singlesample.toml
+++ b/configs/defaults/gatk_sv_singlesample.toml
@@ -1,7 +1,5 @@
 [workflow]
 name = 'gatk_sv'
-dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 status_reporter = 'metamist'
 

--- a/configs/defaults/pre_alignment.toml
+++ b/configs/defaults/pre_alignment.toml
@@ -1,7 +1,6 @@
 [workflow]
 name = 'pre_alignment'
 dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 status_reporter = 'metamist'
 
 [hail]

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -1,7 +1,5 @@
 [workflow]
 name = 'seqr_loader'
-dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 status_reporter = 'metamist'
 
 # Use GnarlyGenotyper instead of GenotypeGVCFs

--- a/configs/defaults/seqr_loader_long_read.toml
+++ b/configs/defaults/seqr_loader_long_read.toml
@@ -1,6 +1,5 @@
 [workflow]
 name = 'seqr_loader_long_read'
 dataset_gcp_project = 'seqr-308602'
-dataset = 'seqr'
 status_reporter = 'metamist'
 bam_to_cram_analysis_type = 'pacbio_cram'


### PR DESCRIPTION
We do a little copy-pasting, and we've been setting `dataset` and `dataset_gcp_project` in the default configs.

At best this is harmless, as the default configs are loaded first, then overridden by the analysis-runner defaults, then any manually specified configs.

At worst (if one of these configs is picked manually as a `--config` CLI arg) the dataset/gcp project will be overridden at runtime, leading to errors (https://batch.hail.populationgenomics.org.au/batches/454726/jobs/1 as an example)