### PR TITLE
Allow for other reference genomes in bamtocram job

### DIFF
--- a/cpg_workflows/jobs/align_rna.py
+++ b/cpg_workflows/jobs/align_rna.py
@@ -8,7 +8,7 @@ import hailtop.batch as hb
 from hailtop.batch.job import Job
 
 from cpg_utils import Path, to_path
-from cpg_utils.config import image_path
+from cpg_utils.config import image_path, reference_path
 from cpg_utils.hail_batch import Batch, command
 from cpg_workflows.filetypes import (
     BamPath,
@@ -235,6 +235,7 @@ def align(
             extra_label=extra_label,
             job_attrs=job_attrs,
             requested_nthreads=requested_nthreads,
+            reference_fasta_path=reference_path('star/fasta'),
         )
         jobs.append(j)
         out_cram_path = to_path(output_cram.path)

--- a/cpg_workflows/jobs/bam_to_cram.py
+++ b/cpg_workflows/jobs/bam_to_cram.py
@@ -17,7 +17,7 @@ def bam_to_cram(
     extra_label: str | None = None,
     job_attrs: dict | None = None,
     requested_nthreads: int | None = None,
-    reference_path: Path | None = None,
+    reference_fasta_path: Path | None = None,
 ) -> tuple[Job, ResourceGroup]:
     """
     Convert a BAM file to a CRAM file.
@@ -35,13 +35,9 @@ def bam_to_cram(
     j.image(image_path('samtools'))
 
     # Get fasta file
-    fasta_path = reference_path
-    if not fasta_path:
-        fasta_path = config_retrieve(['references', 'star', 'fasta'])
-
     fasta = b.read_input_group(
-        fasta=fasta_path,
-        fasta_fai=f'{fasta_path}.fai',
+        fasta=reference_fasta_path,
+        fasta_fai=f'{reference_fasta_path}.fai',
     )
 
     # Set resource requirements

--- a/cpg_workflows/jobs/bam_to_cram.py
+++ b/cpg_workflows/jobs/bam_to_cram.py
@@ -6,7 +6,7 @@ from hailtop.batch import ResourceGroup
 from hailtop.batch.job import Job
 
 from cpg_utils import Path
-from cpg_utils.config import get_config, image_path
+from cpg_utils.config import config_retrieve, image_path
 from cpg_utils.hail_batch import Batch, command
 from cpg_workflows.resources import STANDARD
 
@@ -17,6 +17,7 @@ def bam_to_cram(
     extra_label: str | None = None,
     job_attrs: dict | None = None,
     requested_nthreads: int | None = None,
+    reference_path: Path | None = None,
 ) -> tuple[Job, ResourceGroup]:
     """
     Convert a BAM file to a CRAM file.
@@ -34,7 +35,10 @@ def bam_to_cram(
     j.image(image_path('samtools'))
 
     # Get fasta file
-    fasta_path = str(get_config()['references']['star']['fasta'])
+    fasta_path = reference_path
+    if not fasta_path:
+        fasta_path = config_retrieve(['references', 'star', 'fasta'])
+
     fasta = b.read_input_group(
         fasta=fasta_path,
         fasta_fai=f'{fasta_path}.fai',

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -52,6 +52,7 @@ class BamToCram(SequencingGroupStage):
             extra_label='long_read',
             job_attrs=self.get_job_attrs(sequencing_group),
             requested_nthreads=1,
+            reference_path=reference_path('broad/ref_fasta'),
         )
         b.write_output(output_cram, str(self.expected_outputs(sequencing_group)['cram']).removesuffix('.cram'))
 

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -52,7 +52,7 @@ class BamToCram(SequencingGroupStage):
             extra_label='long_read',
             job_attrs=self.get_job_attrs(sequencing_group),
             requested_nthreads=1,
-            reference_path=reference_path('broad/ref_fasta'),
+            reference_fasta_path=reference_path('broad/ref_fasta'),
         )
         b.write_output(output_cram, str(self.expected_outputs(sequencing_group)['cram']).removesuffix('.cram'))
 


### PR DESCRIPTION
The bam_to_cram job was using the `STAR` reference fasta by default - mainly for doing work with RNA seq data. 

This PR adds a new argument to the bam_to_cram job, called `reference_fasta_path`. This will now determine the fasta referenced used by the samtools job.

When the bam_to_cram job is invoked by the `seqr_loader_long_read` stage `BamToCram`, we can set our reference path to the default hg38 masked reference from the Broad, the same one used in the Alignment pipeline. 

I've also updated the only other place the bam_to_cram job was used in cpg_workflows, which is in `align_rna.py`. 
I set the reference path to be the original `STAR` hg38 fasta for this job, so it will function the same after this change. 

---

@cassimons this should resolve the IGV.js issue regarding viewing the long read CRAMs. 

When we converted from BAM to CRAM with samtools, we used the STAR fasta from the rna seq workflows as the reference:
https://batch.hail.populationgenomics.org.au/batches/453334/jobs/3


I reran the BamToCram stage in testing with the standard masked hg38 reference instead:
https://batch.hail.populationgenomics.org.au/batches/453334/jobs/4

It ran 3x faster and the new CRAM is has no errors in IGV.js 🚀 