### PR TITLE
Mt to es outside dataproc

### DIFF
--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -22,7 +22,9 @@ def main():
     # localise the MT
     mt_name = args.mt_path.split('/')[-1]
     job.command(f'gcloud --no-user-output-enabled storage cp -r {args.mt_name} $BATCH_TMPDIR')
-    job.command(f'mt_to_es --mt_path {mt_name}, --index {args.index} --flag {args.flag} --cpu {ncpu}')
+    job.command(
+        f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {args.index} --flag {args.flag} --cpu {ncpu}',
+    )
     get_batch().run(wait=False)
 
 

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -21,7 +21,7 @@ def main():
 
     # localise the MT
     mt_name = args.mt_path.split('/')[-1]
-    job.command(f'gcloud --no-user-output-enabled storage cp -r {args.mt_name} $BATCH_TMPDIR')
+    job.command(f'gcloud --no-user-output-enabled storage cp -r {args.mt_path} $BATCH_TMPDIR')
     job.command(
         f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {args.index} --flag {args.flag} --cpu {ncpu}',
     )

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -22,9 +22,7 @@ def main():
     # localise the MT
     mt_name = args.mt_path.split('/')[-1]
     job.command(f'gcloud --no-user-output-enabled storage cp -r {args.mt_path} $BATCH_TMPDIR')
