### PR TITLE
Add HIGHMEM workers config option for GenotypeGVCFs jobs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.13
+current_version = 1.24.14
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.13
+  VERSION: 1.24.14
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -41,6 +41,9 @@ write_vcf = ["udn-aus"]
 # genomicsdb_import_mem_gb = 32
 # genomicsdb_import_use_highmem = false
 
+# JointGenotyping GenotypeGVCFs job overrides
+# genotype_gvcfs_use_highmem = false
+
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level
 # sensitivities. The tool matches them internally to a VQSLOD score cutoff

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -121,6 +121,9 @@ delete_scratch_on_exit = false
 # genomicsdb_import_mem_gb = 32
 # genomicsdb_import_use_highmem = false
 
+# JointGenotyping GenotypeGVCFs job overrides
+# genotype_gvcfs_use_highmem = false
+
 [mito_snv]
 # Example config for broad wdl found here:
 # https://raw.githubusercontent.com/broadinstitute/gatk/master/scripts/mitochondria_m2_wdl/ExampleInputsMitochondriaPipeline.json

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -344,7 +344,12 @@ def _add_joint_genotyper_job(
     # * max one-interval full VCF = 5.25G
     # * gathered full VCF: 528.86 GB
     # * gathered site-only VCF: 4.29 GB
-    res = STANDARD.request_resources(ncpu=4)
+    if config_retrieve(['resource_overrides', 'genotype_gvcfs_use_highmem'], False):
+        genotype_gvcfs_machine_type = STANDARD
+    else:
+        genotype_gvcfs_machine_type = HIGHMEM
+
+    res = genotype_gvcfs_machine_type.request_resources(ncpu=4)
     res.set_to_job(j)
 
     j.declare_resource_group(output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})

--- a/cpg_workflows/resources.py
+++ b/cpg_workflows/resources.py
@@ -327,9 +327,13 @@ def joint_calling_scatter_count(sequencing_group_count: int) -> int:
     if scatter_count := get_config()['workflow'].get('scatter_count'):
         return scatter_count
 
+    # Values adjusted based on experience with the joint-calling jobs
+    # on genome sequencing groups.
+    # e.g. 1000 scatter count was too low for 3800 genomes.
     for threshold, scatter_count in {
-        4000: 1000,
-        3000: 800,
+        4000: 1400,
+        3500: 1200,
+        3000: 1000,
         2000: 600,
         1000: 400,
         500: 200,

--- a/cpg_workflows/resources.py
+++ b/cpg_workflows/resources.py
@@ -327,8 +327,9 @@ def joint_calling_scatter_count(sequencing_group_count: int) -> int:
     if scatter_count := get_config()['workflow'].get('scatter_count'):
         return scatter_count
 
-    # Values adjusted based on experience with the joint-calling jobs
-    # on genome sequencing groups.
+    # Estimating this is challenging because GenotypeGVCFs does not scale
+    # linearly with the number of genomes.
+    # Values are adjusted based on experience with the actual number of genomes.
     # e.g. 1000 scatter count was too low for 3800 genomes.
     for threshold, scatter_count in {
         4000: 1400,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.13',
+    version='1.24.14',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
#### Added a config option to use HIGHMEM machines for the GenotypeGVCFs jobs. 
High memory workers should not be necessary if the correct scatter count is chosen from the start of the workflow.
_However_, if you are part-way through a joint callset and some jobs are failing and need more memory, this might be needed to get the failing jobs to succeed on a re-run.

#### Changed the scatter count values in resources.py.
For the most part this has been set with the `workflow.scatter_count` config option, so these defaults have not been used. But because they serve as a reference I've updated them and added some comments about about our experiences with sharding the joint genotyping jobs at scale.