### PR TITLE
More flexibility in batch sizes

### DIFF
--- a/cpg_workflows/jobs/sample_batching.py
+++ b/cpg_workflows/jobs/sample_batching.py
@@ -13,7 +13,7 @@ from cpg_workflows.utils import get_logger
 SEX_VALS = {'male', 'female'}
 
 
-def batch_sgs(md: pd.DataFrame, min_batch_size, max_batch_size) -> list[dict]:
+def batch_sgs(md: pd.DataFrame, min_batch_size: int, max_batch_size: int) -> list[dict]:
     """
     Batch sequencing groups by coverage, and chrX ploidy
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -227,7 +227,7 @@ class CreateSampleBatches(CohortStage):
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return {'batch_json': self.prefix / 'sgid_batches.json'}
+        return {'batch_json': self.analysis_prefix / 'sgid_batches.json'}
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
         """

--- a/scripts/regenerate_all_sample_batches.py
+++ b/scripts/regenerate_all_sample_batches.py
@@ -58,6 +58,8 @@ if __name__ == '__main__':
     parser.add_argument('-i', help='Path to the QC tables', nargs='+', required=True)
     parser.add_argument('-p', help='Names of all relevant projects', nargs='+', required=True)
     parser.add_argument('-o', help='Where to write the output', required=True)
+    parser.add_argument('--min', help='Min Batch Size', type=int, default=200)
+    parser.add_argument('--max', help='Max Batch Size', type=int, default=300)
     args, unknown = parser.parse_known_args()
 
     if unknown:
@@ -84,7 +86,7 @@ if __name__ == '__main__':
         raise ValueError('No samples found in the QC tables')
 
     # now make some batches
-    batches = batch_sgs(one_big_df, min_batch_size=200, max_batch_size=300)
+    batches = batch_sgs(one_big_df, min_batch_size=args.min, max_batch_size=args.max)
 
     with to_path(args.o).open('w') as f:
         f.write(json.dumps(batches, indent=4))


### PR DESCRIPTION
This script is used to take multiple separate batch outputs, merge them all, and produce new batches from the larger cohort. 

This overcomes a limitation in GATK-SV where batches > 500 create errors when collecting/calculating all the median coverage files (huge amount of data), and allows us to take the pre-calculated metrics from a larger number of samples when deciding new batches.

This is just a quick bump to let us define the output batch sizes with more flexibility