-    job.command(
-        f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {args.index} --flag {args.flag} --cpu {ncpu}',
-    )
+    job.command(f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {args.index} --flag {args.flag}')
     get_batch().run(wait=False)
 
 

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -1,0 +1,30 @@
+from argparse import ArgumentParser
+
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import get_batch
+
+
+def main():
+    parser = ArgumentParser(description='Argument Parser for the ES generation script')
+    parser.add_argument('--mt_path', help='MT path name', required=True)
+    parser.add_argument('--index', help='ES index name', required=True)
+    parser.add_argument('--flag', help='ES index "DONE" file path')
+    args = parser.parse_args()
+
+    job = get_batch().new_job(f'Generate {args.index} from {args.mt_path}')
+    job.image(config_retrieve(['workflow', 'driver_image']))
+    job.storage(config_retrieve(['workflow', 'storage_requirement'], '10Gi'))
+    job.memory(config_retrieve(['workflow', 'memory_requirement'], 'highmem'))
+
+    ncpu = config_retrieve(['workflow', 'ncpu'], 4)
+    job.cpu(ncpu)
+
+    # localise the MT
+    mt_name = args.mt_path.split('/')[-1]
+    job.command(f'gcloud --no-user-output-enabled storage cp -r {args.mt_name} $BATCH_TMPDIR')
+    job.command(f'mt_to_es --mt_path {mt_name}, --index {args.index} --flag {args.flag} --cpu {ncpu}')
+    get_batch().run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -1,3 +1,4 @@
+import logging
 from argparse import ArgumentParser
 
 from cpg_utils.config import config_retrieve
@@ -10,6 +11,11 @@ def main():
     parser.add_argument('--index', help='ES index name', required=True)
     parser.add_argument('--flag', help='ES index "DONE" file path')
     args = parser.parse_args()
+
+    if not args.index.islower():
+        lower_index = args.index.lower()
+        logging.info(f'ES Index name must be lower case ({args.index}), changing to {lower_index}')
+        args.index = lower_index
 
     job = get_batch().new_job(f'Generate {args.index} from {args.mt_path}')
     job.image(config_retrieve(['workflow', 'driver_image']))

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -13,8 +13,8 @@ def main():
 
     job = get_batch().new_job(f'Generate {args.index} from {args.mt_path}')
     job.image(config_retrieve(['workflow', 'driver_image']))
-    job.storage(config_retrieve(['workflow', 'storage_requirement'], '10Gi'))
-    job.memory(config_retrieve(['workflow', 'memory_requirement'], 'highmem'))
+    job.storage(config_retrieve(['workflow', 'storage_requirement'], '40Gi'))
+    job.memory(config_retrieve(['workflow', 'memory_requirement'], 'lowmem'))
 
     ncpu = config_retrieve(['workflow', 'ncpu'], 4)
     job.cpu(ncpu)

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -13,7 +13,7 @@ def main():
 
     job = get_batch().new_job(f'Generate {args.index} from {args.mt_path}')
     job.image(config_retrieve(['workflow', 'driver_image']))
-    job.storage(config_retrieve(['workflow', 'storage_requirement'], '5000Gi'))
+    job.storage(config_retrieve(['workflow', 'storage_requirement'], '500Gi'))
     job.memory(config_retrieve(['workflow', 'memory_requirement'], 'lowmem'))
 
     ncpu = config_retrieve(['workflow', 'ncpu'], 4)

--- a/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
+++ b/cpg_workflows/dataproc_scripts/mt_no_dp_wrapper.py
@@ -13,7 +13,7 @@ def main():
 
     job = get_batch().new_job(f'Generate {args.index} from {args.mt_path}')
     job.image(config_retrieve(['workflow', 'driver_image']))
-    job.storage(config_retrieve(['workflow', 'storage_requirement'], '40Gi'))
+    job.storage(config_retrieve(['workflow', 'storage_requirement'], '5000Gi'))
     job.memory(config_retrieve(['workflow', 'memory_requirement'], 'lowmem'))
 
     ncpu = config_retrieve(['workflow', 'ncpu'], 4)

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -233,17 +233,12 @@ def main():
     es_client = ElasticsearchClient(host=host, port=port, es_username=username, es_password=password)
 
     # delete the index if it exists already
-    if es_client.es.indices.exists(index=args.es_index):
-        es_client.es.indices.delete(index=args.es_index)
+    if es_client.es.indices.exists(index=args.index):
+        es_client.es.indices.delete(index=args.index)
 
-    es_client.export_table_to_elasticsearch(
-        row_ht,
-        index_name=args.es_index,
-        num_shards=es_shards,
-        write_null_values=True,
-    )
+    es_client.export_table_to_elasticsearch(row_ht, index_name=args.index, num_shards=es_shards, write_null_values=True)
 
-    _cleanup(es_client, args.es_index, es_shards)
+    _cleanup(es_client, args.index, es_shards)
     with to_path(args.flag).open('w') as f:
         f.write('done')
 

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -279,7 +279,7 @@ def elasticsearch_row(mt: hl.MatrixTable):
     # Converts a mt to the row equivalent.
     table = mt.rows()
     if 'vep' in table.row:
-        table = mt.drop('vep')
+        table = table.drop('vep')
     key = table.key
     # Converts nested structs into one field, e.g. {a: {b: 1}} => a.b: 1
     flat_table = table.flatten()

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -279,7 +279,7 @@ def main():
     # https://github.com/broadinstitute/seqr-loading-pipelines/blob/c113106204165e22b7a8c629054e94533615e7d2/luigi_pipeline/lib/hail_tasks.py#L273
     # the denominator in this calculation used to be  1.4 * 10 ** 9, resulting in ~65GB shards
     # it's been reduced to give us more shards, closer to the optimum range 10-50GB
-    es_shards = math.ceil((mt.count_rows() * mt.count_cols()) / 10 ** 9)
+    es_shards = math.ceil((mt.count_rows() * mt.count_cols()) / 10**9)
 
     es_client = ElasticsearchClient(host=host, port=port, es_username=username, es_password=password)
 

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -11,7 +11,6 @@ import hail as hl
 from cpg_utils import to_path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import config_retrieve
-from cpg_utils.hail_batch import init_batch
 
 # make encoded values as human-readable as possible
 ES_FIELD_NAME_ESCAPE_CHAR = '$'
@@ -201,7 +200,7 @@ def main(password: str, mt_path: str, es_index: str, done_path: str):
     logging.info(f'Connecting to ElasticSearch: host="{host}", port="{port}", user="{username}"')
 
     # start a hail batch - this was hl.init('GRCh38') in Dataproc, but we won't have the related data networked as-local
-    init_batch()
+    hl.init(default_reference='GRCh38')
 
     mt = hl.read_matrix_table(mt_path)
 

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -200,7 +200,8 @@ def main(password: str, mt_path: str, es_index: str, done_path: str):
     logging.info(f'Connecting to ElasticSearch: host="{host}", port="{port}", user="{username}"')
 
     # start a hail batch - this was hl.init('GRCh38') in Dataproc, but we won't have the related data networked as-local
-    hl.init(default_reference='GRCh38')
+    hl.init(default_reference='GRCh38',
+            billing_project=config_retrieve(['hail', 'billing_project']))
 
     mt = hl.read_matrix_table(mt_path)
 

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -5,13 +5,13 @@ from io import StringIO
 from sys import exit
 
 import elasticsearch
+
 import hail as hl
 
 from cpg_utils import to_path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
-
 
 # make encoded values as human-readable as possible
 ES_FIELD_NAME_ESCAPE_CHAR = '$'
@@ -71,7 +71,7 @@ def encode_field_name(s):
     field_name = StringIO()
     for i, c in enumerate(s):
         if c == ES_FIELD_NAME_ESCAPE_CHAR:
-            field_name.write(2*ES_FIELD_NAME_ESCAPE_CHAR)
+            field_name.write(2 * ES_FIELD_NAME_ESCAPE_CHAR)
         elif c in ES_FIELD_NAME_SPECIAL_CHAR_MAP:
             field_name.write(ES_FIELD_NAME_SPECIAL_CHAR_MAP[c])  # encode the char
         else:
@@ -138,7 +138,7 @@ class ElasticsearchClient:
                     'index.mapping.total_fields.limit': 10000,
                     'index.refresh_interval': -1,
                     'index.codec': 'best_compression',  # halves disk usage, no difference in query times
-                }
+                },
             }
 
             logging.info(f'create_mapping - elasticsearch schema: \n{elasticsearch_schema}')
