### PR TITLE
Trim analysis callables

### DIFF
--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -29,12 +29,7 @@ def stripy(
     """
     Run STRipy
     """
-    if can_reuse(
-        [
-            out_path,
-        ],
-        overwrite,
-    ):
+    if can_reuse(out_path, overwrite):
         return None
 
     job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
@@ -46,7 +41,6 @@ def stripy(
     # Stripy accesses a relatively small number of discrete regions from each cram
     # accessing the cram via cloudfuse is faster than localising the full cram
     bucket = cram_path.path.drive
-    print(f'bucket = {bucket}')
     bucket_mount_path = to_path('/bucket')
     j.cloudfuse(bucket, str(bucket_mount_path), read_only=True)
     mounted_cram_path = bucket_mount_path / '/'.join(cram_path.path.parts[2:])

--- a/cpg_workflows/jobs/vep.py
+++ b/cpg_workflows/jobs/vep.py
@@ -176,7 +176,7 @@ def vep_one(
     vep_image = image_path(f'vep_{vep_version}')
     vep_mount_path = to_path(reference_path(f'vep_{vep_version}_mount'))
     assert all([vep_image, vep_mount_path])
-    logging.info(f'Using VEP {vep_version}')
+    logging.debug(f'Using VEP {vep_version}')
 
     j = b.new_job('VEP', (job_attrs or {}) | dict(tool=f'VEP {vep_version}'))
     j.image(vep_image)

--- a/cpg_workflows/stages/aip.py
+++ b/cpg_workflows/stages/aip.py
@@ -330,7 +330,6 @@ class RunHailSVFiltering(DatasetStage):
     required_stages=[GeneratePED, GeneratePanelData, QueryPanelapp, RunHailFiltering, RunHailSVFiltering],
     analysis_type='aip-results',
     analysis_keys=['summary_json'],
-    update_analysis_meta=lambda x: {'type': 'aip_output_json'},
 )
 class ValidateMOI(DatasetStage):
     """
@@ -404,7 +403,6 @@ class ValidateMOI(DatasetStage):
     required_stages=[GeneratePED, ValidateMOI, QueryPanelapp, RunHailFiltering],
     analysis_type='aip-report',
     analysis_keys=['results_html', 'latest_html'],
-    update_analysis_meta=lambda x: {'type': 'aip_output_html'},
     tolerate_missing_output=True,
 )
 class CreateAIPHTML(DatasetStage):

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -64,20 +64,6 @@ def create_polling_intervals() -> dict:
     return polling_interval_dict
 
 
-def _sv_batch_meta(output_path: str) -> dict[str, Any]:
-    """
-    Callable, add meta[type] to custom analysis object
-    """
-    return {'type': 'gatk-sv-batch-calls'}
-
-
-def _sv_individual_meta(output_path: str) -> dict[str, Any]:
-    """
-    Callable, add meta[type] to custom analysis object
-    """
-    return {'type': 'gatk-sv-sequence-group-calls'}
-
-
 def get_fasta() -> Path:
     """
     find or return the fasta to use

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample_1.py
@@ -13,7 +13,6 @@ from cpg_utils.config import AR_GUID_NAME, config_retrieve, try_get_ar_guid
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     SV_CALLERS,
     CromwellJobSizes,
-    _sv_batch_meta,
     add_gatk_sv_jobs,
     get_fasta,
     get_images,
@@ -497,7 +496,6 @@ class MergeBatchSites(CohortStage):
     required_stages=[FilterBatch, GatherBatchEvidence],
     analysis_type='sv',
     analysis_keys=[f'genotyped_{mode}_vcf' for mode in ['pesr', 'depth']],
-    update_analysis_meta=_sv_batch_meta,
 )
 class GenotypeBatch(CohortStage):
     """

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -12,7 +12,6 @@ from cpg_workflows.jobs import sample_batching
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     SV_CALLERS,
     CromwellJobSizes,
-    _sv_individual_meta,
     add_gatk_sv_jobs,
     get_fasta,
     get_images,
@@ -29,11 +28,7 @@ from cpg_workflows.workflow import (
 )
 
 
-@stage(
-    analysis_keys=[f'{caller}_vcf' for caller in SV_CALLERS],
-    analysis_type='sv',
-    update_analysis_meta=_sv_individual_meta,
-)
+@stage(analysis_keys=[f'{caller}_vcf' for caller in SV_CALLERS], analysis_type='sv')
 class GatherSampleEvidence(SequencingGroupStage):
     """
     https://github.com/broadinstitute/gatk-sv#gathersampleevidence

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -423,12 +423,7 @@ class FastCombineGCNVs(CohortStage):
         return self.make_outputs(cohort, data=outputs, jobs=job_or_none)
 
 
-@stage(
-    required_stages=FastCombineGCNVs,
-    analysis_type='cnv',
-    analysis_keys=['annotated_vcf'],
-    update_analysis_meta=lambda x: {'type': 'gCNV-annotated'},
-)
+@stage(required_stages=FastCombineGCNVs, analysis_type='cnv', analysis_keys=['annotated_vcf'])
 class AnnotateCNV(CohortStage):
     """
     Smaller, direct annotation using SvAnnotate
@@ -473,12 +468,7 @@ class AnnotateCNV(CohortStage):
         return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
 
 
-@stage(
-    required_stages=AnnotateCNV,
-    analysis_type='cnv',
-    analysis_keys=['strvctvre_vcf'],
-    update_analysis_meta=lambda x: {'type': 'gCNV-STRVCTCRE-annotated'},
-)
+@stage(required_stages=AnnotateCNV, analysis_type='cnv', analysis_keys=['strvctvre_vcf'])
 class AnnotateCNVVcfWithStrvctvre(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -3,7 +3,6 @@ Stages that generates and summarises GVCF QC.
 """
 
 import logging
-from typing import Any
 
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve
@@ -96,25 +95,7 @@ class GvcfHappy(SequencingGroupStage):
             return self.make_outputs(sequencing_group, self.expected_outputs(sequencing_group), jobs)
 
 
-def _update_meta(output_path: str) -> dict[str, Any]:
-    import json
-
-    from cloudpathlib import CloudPath
-
-    with CloudPath(output_path).open() as f:
-        d = json.load(f)
-    return {'multiqc': d['report_general_stats_data']}
-
-
-@stage(
-    required_stages=[
-        GvcfQC,
-        GvcfHappy,
-    ],
-    analysis_type='qc',
-    analysis_keys=['json'],
-    update_analysis_meta=_update_meta,
-)
+@stage(required_stages=[GvcfQC, GvcfHappy], analysis_type='qc', analysis_keys=['json'])
 class GvcfMultiQC(DatasetStage):
     """
     Run MultiQC to summarise all GVCF QC.

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -12,7 +12,6 @@ from cpg_workflows.jobs.validation import (
     run_happy_on_vcf,
     validation_mt_to_vcf_job,
 )
-from cpg_workflows.stages.seqr_loader import _sg_vcf_meta
 from cpg_workflows.workflow import (
     SequencingGroup,
     SequencingGroupStage,
@@ -22,14 +21,10 @@ from cpg_workflows.workflow import (
     stage,
 )
 
-from .. import get_batch
+from cpg_utils.hail_batch import get_batch
 
 
-@stage(
-    analysis_type='custom',
-    update_analysis_meta=_sg_vcf_meta,
-    analysis_keys=['vcf'],
-)
+@stage(analysis_type='custom', analysis_keys=['vcf'])
 class ValidationMtToVcf(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
         return {

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -7,6 +7,7 @@ Content relating to the hap.py validation process
 import logging
 
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.validation import (
     parse_and_post_results,
     run_happy_on_vcf,
@@ -20,8 +21,6 @@ from cpg_workflows.workflow import (
     get_workflow,
     stage,
 )
-
-from cpg_utils.hail_batch import get_batch
 
 
 @stage(analysis_type='custom', analysis_keys=['vcf'])

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -8,12 +8,15 @@ from typing import Any
 from cpg_utils import Path, dataproc, to_path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import get_config, image_path
-from cpg_utils.hail_batch import query_command
+from cpg_utils.hail_batch import get_batch, query_command
 from cpg_workflows.jobs.seqr_loader import (
     annotate_dataset_jobs,
     cohort_to_vcf_job,
 )
 from cpg_workflows.query_modules import seqr_loader
+from cpg_workflows.stages.joint_genotyping import JointGenotyping
+from cpg_workflows.stages.vep import Vep
+from cpg_workflows.stages.vqsr import Vqsr
 from cpg_workflows.workflow import (
     Cohort,
     CohortStage,
@@ -24,11 +27,6 @@ from cpg_workflows.workflow import (
     get_workflow,
     stage,
 )
-
-from cpg_utils.hail_batch import get_batch
-from cpg_workflows.stages.joint_genotyping import JointGenotyping
-from cpg_workflows.stages.vep import Vep
-from cpg_workflows.stages.vqsr import Vqsr
 
 
 @stage(required_stages=[JointGenotyping, Vqsr, Vep])


### PR DESCRIPTION
I don't think this is relevant to the current failing workflows, but we have a large number of pointless metadata-update callables. This process of updating an analysis dict with a called method in a later job is... probably not a good mechanic.

I would personally use a combination of analysis entry type and meta.stage to find entries, and AFAIK none of the fields removed here are used in scripts/other stages. The gvcf_qc meta update should have already been removed in https://github.com/populationgenomics/production-pipelines/pull/718

In code these callable methods are annotated with `TODO: Replace this once dynamic analysis types land in metamist.` - we have that now, so we should probably update the analysis types we generate