### PR TITLE
Annotate long read svs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.0
+current_version = 1.25.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.0
+  VERSION: 1.25.1
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader_long_read.toml
+++ b/configs/defaults/seqr_loader_long_read.toml
@@ -3,3 +3,14 @@ name = 'seqr_loader_long_read'
 dataset_gcp_project = 'seqr-308602'
 status_reporter = 'metamist'
 bam_to_cram_analysis_type = 'pacbio_cram'
+
+[references.gatk_sv]
+# a couple of annotation arguments are not files
+# github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
+external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
+external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
+
+[images]
+gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
+sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
+sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-09-13-v0.28.3-beta-af8362e3"

--- a/cpg_workflows/jobs/sample_batching.py
+++ b/cpg_workflows/jobs/sample_batching.py
@@ -64,8 +64,10 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
         return [
             {
                 'sequencing_groups': md.ID.tolist(),
-                'male': md[~is_female].ID.toList(),
-                'female': md[is_female].ID.toList(),
+                'male': md[~is_female].ID.to_list(),
+                'male_count': len(md[~is_female]),
+                'female': md[is_female].ID.to_list(),
+                'female_count': len(md[is_female]),
                 'mf_ratio': is_male.sum() / is_female.sum(),
                 'size': n_sg,
                 'coverage_medians': md.median_coverage.tolist(),
@@ -123,8 +125,10 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
             {
                 'sequencing_groups': sample_ids.ID.tolist(),
                 'size': len(sample_ids),
-                'male': md_sex_cov['male'][cov].tolist(),
-                'female': md_sex_cov['female'][cov].tolist(),
+                'male': md_sex_cov['male'][cov].ID.tolist(),  # type: ignore
+                'male_count': len(md_sex_cov['male'][cov]),
+                'female': md_sex_cov['female'][cov].ID.tolist(),  # type: ignore
+                'female_count': len(md_sex_cov['female'][cov]),
                 'mf_ratio': (len(md_sex_cov['male'][cov]) or 1) / (len(md_sex_cov['female'][cov]) or 1),
                 'coverage_medians': sample_ids.median_coverage.tolist(),
             },

--- a/cpg_workflows/jobs/sample_batching.py
+++ b/cpg_workflows/jobs/sample_batching.py
@@ -3,12 +3,12 @@ extract from Broad sample batching script for GATK-SV
 """
 
 import json
-import logging
 
 import numpy as np
 import pandas as pd
 
 from cpg_utils import to_path
+from cpg_workflows.utils import get_logger
 
 SEX_VALS = {'male', 'female'}
 
@@ -42,6 +42,8 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
         {
             batch_ID: {
                 'sequencing_groups': [sample1, sample2, ...],
+                'male': [sample1, sample3, ...],
+                'female': [sample1, sample3, ...],
                 'mf_ratio': float,
                 'size': int,
                 'coverage_medians': [float, float, ...],
@@ -58,10 +60,12 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
 
     # shortcut return if the total sequencing groups is a valid batch
     if min_batch_size <= n_sg <= max_batch_size:
-        logging.info(f'Number of sequencing_groups ({n_sg}) is within range of batch sizes')
+        get_logger().info(f'Number of sequencing_groups ({n_sg}) is within range of batch sizes')
         return [
             {
                 'sequencing_groups': md.ID.tolist(),
+                'male': md[~is_female].ID.toList(),
+                'female': md[is_female].ID.toList(),
                 'mf_ratio': is_male.sum() / is_female.sum(),
                 'size': n_sg,
                 'coverage_medians': md.median_coverage.tolist(),
@@ -79,7 +83,7 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
         n_per_batch = n_sg // cov_bins
     # endregion
 
-    logging.info(
+    get_logger().info(
         f"""
     Batching Specs:
     Total sequencing_groups: {n_sg}
@@ -94,6 +98,10 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
         'female': md[is_female].sort_values(by='median_coverage'),
     }
 
+    get_logger().info('Sex distribution across all samples:')
+    for sex, entries in md_sex.items():
+        get_logger().info(f'{sex}: {len(entries)}')
+
     # array split each sex proportionally
     md_sex_cov = {sex: np.array_split(md_sex[sex], cov_bins) for sex in SEX_VALS}
 
@@ -101,11 +109,23 @@ def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
     batches = []
     for cov in range(cov_bins):
         sample_ids = pd.concat([md_sex_cov['male'][cov], md_sex_cov['female'][cov]])  # type: ignore
+        get_logger().info(
+            f"""
+        ---
+        Batch {cov}:
+        Samples: {len(sample_ids)}
+        Males: {len(md_sex_cov['male'][cov])}
+        Females: {len(md_sex_cov['female'][cov])}
+        ---
+        """,
+        )
         batches.append(
             {
                 'sequencing_groups': sample_ids.ID.tolist(),
                 'size': len(sample_ids),
-                'mf_ratio': len(md_sex_cov['male'][cov]) or 1 / len(md_sex_cov['female'][cov]) or 1,
+                'male': md_sex_cov['male'][cov].tolist(),
+                'female': md_sex_cov['female'][cov].tolist(),
+                'mf_ratio': (len(md_sex_cov['male'][cov]) or 1) / (len(md_sex_cov['female'][cov]) or 1),
                 'coverage_medians': sample_ids.median_coverage.tolist(),
             },
         )
@@ -136,7 +156,7 @@ def partition_batches(
     """
 
     # read in the metadata contents
-    logging.basicConfig(level=logging.INFO)
+    get_logger(__file__).info('Starting the batch creation process')
 
     # load in the metadata file
     md = pd.read_csv(metadata_file, sep='\t', low_memory=False)
@@ -154,7 +174,7 @@ def partition_batches(
     batches = batch_sgs(md=md, min_batch_size=min_batch_size, max_batch_size=max_batch_size)
 
     # write out the batches to GCP
-    logging.info(batches)
+    get_logger().info(batches)
 
     # write the batch JSON out to a file, inc. PCR state
     with to_path(output_json).open('w') as handle:

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -1,5 +1,3 @@
-
-
 def modify_sniffles_vcf(file_in: str, file_out: str):
     """
     to be run as a PythonJob - scrolls through the

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -1,0 +1,38 @@
+
+
+def modify_sniffles_vcf(file_in: str, file_out: str):
+    """
+    to be run as a PythonJob - scrolls through the
+
+    Args:
+        file_in (str): localised, VCF directly from Sniffles
+        file_out (str): local batch output path, same VCF with INFO/ALT alterations
+    """
+    import gzip
+
+    # read and write compressed. This is only a single sample VCF, but... it's good practice
+    with gzip.open(file_in, 'rt') as f:
+        with gzip.open(file_out, 'wt') as f_out:
+            for line in f:
+                # don't alter current header lines
+                if line.startswith('#'):
+                    f_out.write(line)
+                    continue
+
+                # for non-header lines, split on tabs
+                l_split = line.split('\t')
+
+                # reduce the massive REF alleles to a single base
+                l_split[3] = l_split[3][0]
+
+                # e.g. AN_Orig=61;END=56855888;SVTYPE=DUP
+                info_dict: dict[str, str] = {}
+                for entry in l_split[7].split(';'):
+                    if '=' in entry:
+                        key, value = entry.split('=')
+                        info_dict[key] = value
+
+                # replace the alt with a symbolic String
+                l_split[4] = f'<{info_dict["SVTYPE"]}>'
+                # rebuild the string and write as output
+                f_out.write('\t'.join(l_split))

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -4,10 +4,11 @@ Intended for use with long-read BAM files from PacBio.
 """
 from functools import cache
 from cpg_utils import Path
-from cpg_utils.config import config_retrieve, reference_path
+from cpg_utils.config import config_retrieve, image_path, reference_path, try_get_ar_guid, AR_GUID_NAME
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.filetypes import CramPath
-from cpg_workflows.jobs import bam_to_cram
+from cpg_workflows.jobs import bam_to_cram, seqr_loader_long_read
+from cpg_workflows.utils import ExpectedResultT
 from cpg_workflows.workflow import (
     Cohort,
     CohortStage,
@@ -17,15 +18,17 @@ from cpg_workflows.workflow import (
     StageOutput,
     stage,
 )
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import queue_annotate_sv_jobs
 
 from metamist.graphql import gql, query
 
 
 VCF_QUERY = gql(
     """
-    query MyQuery($dataset: String!, $sgid: String!) {
+    query MyQuery($dataset: String!) {
   project(name: $dataset) {
-    sequencingGroups(id: {eq: $sgid}) {
+    sequencingGroups {
+      id
       analyses(type: {eq: "pacbio_vcf"}) {
         output
       }
@@ -37,25 +40,24 @@ VCF_QUERY = gql(
 
 
 @cache
-def query_sv_vcf_for_sgid(dataset_name: str, sgid: str) -> str | None:
+def query_for_sv_vcfs(dataset_name: str) -> dict[str, str]:
     """
     query metamist for the SV VCF, possibility of none found
 
     Args:
-        dataset_name ():
-        sgid ():
+        dataset_name (str):
 
     Returns:
-
+        a dictionary of the SG IDs and their phased SV VCF
     """
-    analysis_results = query(VCF_QUERY, variables={'dataset': dataset_name, 'sgid': sgid})
+    return_dict: dict[str, str] = {}
+    analysis_results = query(VCF_QUERY, variables={'dataset': dataset_name})
     for sg_id_section in analysis_results['data']['project']['sequencingGroups']:
         for analysis in sg_id_section['analyses']:
             if analysis['output'].endswith('.SVs.phased.vcf.gz'):
-                return analysis['output']
+                return_dict[sg_id_section['id']] = analysis['output']
 
-    # null case, no recorded data for this SG
-    return None
+    return return_dict
 
 
 def make_long_read_cram_path(sequencing_group: SequencingGroup) -> CramPath:
@@ -105,14 +107,17 @@ class BamToCram(SequencingGroupStage):
         return self.make_outputs(sequencing_group, data=self.expected_outputs(sequencing_group), jobs=[job])
 
 
-@stage()
+@stage(analysis_keys=['vcf'], analysis_type='custom')
 class ReFormatPacBioSVs(SequencingGroupStage):
     """
     take each of the long-read SV VCFs, and re-format the contents
     """
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
-        return {'vcf': self.prefix / 'reformatted_svs.vcf.bgz', 'index': self.prefix / 'reformatted_svs.vcf.bgz.tbi'}
+        return {
+            'vcf': self.prefix / f'{sequencing_group.id}_reformatted_svs.vcf.bgz',
+            'index': self.prefix / f'{sequencing_group.id}_reformatted_svs.vcf.bgz.tbi'
+        }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:
         """
@@ -121,20 +126,119 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         Args:
             sequencing_group ():
             inputs ():
-
-        Returns:
-
         """
-        # query for the SV VCF
-        return self.make_outputs(...)
+
+        # find the vcf for this SG
+        query_result = query_for_sv_vcfs(dataset_name=sequencing_group.dataset.name)
+
+        expected_outputs = self.expected_outputs(sequencing_group)
+
+        # instead of handling, we should probably just exclude this and run again
+        if sequencing_group.id not in query_result:
+            raise ValueError(f'No SV VCFs recorded for {sequencing_group.id}')
+
+        lr_sv_vcf: str = query_result[sequencing_group.id]
+        local_vcf = get_batch().read_input(lr_sv_vcf)
+
+        py_job = get_batch().new_python_job(f'Convert {lr_sv_vcf} prior to annotation')
+        py_job.storage('10Gi')
+        py_job.call(seqr_loader_long_read.modify_sniffles_vcf, local_vcf, py_job.output)
+
+        # block-gzip and index that result
+        tabix_job = get_batch().new_job(
+            name=f'BGZipping and Indexing for {sequencing_group.id}',
+            attributes={'tool': 'bcftools'}
+        )
+        tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
+        tabix_job.image(image=image_path('bcftools'))
+        tabix_job.storage('10Gi')
+        tabix_job.command(f'bcftools view {py_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')  # type: ignore
+        tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')  # type: ignore
+
+        # write from temp storage into GCP
+        get_batch().write_output(tabix_job.vcf_out, str(expected_outputs['vcf']).removesuffix('vcf.bgz'))
+
+        return self.make_outputs(target=sequencing_group, jobs=[py_job, tabix_job], data=expected_outputs)
 
 
 @stage(required_stages=ReFormatPacBioSVs)
-# do a thing
+class MergeLongReadSVs(CohortStage):
+    """
+    find all the amended VCFs, and do a naive merge into one huge VCF
+
+    """
+    def expected_outputs(self, cohort: Cohort) -> ExpectedResultT:
+        return {
+            'vcf': self.prefix / 'merged_reformatted_svs.vcf.bgz',
+            'index': self.prefix / 'merged_reformatted_svs.vcf.bgz.tbi'
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        reuse the gVCF method which does the same? FastCombineVcfs. Nah, not yet
+        unhappy with the redundancy
+        """
+
+        outputs = self.expected_outputs(cohort)
+
+        # do a slapdash bcftools merge on all input files...
+        modified_vcfs = inputs.as_dict_by_target(ReFormatPacBioSVs)
+
+        batch_vcfs = [
+            get_batch().read_input_group(**{'vcf.gz': each_vcf, 'vcf.gz.tbi': f'{each_vcf}.tbi'})['vcf.gz']
+            for each_vcf in [str(modified_vcfs[sgid]['vcf']) for sgid in cohort.get_sequencing_group_ids()]
+        ]
+
+        # just gonna create a job and commands here... this could be in a jobs file, but... shrug
+        merge_job = get_batch().new_job('Merge Long-Read SV calls', attributes={'tool': 'bcftools'})
+        merge_job.image(image=image_path('bcftools'))
+        # guessing at resource requirements
+        merge_job.cpu(4)
+        merge_job.memory('16Gi')
+        merge_job.storage('50Gi')
+        merge_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
+
+        # option breakdown:
+        # -Oz: bgzip output
+        # -o: output file
+        # --threads: number of threads to use
+        # -m: merge strategy
+        # -0: compression level
+        merge_job.command(
+            f'bcftools merge {" ".join(batch_vcfs)} -Oz -o '
+            f'{merge_job.output["vcf.bgz"]} --threads 4 -m all -0'  # type: ignore
+        )
+        merge_job.command(f'tabix {merge_job.output["vcf.bgz"]}')  # type: ignore
+
+        # write the result out
+        get_batch().write_output(merge_job.output, outputs['vcf'].removesuffix('vcf.bgz'))
+
+        return self.make_outputs(cohort, data=outputs, jobs=merge_job)
+
+
+@stage(required_stages=MergeLongReadSVs, analysis_type='custom', analysis_keys=['annotated_vcf'])
 class AnnotateLongReadSVs(CohortStage):
-    """
-    find all the analysis entries for a long-read SV VCF for these SG IDs
-    do
-    """
-    ...
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        return {
+            'annotated_vcf': self.prefix / 'annotated_long_read_svs.vcf.bgz',
+            'annotated_vcf_index': self.prefix / 'annotated_long_read_svs.vcf.bgz.tbi'
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
+        """
+        use the communal GATK-SV wrapper to annotate this merged VCF
+        """
+        expected_out = self.expected_outputs(cohort)
+
+        billing_labels = {'stage': self.name.lower(), AR_GUID_NAME: try_get_ar_guid()}
+
+        job_or_none = queue_annotate_sv_jobs(
+            cohort=cohort,
+            cohort_prefix=self.prefix,
+            input_vcf=inputs.as_dict(cohort, MergeLongReadSVs)['vcf'],
+            outputs=expected_out,
+            labels=billing_labels,
+        )
+        return self.make_outputs(cohort, data=expected_out, jobs=job_or_none)
+
 

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -42,7 +42,9 @@ VCF_QUERY = gql(
 @cache
 def query_for_sv_vcfs(dataset_name: str) -> dict[str, str]:
     """
-    query metamist for the SV VCF, possibility of none found
+    query metamist for the PacBio SV VCFs
+    return a dictionary of each CPG ID and its corresponding VCF
+    this is cached - used in a SequencingGroupStage, but we only want to query for it once instead of once/SG
 
     Args:
         dataset_name (str):

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -11,13 +11,13 @@ filter to retain only active SG IDs, then re-batch cleanly.
 
 
 import json
-import logging
 from argparse import ArgumentParser
 
 import pandas as pd
 
 from cpg_utils import to_path
 from cpg_workflows.jobs.sample_batching import batch_sgs
+from cpg_workflows.utils import get_logger
 from metamist.graphql import gql, query
 
 FIND_ACTIVE_SGS = gql(
@@ -53,7 +53,7 @@ def collect_all_sgids(projects: list[str]) -> list[str]:
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
+    get_logger(__file__).info('Starting the re-batching process')
     parser = ArgumentParser()
     parser.add_argument('-i', help='Path to the QC tables', nargs='+', required=True)
     parser.add_argument('-p', help='Names of all relevant projects', nargs='+', required=True)
@@ -64,12 +64,13 @@ if __name__ == '__main__':
         raise ValueError(f'Unrecognised arguments: {unknown}')
 
     assert args.p and args.i
-    logging.info(f'Collecting all active SG IDs for {args.p}')
+    get_logger().info(f'Collecting all active SG IDs for {args.p}')
     all_sg_ids = collect_all_sgids(args.p)
+    get_logger().info(f'Identified {len(all_sg_ids)} active SG IDs')
 
     dataframes = []
     for each in args.i:
-        logging.info(f'Loading {each}')
+        get_logger().info(f'Loading {each}')
         this_df = pd.read_csv(each, sep='\t', low_memory=False)
         this_df.columns = [x.replace('#', '') for x in this_df.columns]  # type: ignore
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.0',
+    version='1.25.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_gatk_sv_methods.py
+++ b/test/test_gatk_sv_methods.py
@@ -7,12 +7,7 @@ import pytest
 
 from cpg_utils import to_path
 from cpg_workflows.jobs.sample_batching import batch_sgs
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
-    get_fasta,
-    get_images,
-    get_references,
-    image_path,
-)
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_fasta, get_images, get_references, image_path
 
 from . import set_config
 


### PR DESCRIPTION
Sorry for the delay, this has been half done for a few weeks

Proposed extension to the long-read pipeline:

- query metamist for the SV VCFs
- re-process the contents by adding the symbolic allele & INFO content required for SVAnnotate
- naive merge of all single-sample VCFs into one fat VCF
- annotate that VCF