@@ -154,7 +154,7 @@ class ElasticsearchClient:
                 'es.nodes.wan.only': 'true',
                 'es.net.http.auth.user': self._es_username,
                 'es.net.http.auth.pass': self._es_password,
-            }
+            },
         )
         es_config['es.write.operation'] = 'index'
         # encode any special chars in column names
@@ -189,9 +189,7 @@ class ElasticsearchClient:
 
         self.create_mapping(index_name, elasticsearch_schema, num_shards=kwargs['num_shards'], _meta=_meta)
 
-        hl.export_elasticsearch(
-            table, self._host, int(self._port), index_name, '', 5000, es_config
-        )
+        hl.export_elasticsearch(table, self._host, int(self._port), index_name, '', 5000, es_config)
         self.es.indices.forcemerge(index=index_name, request_timeout=60)
 
 

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -1,9 +1,9 @@
 import logging
 import math
+import time
 from argparse import ArgumentParser
 from io import StringIO
 from sys import exit
-import time
 
 import elasticsearch
 
@@ -124,8 +124,11 @@ class ElasticsearchClient:
             if LOADING_NODES_NAME not in shards:
                 logging.warning("Shards are on {}".format(shards))
                 return
-            logging.warning("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
-                len(shards.strip().split("\n")), shards))
+            logging.warning(
+                "Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
+                    len(shards.strip().split("\n")), shards,
+                ),
+            )
             time.sleep(5)
 
         raise Exception('Shards did not transfer off loading nodes')

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -1,3 +1,10 @@
+"""
+I've peppered this with references to the original source code I'm borrowing/stealing from
+
+1 major source:
+https://github.com/broadinstitute/seqr-loading-pipelines/blob/c113106204165e22b7a8c629054e94533615e7d2/luigi_pipeline/lib/hail_tasks.py
+"""
+
 import logging
 import math
 import time
@@ -118,6 +125,7 @@ class ElasticsearchClient:
     def wait_for_shard_transfer(self, index_name, num_attempts=1000):
         """
         Wait for shards to move off of the loading nodes before connecting to seqr
+        https://github.com/broadinstitute/seqr-loading-pipelines/blob/c113106204165e22b7a8c629054e94533615e7d2/luigi_pipeline/lib/hail_tasks.py#L266
         """
         for i in range(num_attempts):
             shards = self.es.cat.shards(index=index_name)
