### PR TITLE
Add resource override config option for genomics DB import memory

### DIFF
--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -37,6 +37,9 @@ write_vcf = ["udn-aus"]
 # defaults in code are 40 for genomes, none for exomes
 #haplotypecaller_storage = 80
 
+# JointGenotyping GenomicsDBImport job overrides
+# genomicsdb_import_mem_gb = 60
+
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level
 # sensitivities. The tool matches them internally to a VQSLOD score cutoff

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -39,6 +39,7 @@ write_vcf = ["udn-aus"]
 
 # JointGenotyping GenomicsDBImport job overrides
 # genomicsdb_import_mem_gb = 32
+# genomicsdb_import_use_highmem = false
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -38,7 +38,7 @@ write_vcf = ["udn-aus"]
 #haplotypecaller_storage = 80
 
 # JointGenotyping GenomicsDBImport job overrides
-# genomicsdb_import_mem_gb = 60
+# genomicsdb_import_mem_gb = 32
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -117,6 +117,9 @@ delete_scratch_on_exit = false
 # Use additional storage in postproc_gvcf job for large gVCFs
 # postproc_gvcf_storage = 50
 
+# JointGenotyping GenomicsDBImport job overrides
+# genomicsdb_import_mem_gb = 60
+
 [mito_snv]
 # Example config for broad wdl found here:
 # https://raw.githubusercontent.com/broadinstitute/gatk/master/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -118,7 +118,7 @@ delete_scratch_on_exit = false
 # postproc_gvcf_storage = 50
 
 # JointGenotyping GenomicsDBImport job overrides
-# genomicsdb_import_mem_gb = 60
+# genomicsdb_import_mem_gb = 32
 
 [mito_snv]
 # Example config for broad wdl found here:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -119,6 +119,7 @@ delete_scratch_on_exit = false
 
 # JointGenotyping GenomicsDBImport job overrides
 # genomicsdb_import_mem_gb = 32
