### PR TITLE
Don't re-create the Hail reference

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.11
+current_version = 1.25.12
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.11
+  VERSION: 1.25.12
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/seqr_loader_long_read.py
+++ b/cpg_workflows/jobs/seqr_loader_long_read.py
@@ -25,10 +25,10 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, f
     # initiate a batch - must be a service backend in a PythonJob?
     init_batch()
 
-    # create a ReferenceGenome object
-    rg_38 = hl.ReferenceGenome('GRCh38')
+    # use the existing GRCh38 reference hail knows about
+    rg_38 = hl.get_reference('GRCh38')
 
-    # add the sequence
+    # add the sequence to pull from
     rg_38.add_sequence(fasta_file=fa, index_file=fa_fai)
 
     # read and write compressed. This is only a single sample VCF, but... it's good practice

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -424,7 +424,8 @@ class RunHailFiltering(DatasetStage):
             f'--pedigree {local_ped} '
             f'--vcf_out {job.output["vcf.bgz"]} '
             f'--clinvar "${{BATCH_TMPDIR}}/{clinvar_name}" '
-            f'--pm5 "${{BATCH_TMPDIR}}/{pm5_name}" ',
+            f'--pm5 "${{BATCH_TMPDIR}}/{pm5_name}" '
+            f'--checkpoint "${{BATCH_TMPDIR}}/checkpoint.mt" ',
         )
         get_batch().write_output(job.output, str(expected_out["labelled_vcf"]).removesuffix('.vcf.bgz'))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.11',
+    version='1.25.12',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Tested locally. I mean... I thought the previous syntax was tested locally as well, but it was effectively trying to register a new reference genome called `GRCh38`, despite Hail already knowing about a reference called `GRCh38`, so it was rejected.

Instead the process needs to be
- get the existing reference 
- attach a sequence source to it
- query it for positions

Local:
```
Python 3.11.0 (main, Nov 16 2022, 11:15:40) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import hail as hl
>>> hl.init()
...
Welcome to
     __  __     <>__
    / /_/ /__  __/ /
   / __  / _ `/ / /
  /_/ /_/\_,_/_/_/   version 0.2.131-11d9b2ff89da
LOGGING: writing to /Users/mwelland/binfx/hail-20240716-1415-0.2.131-11d9b2ff89da.log
>>> hl.default_reference('GRCh38')
>>> rg38 = hl.get_reference('GRCh38')
>>> rg38.add_sequence(fasta_file=f'Homo_sapiens_assembly38_masked.fasta', index_file='Homo_sapiens_assembly38_masked.fasta.fai')
>>> hl.eval(hl.get_sequence('chr1', 1234568, reference_genome=rg38))
'G' 
```

