### PR TITLE
Run correction

### DIFF
--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -14,7 +14,7 @@ status_reporter = 'metamist'
 obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'
 
 [images]
-talos = "australia-southeast1-docker.pkg.dev/cpg-common/images/talos:latest"
+talos = "australia-southeast1-docker.pkg.dev/cpg-common/images/talos:4.0.1"
 
 [panels]
 default_panel = 137

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -342,7 +342,7 @@ class RunHailFiltering(DatasetStage):
 
         job.command(
             f'python3 talos/hail_filter_and_label.py '
-            f'--mt "${{BATCH_TMPDIR}}{mt_name}" '
+            f'--mt "${{BATCH_TMPDIR}}/{mt_name}" '
             f'--panelapp {panelapp_json!r} '
             f'--pedigree {local_ped!r} '
             f'--vcf_out {job.output["vcf.bgz"]} '


### PR DESCRIPTION
- Adds a fatal missing slash when passing the localised MT directory path
- Adds an explicit version to the Talos image (I'm planning to move this to the images repo, so it will feature as a standard image in config)

Partially successful run: https://batch.hail.populationgenomics.org.au/batches/456624

Will require deployment of https://github.com/populationgenomics/automated-interpretation-pipeline/pull/408