+# genomicsdb_import_use_highmem = false
 
 [mito_snv]
 # Example config for broad wdl found here:

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -233,18 +233,19 @@ def genomicsdb(
     # GiB lower than the total memory allocated to the VM because this tool uses
     # a significant amount of non-heap memory for native libraries.
     xms_gb = 8
-    xmx_gb = config_retrieve(
+    genomicsdb_import_mem_gb = config_retrieve(
         [
             'resource_overrides',
             'genomicsdb_import_mem_gb',
         ],
-        25,
+        32,  # total memory allocated to the VM
     )
+    xmx_gb = genomicsdb_import_mem_gb - 7  # 25GB heap memory by default
 
     STANDARD.set_resources(
         j,
         nthreads=nthreads,
-        mem_gb=xmx_gb + 4,
+        mem_gb=genomicsdb_import_mem_gb,
         storage_gb=20,
     )
 

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -16,7 +16,7 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, image_path, reference_path
 from cpg_utils.hail_batch import command, fasta_res_group
 from cpg_workflows.filetypes import GvcfPath
-from cpg_workflows.resources import STANDARD, joint_calling_scatter_count
+from cpg_workflows.resources import HIGHMEM, STANDARD, joint_calling_scatter_count
 from cpg_workflows.utils import can_reuse
 
 from .picard import get_intervals
@@ -242,7 +242,15 @@ def genomicsdb(
     )
     xmx_gb = genomicsdb_import_mem_gb - 7  # 25GB heap memory by default
 
-    STANDARD.set_resources(
+    if config_retrieve(
+        ['resource_overrides', 'genomicsdb_import_use_highmem'],
+        False,
+    ):
+        genomicsdb_import_machine_type = STANDARD
+    else:
+        genomicsdb_import_machine_type = HIGHMEM
+
+    genomicsdb_import_machine_type.set_resources(
         j,
         nthreads=nthreads,
         mem_gb=genomicsdb_import_mem_gb,

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -13,7 +13,7 @@ from hailtop.batch import Resource
 from hailtop.batch.job import Job
 
 from cpg_utils import Path, to_path
-from cpg_utils.config import get_config, image_path, reference_path
+from cpg_utils.config import config_retrieve, image_path, reference_path
 from cpg_utils.hail_batch import command, fasta_res_group
 from cpg_workflows.filetypes import GvcfPath
 from cpg_workflows.resources import STANDARD, joint_calling_scatter_count
@@ -86,7 +86,7 @@ def make_joint_genotyping_jobs(
     genomicsdb_bucket = tmp_bucket / 'genomicsdbs'
     sample_map_bucket_path = genomicsdb_bucket / 'sample_map.csv'
     df = pd.DataFrame([{'id': sid, 'path': str(path)} for sid, path in gvcf_by_sgid.items()])
-    if not get_config()['workflow'].get('dry_run', False):
+    if not config_retrieve(['workflow', 'dry_run'], False):
         with sample_map_bucket_path.open('w') as fp:
             df.to_csv(fp, index=False, header=False, sep='\t')
 
@@ -234,6 +234,13 @@ def genomicsdb(
     # a significant amount of non-heap memory for native libraries.
     xms_gb = 8
     xmx_gb = 25
+    xmx_gb = config_retrieve(
+        [
+            'resource_overrides',
+            'genomicsdb_import_mem_gb',
+        ],
+        xmx_gb,
+    )
 
     STANDARD.set_resources(
         j,

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -233,7 +233,6 @@ def genomicsdb(
     # GiB lower than the total memory allocated to the VM because this tool uses
     # a significant amount of non-heap memory for native libraries.
     xms_gb = 8
-    xmx_gb = 25
     xmx_gb = config_retrieve(
         [
             'resource_overrides',

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -246,9 +246,9 @@ def genomicsdb(
         ['resource_overrides', 'genomicsdb_import_use_highmem'],
         False,
     ):
-        genomicsdb_import_machine_type = STANDARD
-    else:
         genomicsdb_import_machine_type = HIGHMEM
+    else:
+        genomicsdb_import_machine_type = STANDARD
 
     genomicsdb_import_machine_type.set_resources(
         j,

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -238,7 +238,7 @@ def genomicsdb(
             'resource_overrides',
             'genomicsdb_import_mem_gb',
         ],
-        32,  # total memory allocated to the VM
+        32,  # 32GB total memory allocated to the VM by default
     )
     xmx_gb = genomicsdb_import_mem_gb - 7  # 25GB heap memory by default
 

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -239,13 +239,13 @@ def genomicsdb(
             'resource_overrides',
             'genomicsdb_import_mem_gb',
         ],
-        xmx_gb,
+        25,
     )
 
     STANDARD.set_resources(
         j,
         nthreads=nthreads,
-        mem_gb=xmx_gb + 1,
+        mem_gb=xmx_gb + 4,
         storage_gb=20,
     )
 


### PR DESCRIPTION
Adds a config option to set the requested memory for GATK `GenomicsDBImport` jobs.

---

### NOTE
Current code has this comment about the memory request:
```python
    # The Broad: The memory setting here is very important and must be several
    # GiB lower than the total memory allocated to the VM because this tool uses
    # a significant amount of non-heap memory for native libraries.
    xms_gb = 8
    xmx_gb = 25
```
Then, the memory is requested from a `STANDARD` machine type:
```python
    STANDARD.set_resources(
        j,
        nthreads=nthreads,
        mem_gb=xmx_gb + 1,
        storage_gb=20,
    )
```

1. Should this PR also add in the option to request a `HIGHMEM` [machine type](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/resources.py#L193) instead of `STANDARD`? 
2. The requested memory for the VM is defined as `xmx_gb + 1`, so this config option is actually tweaking the java job memory. 
Is this fine? Would a value like `xmx_gb = 63` make sense, meaning we request 64GB memory total for the job VM?