@@ -294,6 +302,7 @@ def elasticsearch_row(mt: hl.MatrixTable):
 def _mt_num_shards(mt):
     """
     Calculate the number of shards from the number of variants and sequencing groups.
+    https://github.com/broadinstitute/seqr-loading-pipelines/blob/c113106204165e22b7a8c629054e94533615e7d2/luigi_pipeline/lib/hail_tasks.py#L273
     """
     denominator = 1.4 * 10**9
     calculated_num_shards = math.ceil((mt.count_rows() * mt.count_cols()) / denominator)

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -126,7 +126,8 @@ class ElasticsearchClient:
                 return
             logging.warning(
                 "Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
-                    len(shards.strip().split("\n")), shards,
+                    len(shards.strip().split("\n")),
+                    shards,
                 ),
             )
             time.sleep(5)

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -221,7 +221,6 @@ def main():
     parser.add_argument('--mt_path', help='MT path name', required=True)
     parser.add_argument('--index', help='ES index name', required=True)
     parser.add_argument('--flag', help='ES index "DONE" file path')
-    parser.add_argument('--cpu', help='number of available cores', default=4, type=int)
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
 
@@ -241,7 +240,8 @@ def main():
     username = config_retrieve(['elasticsearch', 'username'])
     logging.info(f'Connecting to ElasticSearch: host="{host}", port="{port}", user="{username}"')
 
-    hl.context.init_spark(master=f'local[{args.cpu}]', quiet=True)
+    ncpu = config_retrieve(['workflow', 'ncpu'], 4)
+    hl.context.init_spark(master=f'local[{ncpu}]', quiet=True)
     hl.default_reference('GRCh38')
 
     mt = hl.read_matrix_table(args.mt_path)

--- a/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
+++ b/cpg_workflows/dataproc_scripts/mt_to_es_free_of_dataproc.py
@@ -200,8 +200,7 @@ def main(password: str, mt_path: str, es_index: str, done_path: str):
     logging.info(f'Connecting to ElasticSearch: host="{host}", port="{port}", user="{username}"')
 
     # start a hail batch - this was hl.init('GRCh38') in Dataproc, but we won't have the related data networked as-local
-    hl.init(default_reference='GRCh38',
-            billing_project=config_retrieve(['hail', 'billing_project']))
+    hl.context.init_spark(default_reference='GRCh38')
 
     mt = hl.read_matrix_table(mt_path)
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
         'console_scripts': [
             # script for modifying the content of a sniffles VCF, used in Long-Read SV pipeline
             'modify_sniffles = cpg_workflows.scripts.long_read_sniffles_vcf_modifier:cli_main',
+            # for use in translating a MatrixTable to an ES index, first localising the MT
+            'mt_to_es = cpg_workflows.dataproc_scripts.mt_to_es_free_of_dataproc:main',
         ],
     },
 )


### PR DESCRIPTION
Closes #800

Tested here with a small Exome MT -> ES (2GB): https://batch.hail.populationgenomics.org.au/batches/461296

~Untested~

- We are currently locked into using the seqr-loading-pipelines code as a submodule, and DataProc as an execution environment, when building ElasticSearch indexes for Seqr
- This change takes all the methods and process that we use from seqr-loading-pipelines, skips all the content which is never triggered when we run an MTtoES transition. Once we remove all the code paths we never intend to execute, what's left is a fairly thin wrapper around the elasticsearch library and a few Hail Methods

## Process:

1. copy the target MT into the VM
2. start a Hail local Spark instance
3. generate the ES password from secrets in a config file - this removes the need to pass a secret in plain text
4. Uses the same MT -> flattened HT method as the existing script
5. Creates an ElasticSearchClient, modelled on the Hail version. This contains all the method calls we previously executed, instead of importing those methods from `seqr-loading-pipelines`
6. Removes the ES Index if it already exists (unexpected)
7. Pushes a new index by name to the ES instance, cleans up, and writes a 'DONE' file

This is complete theft:
- where we were importing/inheriting from the HailES Client, I've created an equivalent client with the same functionality (limited to only the methods/calls we actually execute)
- where we referenced constants in the SLP repo, or call methods which require constants, I've copied them in
- where SLP methods called out to Hail methods, we're using those Hail methods directly
- there's no doubt a need to more explicitly credit the client/code I'm ripping off here

some optimisation params: 
https://github.com/broadinstitute/seqr-loading-pipelines/blob/c113106204165e22b7a8c629054e94533615e7d2/hail_scripts/elasticsearch/hail_elasticsearch_client.py#L196-L206
https://www.elastic.co/guide/en/elasticsearch/hadoop/current/configuration.html