### PR TITLE
LR SV pythonJob fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.10
+current_version = 1.25.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.10
+  VERSION: 1.25.11
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -18,8 +18,9 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, f
     """
     import gzip
 
-    from cpg_utils.hail_batch import init_batch
     import hail as hl
+
+    from cpg_utils.hail_batch import init_batch
 
     # initiate a batch - must be a service backend in a PythonJob?
     init_batch()

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -18,12 +18,11 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, f
     """
     import gzip
 
+    from cpg_utils.hail_batch import init_batch
     import hail as hl
 
-    # initiate a batch
-    hl.init()
-    # set the default reference
-    hl.default_reference('GRCh38')
+    # initiate a batch - must be a service backend in a PythonJob?
+    init_batch()
 
     # create a ReferenceGenome object
     rg_38 = hl.ReferenceGenome('GRCh38')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.10',
+    version='1.25.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Hail runtime requires service backend?

See https://batch.hail.populationgenomics.org.au/batches/461977/jobs/1
ValueError: No billing project.  Call 'init_batch' with the billing project or run 'hailctl config set batch/billing_project MY_BILLING_PROJECT'

Despite using localised files, it looks like running hail inside a python_job might need to be initialised with a service backend?

I'm genuinely not sure if this is the solution, I was surprised this was a requirement...