### PR TITLE
Update Hail pinning as we have deployed 0.2.132

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.5
+current_version = 1.25.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.5
+  VERSION: 1.25.6
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'cpg-utils>=5.0.4',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        'hail==0.2.130',  # Pin Hail at CPG's installed version
+        'hail==0.2.132',  # Pin Hail at CPG's installed version
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
         'grpcio-status>=1.62',  # Avoid dependency resolution backtracking

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ setup(
         'hail==0.2.132',  # Pin Hail at CPG's installed version
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
-        'grpcio-status>=1.62',  # Avoid dependency resolution backtracking
+        'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking
         'onnx',
         'onnxruntime',
         'skl2onnx',
         'metamist>=6.9.0',
         'pandas',
-        'peddy',
+        'peddy>=0.4.8',  # Avoid 0.4.7, which is incompatible
         'fsspec',
         'slack_sdk',
         'elasticsearch==8.*',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.5',
+    version='1.25.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
With the merging of populationgenomics/hail#344, our CPG Hail installation is now at 0.2.132+localpatches.

~~(But please wait until analysis-runner's driver image has been successfully rebuilt before merging this.)~~ 