### PR TITLE
Use Talos endpoints

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.1
+current_version = 1.25.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.1
+  VERSION: 1.25.2
 
 jobs:
   docker:

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -13,9 +13,6 @@ status_reporter = 'metamist'
 
 obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'
 
-[images]
-talos = "australia-southeast1-docker.pkg.dev/cpg-common/images/talos:4.0.1"
-
 [panels]
 default_panel = 137
 panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -275,8 +275,10 @@ class QueryPanelapp(DatasetStage):
         hpo_panel_json = inputs.as_path(target=dataset, stage=GeneratePanelData, key='hpo_panels')
         expected_out = self.expected_outputs(dataset)
         job.command(
-            f'query_panelapp --panels {get_batch().read_input(str(hpo_panel_json))} '
-            f'--out_path {job.output} --dataset {dataset.name} ',
+            'query_panelapp '
+            f'--panels {get_batch().read_input(str(hpo_panel_json))} '
+            f'--out_path {job.output} '
+            f'--dataset {dataset.name} ',
         )
         get_batch().write_output(job.output, str(expected_out['panel_data']))
 
@@ -337,9 +339,13 @@ class RunHailFiltering(DatasetStage):
         job.command(f'cd $BATCH_TMPDIR && gcloud --no-user-output-enabled storage cp -r {input_mt} . && cd -')
 
         job.command(
-            f'hail_label --mt "${{BATCH_TMPDIR}}/{mt_name}" '  # type: ignore
-            f'--panelapp {panelapp_json} --pedigree {local_ped} --vcf_out {job.output["vcf.bgz"]} '
-            f'--clinvar "${{BATCH_TMPDIR}}/{clinvar_name}" --pm5 "${{BATCH_TMPDIR}}/{pm5_name}" ',
+            'hail_label '
+            f'--mt "${{BATCH_TMPDIR}}/{mt_name}" '  # type: ignore
+            f'--panelapp {panelapp_json} '
+            f'--pedigree {local_ped} '
+            f'--vcf_out {job.output["vcf.bgz"]} '
+            f'--clinvar "${{BATCH_TMPDIR}}/{clinvar_name}" '
+            f'--pm5 "${{BATCH_TMPDIR}}/{pm5_name}" ',
         )
         get_batch().write_output(job.output, str(expected_out["labelled_vcf"]).removesuffix('.vcf.bgz'))
 
@@ -379,8 +385,11 @@ class RunHailSVFiltering(DatasetStage):
             # copy the mt in
             job.command(f'gcloud --no-user-output-enabled storage cp -r {sv_path} .')
             job.command(
-                f'hail_label_sv --mt {sv_file} --panelapp {panelapp_json} '  # type: ignore
-                f'--pedigree {local_ped} --vcf_out {job.output["vcf.bgz"]} ',
+                'hail_label_sv '
+                f'--mt {sv_file} '
+                f'--panelapp {panelapp_json} '
+                f'--pedigree {local_ped} '
+                f'--vcf_out {job.output["vcf.bgz"]} ',  # type: ignore
             )
             get_batch().write_output(job.output, str(expected_out[sv_file]).removesuffix('.vcf.bgz'))
             sv_jobs.append(job)
@@ -435,7 +444,8 @@ class ValidateMOI(DatasetStage):
         )['vcf.bgz']
 
         job.command(
-            f'run_moi_tests --labelled_vcf {labelled_vcf} '
+            'run_moi_tests '
+            f'--labelled_vcf {labelled_vcf} '
             f'--out_json {job.output} '
             f'--panelapp {panel_input} '
             f'--pedigree {pedigree} '
@@ -474,8 +484,12 @@ class CreateTalosHTML(DatasetStage):
         # this will still try to write directly out - latest is optional, and splitting is arbitrary
         # Hail can't handle optional outputs being copied out AFAIK
         command_string = (
-            f'build_html --results {results_json} --panelapp {panel_input} --dataset {dataset.name} '
-            f'--output {str(expected_out["results_html"])}  --latest {str(expected_out["latest_html"])} '
+            'build_html '
+            '--results {results_json} '
+            '--panelapp {panel_input} '
+            '--dataset {dataset.name} '
+            f'--output {str(expected_out["results_html"])} '
+            f'--latest {str(expected_out["latest_html"])} '
         )
 
         if report_splitting := config_retrieve(['workflow', 'report_splitting', dataset.name], False):
@@ -526,7 +540,11 @@ class GenerateSeqrFile(DatasetStage):
         job.image(image_path('talos'))
         lookup_in_batch = get_batch().read_input(seqr_lookup)
         job.command(
-            f'generate_seqr_file {input_localised} {job.out_json} {job.pheno_json} --external_map {lookup_in_batch}',
+            'generate_seqr_file '
+            f'{input_localised} '
+            f'{job.out_json} '
+            f'{job.pheno_json} '
+            f'--external_map {lookup_in_batch}',
         )
 
         # write the results out

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.1',
+    version='1.25.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
3/3, depends on 
- https://github.com/populationgenomics/automated-interpretation-pipeline/pull/413 being merged and released
- https://github.com/populationgenomics/images/pull/152 being merged after, pointing at the released version

This updates the commands executed inside the talos image to use the console entrypoints instead of referencing a specific script by path. Following the direct-from-git installation, the scripts won't be present as a cloned/copied repo. This change was made when migrating the docker build from the AIP repo into the CPG `images` repo, so that it appears in the standard images config.

Talos image path/name in the default workflow config has been removed