### PR TITLE
Talos updates

### DIFF
--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -13,6 +13,8 @@ default_panel = 137
 obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'
 panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'
 require_pheno_match = ['FLG', 'GJB2', 'F2', 'F5']
+# forbidden_genes = ['a', 'b']
+# forced_panels = [1, 2]
 
 [ValidateMOI]
 # thresholds for different filters during the MOI checks

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -1,9 +1,6 @@
 [workflow]
 name = 'Talos'
 
-# optionally allow for running a different HTML script
-presentation = 'cpg'
-
 # where to register outputs, if at all
 status_reporter = 'metamist'
 
@@ -11,19 +8,11 @@ status_reporter = 'metamist'
 #clinvar_decisions = "HailTable path to private ClinVar"
 #clinvar_pm5 = "HailTable path to ClinVar PM5"
 
-obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'
-
-[images]
-talos = "australia-southeast1-docker.pkg.dev/cpg-common/images/talos:4.0.1"
-
 [panels]
 default_panel = 137
+obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'
 panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'
-panel_month_delta = 12
 require_pheno_match = ['FLG', 'GJB2', 'F2', 'F5']
-
-[clinvar]
-filter_benign = ['illumina laboratory services; illumina']
 
 [moi_tests]
 # thresholds for different filters during the MOI checks
@@ -33,27 +22,40 @@ gnomad_max_homs_recessive = 1
 gnomad_max_ac_dominant = 10
 gnomad_max_hemi = 1
 callset_af_sv_dominant = 0.01
+# these categories don't reach the report without also having a gene-phenotype match
+# stripped down form, e.g. 'categoryboolean6' is '6'
+phenotype_match = ['6']
 
-[csq]
-# variables affecting how the VCF variants are parsed, and AnalysisVariant objects are populated
-csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
-
-[filter]
+[hail_labelling]
 # variables for the hail operations, including CSQ sets and filter thresholds
 ac_threshold = 0.01
+# for de novo testing, use HIGH consequence terms + these terms
 additional_csq = ['missense_variant']
+# maximum allowed population frequency - dominant variants will have a stricter threshold applied later
 af_semi_rare = 0.01
-cadd = 28.1
+# maximum presence in a SV callset to be considered potentially pathogenic
 callset_af_sv_recessive = 0.03
+# all VEP consequences considered HIGH impact
 critical_csq = ['frameshift_variant', 'splice_acceptor_variant', 'splice_donor_variant', 'start_lost', 'stop_gained', 'stop_lost', 'transcript_ablation']
-gerp = 1.0
-eigen = 0.25
+# used in de novo calculation - highest %Alt reads for a parent to be considered WT
 max_parent_ab = 0.05
+# min read depth required for variant calls
 minimum_depth = 10
-polyphen = 0.99
-revel = 0.77
-sift = 0.0
+# threshold for considering SpliceAI calls to be Pathogenic
 spliceai = 0.5
+
+# for generating the VCF output - these are the fields pulled from the MT, in this order
+csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
+
+[hail_labelling.cores]
+# size of VM provisioned for Hail
+sv = 2
+small_variants = 8
+
+[hail_labelling.storage]
+sv = 10
+exome = 50
+genome = 500
 
 [categories]
 1 = 'ClinVar Pathogenic'
@@ -65,23 +67,6 @@ spliceai = 0.5
 pm5 = 'ACMG PM5 - missense in same residue as known pathogenic'
 support = 'High in Silico Scores'
 sv1 = 'Predicted LOF SV'
-
-[hail]
-cancel_after_n_failures = 1
-default_timeout = 6000
-default_memory = 'highmem'
-
-[hail.cores]
-sv = 2
-small_variants = 8
-
-[hail.storage]
-sv = 10
-exome = 50
-genome = 500
-
-[references]
-genome_build = 'GRCh38'
 
 # per-cohort section
 #clinvar_filter = when running a clinvar re-summary, remove submissions by these sites. Default = no removal

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -25,6 +25,8 @@ callset_af_sv_dominant = 0.01
 # these categories don't reach the report without also having a gene-phenotype match
 # stripped down form, e.g. 'categoryboolean6' is '6'
 phenotype_match = ['6']
