### PR TITLE
Update VCF sample id for long reads

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.4
+current_version = 1.25.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.4
+  VERSION: 1.25.5
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -1,12 +1,18 @@
 def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str):
     """
-    to be run as a PythonJob - scrolls through the
+    to be run as a PythonJob - scrolls through the VCF and performs a few updates:
+
+    - replaces the External Sample ID with the internal CPG identifier
+    - replaces the ALT allele with a symbolic "<TYPE>", derived from the SVTYPE INFO field
+    - reduces the massive REF String to only the base at the variant position
+
+    rebuilds the VCF following those edits, and writes the compressed data back out
 
     Args:
         file_in (str): localised, VCF directly from Sniffles
         file_out (str): local batch output path, same VCF with INFO/ALT alterations
-        ext_id (str): external ID
-        int_id (str): required ID inside the reformatted VCF
+        ext_id (str): external ID to replace (if found)
+        int_id (str): CPG ID, required inside the reformatted VCF
     """
     import gzip
 

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -1,36 +1,41 @@
-def modify_sniffles_vcf(file_in: str, file_out: str):
+def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str):
     """
     to be run as a PythonJob - scrolls through the
 
     Args:
         file_in (str): localised, VCF directly from Sniffles
         file_out (str): local batch output path, same VCF with INFO/ALT alterations
+        ext_id (str): external ID
+        int_id (str): required ID inside the reformatted VCF
     """
     import gzip
 
     # read and write compressed. This is only a single sample VCF, but... it's good practice
-    with gzip.open(file_in, 'rt') as f:
-        with gzip.open(file_out, 'wt') as f_out:
-            for line in f:
-                # don't alter current header lines
-                if line.startswith('#'):
-                    f_out.write(line)
-                    continue
+    with gzip.open(file_in, 'rt') as f, gzip.open(file_out, 'wt') as f_out:
 
-                # for non-header lines, split on tabs
-                l_split = line.split('\t')
+        for line in f:
+            # alter the sample line in the header
+            if line.startswith('#'):
+                if line.startswith('#CHR'):
+                    line.replace(ext_id, int_id)
 
-                # reduce the massive REF alleles to a single base
-                l_split[3] = l_split[3][0]
+                f_out.write(line)
+                continue
 
-                # e.g. AN_Orig=61;END=56855888;SVTYPE=DUP
-                info_dict: dict[str, str] = {}
-                for entry in l_split[7].split(';'):
-                    if '=' in entry:
-                        key, value = entry.split('=')
-                        info_dict[key] = value
+            # for non-header lines, split on tabs
+            l_split = line.split('\t')
 
-                # replace the alt with a symbolic String
-                l_split[4] = f'<{info_dict["SVTYPE"]}>'
-                # rebuild the string and write as output
-                f_out.write('\t'.join(l_split))
+            # reduce the massive REF alleles to a single base
+            l_split[3] = l_split[3][0]
+
+            # e.g. AN_Orig=61;END=56855888;SVTYPE=DUP
+            info_dict: dict[str, str] = {}
+            for entry in l_split[7].split(';'):
+                if '=' in entry:
+                    key, value = entry.split('=')
+                    info_dict[key] = value
+
+            # replace the alt with a symbolic String
+            l_split[4] = f'<{info_dict["SVTYPE"]}>'
+            # rebuild the string and write as output
+            f_out.write('\t'.join(l_split))

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -94,7 +94,13 @@ class ReFormatPacBioSVs(SequencingGroupStage):
 
         py_job = get_batch().new_python_job(f'Convert {lr_sv_vcf} prior to annotation')
         py_job.storage('10Gi')
-        py_job.call(seqr_loader_long_read.modify_sniffles_vcf, local_vcf, py_job.output)
+        py_job.call(
+            seqr_loader_long_read.modify_sniffles_vcf,
+            local_vcf,
+            py_job.output,
+            sequencing_group.external_id,
+            sequencing_group.id,
+        )
 
         # block-gzip and index that result
         tabix_job = get_batch().new_job(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.4',
+    version='1.25.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
As discussed - when we loop over the SV VCF to update the fields, this will also run a string replacement, taking out the old ID and putting in the new one