### PR TITLE
Genotypegvcfs mem gb config option

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.15
+current_version = 1.24.16
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.24.15
+  VERSION: 1.24.16
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -42,7 +42,7 @@ write_vcf = ["udn-aus"]
 # genomicsdb_import_use_highmem = false
 
 # JointGenotyping GenotypeGVCFs job overrides
-# genotype_gvcfs_mem_gb = 16
+# genotype_gvcfs_mem_gb = 15
 # genotype_gvcfs_use_highmem = false
 
 [vqsr]

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -42,6 +42,7 @@ write_vcf = ["udn-aus"]
 # genomicsdb_import_use_highmem = false
 
 # JointGenotyping GenotypeGVCFs job overrides
+# genotype_gvcfs_mem_gb = 16
 # genotype_gvcfs_use_highmem = false
 
 [vqsr]

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -122,7 +122,7 @@ delete_scratch_on_exit = false
 # genomicsdb_import_use_highmem = false
 
 # JointGenotyping GenotypeGVCFs job overrides
-# genotype_gvcfs_mem_gb = 16
+# genotype_gvcfs_mem_gb = 15
 # genotype_gvcfs_use_highmem = false
 
 [mito_snv]

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -122,6 +122,7 @@ delete_scratch_on_exit = false
 # genomicsdb_import_use_highmem = false
 
 # JointGenotyping GenotypeGVCFs job overrides
+# genotype_gvcfs_mem_gb = 16
 # genotype_gvcfs_use_highmem = false
 
 [mito_snv]

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -349,7 +349,11 @@ def _add_joint_genotyper_job(
     else:
         genotype_gvcfs_machine_type = HIGHMEM
 
-    res = genotype_gvcfs_machine_type.request_resources(ncpu=4)
+    genotype_gvcfs_mem_gb = config_retrieve(
+        ['resource_overrides', 'genotype_gvcfs_mem_gb'],
+        16,
+    )
+    res = genotype_gvcfs_machine_type.request_resources(ncpu=4, mem_gb=genotype_gvcfs_mem_gb)
     res.set_to_job(j)
 
     j.declare_resource_group(output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -351,7 +351,7 @@ def _add_joint_genotyper_job(
 
     genotype_gvcfs_mem_gb = config_retrieve(
         ['resource_overrides', 'genotype_gvcfs_mem_gb'],
-        16,
+        15,  # 15GB memory default is conistent with ncpu=4 in request_resources
     )
     res = genotype_gvcfs_machine_type.request_resources(ncpu=4, mem_gb=genotype_gvcfs_mem_gb)
     res.set_to_job(j)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.24.15',
+    version='1.24.16',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a config option to customize the memory allocated to GenotypeGVCFs jobs. 
Default is 15GB to match the default 4 cpus (from [`resources.py`](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/resources.py#L139): `ncpu = mem_gb / mem_gb_per_core = 15 / 3.75 = 4`)

This option is necessary because even with HIGHMEM workers, some jobs in the current run are still failing with exit code 247 (container OOM). e.g. https://batch.hail.populationgenomics.org.au/batches/455517/jobs/16

Again, like https://github.com/populationgenomics/production-pipelines/pull/786, this option should not be necessary, unless the scatter count is too low and you need to bump the memory to get the failing jobs over the line. 
Choosing the right scatter count should mean all jobs can complete with STANDARD machine type and default memory / cpu options.