### PR TITLE
Insert valid reference base in LR SV VCFs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.9
+current_version = 1.25.10
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.9
+  VERSION: 1.25.10
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -31,8 +31,8 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str):
             # for non-header lines, split on tabs
             l_split = line.split('\t')
 
-            # reduce the massive REF alleles to a single base
-            l_split[3] = l_split[3][0]
+            # reduce the massive REF alleles to a single symbolic base
+            l_split[3] = 'N'
 
             # e.g. AN_Orig=61;END=56855888;SVTYPE=DUP
             info_dict: dict[str, str] = {}

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -1,10 +1,10 @@
-def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str):
+def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, fa: str, fa_fai: str):
     """
     to be run as a PythonJob - scrolls through the VCF and performs a few updates:
 
     - replaces the External Sample ID with the internal CPG identifier
     - replaces the ALT allele with a symbolic "<TYPE>", derived from the SVTYPE INFO field
-    - reduces the massive REF String to only the base at the variant position
+    - swaps out the REF (huge for deletions, a symbolic "N" for insertions) with the ref base
 
     rebuilds the VCF following those edits, and writes the compressed data back out
 
@@ -13,8 +13,23 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str):
         file_out (str): local batch output path, same VCF with INFO/ALT alterations
         ext_id (str): external ID to replace (if found)
         int_id (str): CPG ID, required inside the reformatted VCF
+        fa (str): path to a reference FastA file
+        fa_fai (str): path to the index
     """
     import gzip
+
+    import hail as hl
+
+    # initiate a batch
+    hl.init()
+    # set the default reference
+    hl.default_reference('GRCh38')
+
+    # create a ReferenceGenome object
+    rg_38 = hl.ReferenceGenome('GRCh38')
+
+    # add the sequence
+    rg_38.add_sequence(fasta_file=fa, index_file=fa_fai)
 
     # read and write compressed. This is only a single sample VCF, but... it's good practice
     with gzip.open(file_in, 'rt') as f, gzip.open(file_out, 'wt') as f_out:
@@ -31,8 +46,8 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str):
             # for non-header lines, split on tabs
             l_split = line.split('\t')
 
-            # reduce the massive REF alleles to a single symbolic base
-            l_split[3] = 'N'
+            # set the reference allele to be the correct reference base
+            l_split[3] = hl.eval(hl.get_sequence(l_split[0], int(l_split[1]), reference_genome=rg_38))
 
             # e.g. AN_Orig=61;END=56855888;SVTYPE=DUP
             info_dict: dict[str, str] = {}

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -98,14 +98,11 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             sequencing_group.external_id,
             sequencing_group.id,
             fasta.fa,
-            fasta.fai
+            fasta.fai,
         )
 
         # block-gzip and index that result
-        tabix_job = get_batch().new_job(
-            name=f'BGZipping and Indexing for {sequencing_group.id}',
-            attributes={'tool': 'bcftools'},
-        )
+        tabix_job = get_batch().new_job(f'BGZipping and Indexing for {sequencing_group.id}', {'tool': 'bcftools'})
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         tabix_job.image(image=image_path('bcftools'))
         tabix_job.storage('10Gi')

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -69,8 +69,8 @@ class ReFormatPacBioSVs(SequencingGroupStage):
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
         return {
-            'vcf': self.prefix / f'{sequencing_group.id}_reformatted_svs.vcf.bgz',
-            'index': self.prefix / f'{sequencing_group.id}_reformatted_svs.vcf.bgz.tbi',
+            'vcf': self.prefix / f'{sequencing_group.id}_reformatted_lr_svs.vcf.bgz',
+            'index': self.prefix / f'{sequencing_group.id}_reformatted_lr_svs.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.9',
+    version='1.25.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
bcftools concat is running into issues when we merge the long-read SV files prior to annotation:

```
The REF prefixes differ: A vs N (1,1)
Failed to merge alleles at chr1:180578 in /io/batch/847ab6/inputs/A5vQV/<ONE_OF_THE_FILES>
```

- Sniffles `Insertions` contain a REF allele of "N"
- Sniffles `Deletions` contain a REF allele of the full inserted sequence
- Both use SVTYPE and SVLEN fields to determine the insertion content

I've was taking the first base of the REF string to make the VCF annotate-able, but when we merge/concat files together, the same contig & position will have a base if it was a deletion, and a N if it's an insertion, which is invalid.

This change inserts the actual reference base for the Chr & Pos when iterating over the variants.

I'm doing this using Hail - create a reference genome, add the corresponding sequence, then recall specific bases from the reference genome object ([ref](https://hail.is/docs/0.2/functions/genetics.html#hail.expr.functions.get_sequence))


## Alternative

We could also get around this by assigning `N` as the reference base consistently, and `<SVTYPE>` as the symbolic alt, but I'm not sure whether we'll run into issues downstream (Seqr? Hail?) when reading `chr:pos:N` as a valid Locus.