+## all these labels will be removed
+#ignore_categories = ['categoryboolean6']
 
 [hail_labelling]
 # variables for the hail operations, including CSQ sets and filter thresholds

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -72,10 +72,5 @@ pm5 = 'ACMG PM5 - missense in same residue as known pathogenic'
 support = 'High in Silico Scores'
 sv1 = 'Predicted LOF SV'
 
-# per-cohort section
-#clinvar_filter = when running a clinvar re-summary, remove submissions by these sites. Default = no removal
-#cohort_panels = any panel IDs to be applied to this cohort, even if not otherwise phenotype-matched
-#gene_prior = if a specific gene list is to be used to determine Cat 2 (new gene-disease associations), provide the filepath here
-
-# this content is not stored in this repository due to data protection concerns.
+# cohort specific parts of the config are not stored in this repository due to data protection concerns.
 # Instead, AIP runs in production-pipelines should use the config from github::production-pipelines-configuration

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -8,13 +8,13 @@ status_reporter = 'metamist'
 #clinvar_decisions = "HailTable path to private ClinVar"
 #clinvar_pm5 = "HailTable path to ClinVar PM5"
 
-[panels]
+[GeneratePanelData]
 default_panel = 137
 obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'
 panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'
 require_pheno_match = ['FLG', 'GJB2', 'F2', 'F5']
 
-[moi_tests]
+[ValidateMOI]
 # thresholds for different filters during the MOI checks
 gnomad_dominant = 0.001
 gnomad_max_homs_dominant = 0
@@ -28,7 +28,7 @@ phenotype_match = ['6']
 ## all these labels will be removed
 #ignore_categories = ['categoryboolean6']
 
-[hail_labelling]
+[RunHailFiltering]
 # variables for the hail operations, including CSQ sets and filter thresholds
 ac_threshold = 0.01
 # for de novo testing, use HIGH consequence terms + these terms
@@ -49,12 +49,12 @@ spliceai = 0.5
 # for generating the VCF output - these are the fields pulled from the MT, in this order
 csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
 
-[hail_labelling.cores]
+[RunHailFiltering.cores]
 # size of VM provisioned for Hail
 sv = 2
 small_variants = 8
 
