### PR TITLE
Add Functionality to Filter PCA Background Population in Large Cohort Pipeline Ancestry Stage

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -21,6 +21,9 @@ highmem_workers = true
 snp_filter_level = 99.7
 indel_filter_level = 99.0
 
+[cramqc]
+assume_sorted = true
+num_pcs = 4
 
 [resource_overrides]
 # Override default resource requirements for unusually large seq data without

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -58,8 +58,9 @@ inferred_ancestry = false
 
 # Extra functionality at the Ancestry stage to make a PCA at a more granular level,
 # by subsetting the background population to individuals of a particular ancestry.
+# Specify in list format the superpopulations to filter for.
 # https://centrepopgen.slack.com/archives/C018KFBCR1C/p1717731698661969
-# superpopulation_to_filter = 'African'
+# superpopulation_to_filter = ['African']
 
 # Set whether to allow column discrepancies when unioning background dataset tables
 #allow_missing_columns = false

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -21,9 +21,6 @@ highmem_workers = true
 snp_filter_level = 99.7
 indel_filter_level = 99.0
 
-[cramqc]
-assume_sorted = true
-num_pcs = 4
 
 [resource_overrides]
 # Override default resource requirements for unusually large seq data without
@@ -58,6 +55,11 @@ inferred_ancestry = false
 # Setting `variants_only_x_ploidy` and `variants_only_y_ploidy` to `False` (default value) causes
 # function to use reference blocks for ploidy calculations
 # https://centrepopgen.slack.com/archives/C018KFBCR1C/p1705539231990829?thread_ts=1704233101.883849&cid=C018KFBCR1C
+
+# Extra functionality at the Ancestry stage to make a PCA at a more granular level,
+# by subsetting the background population to individuals of a particular ancestry.
+# https://centrepopgen.slack.com/archives/C018KFBCR1C/p1717731698661969
+# superpopulation_to_filter = 'African'
 
 # Set whether to allow column discrepancies when unioning background dataset tables
 #allow_missing_columns = false

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -29,6 +29,7 @@ def add_background(
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
     dataset = get_config()['large_cohort']['pca_background']
+    population_to_filter = get_config()['large_cohort']['pca_background'].get('superpopulation_to_filter', False)
     for dataset in get_config()['large_cohort']['pca_background']['datasets']:
         dataset_dict = get_config()['large_cohort']['pca_background'][dataset]
         path = dataset_dict['dataset_path']
@@ -58,6 +59,11 @@ def add_background(
                 metadata_tables.append(sample_qc_background)
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
+            if population_to_filter:
+                background_mt = background_mt.filter_cols(
+                    hl.is_defined(background_mt[population_to_filter]),
+                    keep=True,
+                )
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')
 

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -61,10 +61,7 @@ def add_background(
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
             if population_to_filter:
                 logging.info(f'Filtering background samples by {population_to_filter}')
-                background_mt = background_mt.filter_cols(
-                    hl.is_defined(background_mt[population_to_filter]),
-                    keep=True,
-                )
+                background_mt = background_mt.filter_cols(background_mt.superpopulation == population_to_filter)
                 logging.info(f'Finished filtering background, kept samples that are {population_to_filter}')
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -60,10 +60,12 @@ def add_background(
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
             if population_to_filter:
+                logging.info(f'Filtering background samples by {population_to_filter}')
                 background_mt = background_mt.filter_cols(
                     hl.is_defined(background_mt[population_to_filter]),
                     keep=True,
                 )
+                logging.info(f'Finished filtering background, kept samples that are {population_to_filter}')
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')
 

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -60,11 +60,13 @@ def add_background(
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
             if populations_to_filter:
+                logging.info(f'Superpopulations before filtering {background_mt.superpopulation.collect()}')
                 logging.info(f'Filtering background samples by {populations_to_filter}')
                 background_mt = background_mt.filter_cols(
                     hl.literal(populations_to_filter).contains(background_mt.superpopulation),
                 )
                 logging.info(f'Finished filtering background, kept samples that are {populations_to_filter}')
+                logging.info(f'Superpopulations after filtering {background_mt.superpopulation.collect()}')
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')
 

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -60,13 +60,11 @@ def add_background(
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
             if populations_to_filter:
-                logging.info(f'Superpopulations before filtering {background_mt.superpopulation.collect()}')
                 logging.info(f'Filtering background samples by {populations_to_filter}')
                 background_mt = background_mt.filter_cols(
                     hl.literal(populations_to_filter).contains(background_mt.superpopulation),
                 )
                 logging.info(f'Finished filtering background, kept samples that are {populations_to_filter}')
-                logging.info(f'Superpopulations after filtering {background_mt.superpopulation.collect()}')
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')
 

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -29,7 +29,7 @@ def add_background(
     qc_variants_ht = hl.read_table(sites_table)
     dense_mt = dense_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
     dataset = get_config()['large_cohort']['pca_background']
-    population_to_filter = get_config()['large_cohort']['pca_background'].get('superpopulation_to_filter', False)
+    populations_to_filter = get_config()['large_cohort']['pca_background'].get('superpopulation_to_filter', False)
     for dataset in get_config()['large_cohort']['pca_background']['datasets']:
         dataset_dict = get_config()['large_cohort']['pca_background'][dataset]
         path = dataset_dict['dataset_path']
@@ -59,10 +59,12 @@ def add_background(
                 metadata_tables.append(sample_qc_background)
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
-            if population_to_filter:
-                logging.info(f'Filtering background samples by {population_to_filter}')
-                background_mt = background_mt.filter_cols(background_mt.superpopulation == population_to_filter)
-                logging.info(f'Finished filtering background, kept samples that are {population_to_filter}')
+            if populations_to_filter:
+                logging.info(f'Filtering background samples by {populations_to_filter}')
+                background_mt = background_mt.filter_cols(
+                    hl.literal(populations_to_filter).contains(background_mt.superpopulation),
+                )
+                logging.info(f'Finished filtering background, kept samples that are {populations_to_filter}')
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')
 


### PR DESCRIPTION
This PR introduces an enhancement to the ancestry stage of the large cohort pipeline. The update allows for a more granular PCA by enabling the subsetting of the background population to individuals of a specific ancestry.

Changes include:

A new configuration option under `[large_cohort.pca_background]` named `superpopulation_to_filter`. This option allows users to specify the superpopulation to be used for the PCA. If not specified with population name, the new parameter defaults to `False`.

Additional lines of code in `ancestry_pca.py` that filter the `background_mt` matrix table based on the superpopulation specified in the configuration.

This enhancement provides users with the flexibility to perform PCA on a specific superpopulation, allowing for more detailed and targeted analysis.