### PR TITLE
Long read SV correction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.6
+current_version = 1.25.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.6
+  VERSION: 1.25.7
 
 jobs:
   docker:

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -114,7 +114,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')  # type: ignore
 
         # write from temp storage into GCP
-        get_batch().write_output(tabix_job.vcf_out, str(expected_outputs['vcf']).removesuffix('vcf.bgz'))
+        get_batch().write_output(tabix_job.vcf_out, str(expected_outputs['vcf']).removesuffix('.vcf.bgz'))
 
         return self.make_outputs(target=sequencing_group, jobs=[py_job, tabix_job], data=expected_outputs)
 
@@ -169,7 +169,7 @@ class MergeLongReadSVs(CohortStage):
         merge_job.command(f'tabix {merge_job.output["vcf.bgz"]}')  # type: ignore
 
         # write the result out
-        get_batch().write_output(merge_job.output, outputs['vcf'].removesuffix('vcf.bgz'))  # type: ignore
+        get_batch().write_output(merge_job.output, outputs['vcf'].removesuffix('.vcf.bgz'))  # type: ignore
 
         return self.make_outputs(cohort, data=outputs, jobs=merge_job)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.6',
+    version='1.25.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
accidentally wrote output files to XXX..vcf.bgz, I needed to strip the extra `.` out