-[hail_labelling.storage]
+[RunHailFiltering.storage]
 sv = 10
 exome = 50
 genome = 500

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -626,7 +626,7 @@ class GenerateSeqrFile(DatasetStage):
 
         lookup_in_batch = get_batch().read_input(seqr_lookup)
         job.command(
-            f'TALOS_CONFIG={conf_in_batch} generate_seqr_file '
+            f'TALOS_CONFIG={conf_in_batch} GenerateSeqrFile '
             f'{input_localised} '
             f'{job.out_json} '
             f'{job.pheno_json} '

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -322,7 +322,7 @@ class GeneratePanelData(DatasetStage):
 
         expected_out = self.expected_outputs(dataset)
 
-        hpo_file = get_batch().read_input(config_retrieve(['workflow', 'obo_file']))
+        hpo_file = get_batch().read_input(config_retrieve(['GeneratePanelData', 'obo_file']))
         local_ped = get_batch().read_input(str(inputs.as_path(target=dataset, stage=GeneratePED, key='pedigree')))
         job.command(f'GeneratePanelData -i {local_ped} ' f'--hpo {hpo_file} ' f'--out {job.output}')
         get_batch().write_output(job.output, str(expected_out["hpo_panels"]))

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -285,7 +285,7 @@ class GeneratePED(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         expected_out = self.expected_outputs(dataset)
         query_dataset = dataset.name
@@ -318,7 +318,7 @@ class GeneratePanelData(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         expected_out = self.expected_outputs(dataset)
 
@@ -346,7 +346,7 @@ class QueryPanelapp(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         hpo_panel_json = inputs.as_path(target=dataset, stage=GeneratePanelData, key='hpo_panels')
         expected_out = self.expected_outputs(dataset)
@@ -380,7 +380,7 @@ class RunHailFiltering(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         # MTs can vary from <10GB for a small exome, to 170GB for a larger one
         # Genomes are more like 500GB
@@ -465,7 +465,7 @@ class RunHailFilteringSV(DatasetStage):
             job.image(image_path('talos'))
 
             # use the new config file
-            job.env(conf_in_batch, 'TALOS_CONFIG')
+            job.env('TALOS_CONFIG', conf_in_batch)
             STANDARD.set_resources(job, ncpu=required_cpu, storage_gb=required_storage, mem_gb=16)
 
             # copy the mt in
@@ -503,7 +503,7 @@ class ValidateMOI(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         hpo_panels = get_batch().read_input(str(inputs.as_dict(dataset, GeneratePanelData)['hpo_panels']))
         pedigree = get_batch().read_input(str(inputs.as_path(target=dataset, stage=GeneratePED, key='pedigree')))
@@ -570,7 +570,7 @@ class CreateTalosHTML(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         results_json = get_batch().read_input(str(inputs.as_dict(dataset, ValidateMOI)['summary_json']))
         panel_input = get_batch().read_input(str(inputs.as_dict(dataset, QueryPanelapp)['panel_data']))
@@ -635,7 +635,7 @@ class GenerateSeqrFile(DatasetStage):
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
-        job.env(conf_in_batch, 'TALOS_CONFIG')
+        job.env('TALOS_CONFIG', conf_in_batch)
 
         lookup_in_batch = get_batch().read_input(seqr_lookup)
         job.command(

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -354,9 +354,7 @@ class QueryPanelapp(DatasetStage):
         expected_out = self.expected_outputs(dataset)
         job.command(
             f'TALOS_CONFIG={conf_in_batch} QueryPanelapp '
-            f'--panels {get_batch().read_input(str(hpo_panel_json))} '
-            f'--out_path {job.output} '
-            f'--dataset {dataset.name} ',
+            f'--panels {get_batch().read_input(str(hpo_panel_json))} --out_path {job.output}'
         )
         get_batch().write_output(job.output, str(expected_out['panel_data']))
 
@@ -542,7 +540,7 @@ class ValidateMOI(DatasetStage):
             f'--pedigree {pedigree} '
             f'--input_path {input_path} '
             f'--participant_panels {hpo_panels} '
-            f'--dataset {dataset.name} {sv_vcf_arg}',
+            f'{sv_vcf_arg}',
         )
         get_batch().write_output(job.output, str(self.expected_outputs(dataset)['summary_json']))
         expected_out = self.expected_outputs(dataset)
@@ -580,7 +578,6 @@ class CreateTalosHTML(DatasetStage):
             f'TALOS_CONFIG={conf_in_batch} CreateTalosHTML '
             f'--results {results_json} '
             f'--panelapp {panel_input} '
-            f'--dataset {dataset.name} '
             f'--output {str(expected_out["results_html"])} '
             f'--latest {str(expected_out["latest_html"])} '
         )

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -229,6 +229,7 @@ class MakeRuntimeConfig(DatasetStage):
             'GeneratePanelData': config_retrieve(['GeneratePanelData']),
             'RunHailFiltering': config_retrieve(['RunHailFiltering']),
             'ValidateMOI': config_retrieve(['ValidateMOI']),
+            'CreateTalosHTML': {}
         }
 
         # pull the content relevant to this cohort + sequencing type (mandatory in CPG)

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -506,8 +506,6 @@ class ValidateMOI(DatasetStage):
         pedigree = get_batch().read_input(str(inputs.as_path(target=dataset, stage=GeneratePED, key='pedigree')))
         hail_inputs = inputs.as_dict(dataset, RunHailFiltering)
 
-        input_path = config_retrieve(['workflow', 'matrix_table'], query_for_latest_mt(dataset.name))
-
         # If there are SV VCFs, read each one in and add to the arguments
         sv_paths_or_empty = query_for_sv_mt(dataset.name)
         sv_vcf_arg = ''
@@ -515,10 +513,6 @@ class ValidateMOI(DatasetStage):
             # only go looking for inputs from prior stage where we expect to find them
             hail_sv_inputs = inputs.as_dict(dataset, RunHailFilteringSV)
             for sv_path, sv_file in query_for_sv_mt(dataset.name):
-                # bump input_path to contain both source files if appropriate
-                # this is a string written into the metadata
-                input_path += f', {sv_path}'
-
                 labelled_sv_vcf = get_batch().read_input_group(
                     **{'vcf.bgz': str(hail_sv_inputs[sv_file]), 'vcf.bgz.tbi': f'{hail_sv_inputs[sv_file]}.tbi'},
                 )['vcf.bgz']
@@ -538,7 +532,6 @@ class ValidateMOI(DatasetStage):
             f'--out_json {job.output} '
             f'--panelapp {panel_input} '
             f'--pedigree {pedigree} '
-            f'--input_path {input_path} '
             f'--participant_panels {hpo_panels} '
             f'{sv_vcf_arg}',
         )

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -229,7 +229,7 @@ class MakeRuntimeConfig(DatasetStage):
             'GeneratePanelData': config_retrieve(['GeneratePanelData']),
             'RunHailFiltering': config_retrieve(['RunHailFiltering']),
             'ValidateMOI': config_retrieve(['ValidateMOI']),
-            'CreateTalosHTML': {}
+            'CreateTalosHTML': {},
         }
 
         # pull the content relevant to this cohort + sequencing type (mandatory in CPG)
@@ -326,7 +326,7 @@ class GeneratePanelData(DatasetStage):
             f'TALOS_CONFIG={conf_in_batch} GeneratePanelData '
             f'-i {local_ped} '
             f'--hpo {hpo_file} '
-            f'--out {job.output}'
+            f'--out {job.output}',
         )
         get_batch().write_output(job.output, str(expected_out["hpo_panels"]))
 
@@ -354,7 +354,8 @@ class QueryPanelapp(DatasetStage):
         expected_out = self.expected_outputs(dataset)
         job.command(
             f'TALOS_CONFIG={conf_in_batch} QueryPanelapp '
-            f'--panels {get_batch().read_input(str(hpo_panel_json))} --out_path {job.output}'
+            f'--panels {get_batch().read_input(str(hpo_panel_json))} '
+            f'--out_path {job.output}',
         )
         get_batch().write_output(job.output, str(expected_out['panel_data']))
 
@@ -482,7 +483,14 @@ class RunHailFilteringSV(DatasetStage):
 
 
 @stage(
-    required_stages=[GeneratePED, GeneratePanelData, QueryPanelapp, RunHailFiltering, RunHailFilteringSV, MakeRuntimeConfig],
+    required_stages=[
+        GeneratePED,
+        GeneratePanelData,
+        QueryPanelapp,
+        RunHailFiltering,
+        RunHailFilteringSV,
+        MakeRuntimeConfig,
+    ],
     analysis_type='aip-results',  # note - legacy analysis type
     analysis_keys=['summary_json'],
 )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'bokeh',
         'numpy',
         'click',
+        'toml',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Adds a new Stage - create a custom config for each run of the pipeline (incorporating content specific to the Cohort & sequencing type). Instead of putting everything into the config for every run, then selecting out the bits relevant to _this_ run, create a specific config file for this run.

This separation means that the config for a given Talos run is much easier to define (which will aid redeployment at other sites where the CPG config structure isn't used by default).

This config file is stored in the main output folder for posterity.

Linked with https://github.com/populationgenomics/automated-interpretation-pipeline/pull/416