### PR TITLE
Cohort analysis dataset name

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.8
+current_version = 1.25.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.8
+  VERSION: 1.25.9
 
 jobs:
   docker:

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -227,7 +227,7 @@ class Cohort(Target):
     def __init__(self, name: str | None = None, multicohort: MultiCohort | None = None) -> None:
         super().__init__()
         self.name = name or get_config()['workflow']['dataset']
-        self.analysis_dataset = Dataset(name=self.name, cohort=self)
+        self.analysis_dataset = Dataset(name=get_config()['workflow']['dataset'], cohort=self)
         self._datasets_by_name: dict[str, Dataset] = {}
         self.multicohort = multicohort
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.8',
+    version='1.25.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Currently we assign each Cohort object an attribute `analysis_dataset`
- The Dataset is created with ` Dataset(name=self.name, cohort=self)`, where `self.name` is the name of the CustomCohort
- Error: https://batch.hail.populationgenomics.org.au/batches/461943/jobs/1
- Error message: 

```
cpg_utils.config.ConfigError: Storage section for dataset "COH401" not found in config. Please check that you have permissions to the dataset. Expected section: [storage.COH401]
```

Solution
- When each CustomCohort needs to write to a bucket, it needs to access the config section `storage.XXXX[.analysis,default,tmp...]`, where XXXX has been the dataset.
- CustomCohorts are not tied to a single dataset, so this relationship doesn't hold
- analysis_dataset before CustomCohorts was the contents of `workflow.dataset`, a parent dataset with read permission on all data enclosed by the CustomCohort
- this change resumes the behaviour of cohort.anaylsis_dataset being the content of `workflow.dataset`
- this will not affect DatasetStage outputs, just CohortStages