### PR TITLE
Sniffles: No more python job

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.12
+current_version = 1.25.13
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.12
+  VERSION: 1.25.13
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -8,10 +8,10 @@ def cli_main():
     parser = ArgumentParser(description='CLI for the Sniffles VCF modification script')
     parser.add_argument('--vcf_in', help='Path to a localised VCF, this will be modified', required=True)
     parser.add_argument('--vcf_out', help='Path to an output location for the modified VCF', required=True)
-    parser.add_argument('--ext_id', help='Path to the Sample ID in the input VCF', default=None)
-    parser.add_argument('--int_id', help='Path to the Sample ID we want in the output VCF', default=None)
     parser.add_argument('--fa', help='Path to a FASTA sequence file for GRCh38', required=True)
     parser.add_argument('--fai', help='Path to a FASTA.fai sequence index file for GRCh38', required=True)
+    parser.add_argument('--ext_id', help='Path to the Sample ID in the input VCF', default=None)
+    parser.add_argument('--int_id', help='Path to the Sample ID we want in the output VCF', default=None)
     args, unknown = parser.parse_known_args()
 
     if unknown:
@@ -20,10 +20,10 @@ def cli_main():
     modify_sniffles_vcf(
         file_in=args.vcf_in,
         file_out=args.vcf_out,
-        ext_id=args.ext_id,
-        int_id=args.int_id,
         fa=args.fa,
         fa_fai=args.fai,
+        ext_id=args.ext_id,
+        int_id=args.int_id,
     )
 
 

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -1,8 +1,44 @@
-def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, fa: str, fa_fai: str):
-    """
-    to be run as a PythonJob - scrolls through the VCF and performs a few updates:
+import gzip
+from argparse import ArgumentParser
 
-    - replaces the External Sample ID with the internal CPG identifier
+import hail as hl
+
+
+def cli_main():
+    parser = ArgumentParser(description='CLI for the Sniffles VCF modification script')
+    parser.add_argument('--vcf_in', help='Path to a localised VCF, this will be modified', required=True)
+    parser.add_argument('--vcf_out', help='Path to an output location for the modified VCF', required=True)
+    parser.add_argument('--ext_id', help='Path to the Sample ID in the input VCF', default=None)
+    parser.add_argument('--int_id', help='Path to the Sample ID we want in the output VCF', default=None)
+    parser.add_argument('--fa', help='Path to a FASTA sequence file for GRCh38', required=True)
+    parser.add_argument('--fai', help='Path to a FASTA.fai sequence index file for GRCh38', required=True)
+    args, unknown = parser.parse_known_args()
+
+    if unknown:
+        raise ValueError(f'Unknown input flag(s) used: {unknown}')
+
+    modify_sniffles_vcf(
+        file_in=args.vcf_in,
+        file_out=args.vcf_out,
+        ext_id=args.ext_id,
+        int_id=args.int_id,
+        fa=args.fa,
+        fa_fai=args.fai,
+    )
+
+
+def modify_sniffles_vcf(
+    file_in: str,
+    file_out: str,
+    fa: str,
+    fa_fai: str,
+    ext_id: str | None = None,
+    int_id: str | None = None,
+):
+    """
+    Scrolls through the VCF and performs a few updates:
+
+    - replaces the External Sample ID with the internal CPG identifier (if both are provided)
     - replaces the ALT allele with a symbolic "<TYPE>", derived from the SVTYPE INFO field
     - swaps out the REF (huge for deletions, a symbolic "N" for insertions) with the ref base
 
@@ -11,19 +47,14 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, f
     Args:
         file_in (str): localised, VCF directly from Sniffles
         file_out (str): local batch output path, same VCF with INFO/ALT alterations
+        fa (str): path to a reference FastA file
+        fa_fai (str): path to the FA index
         ext_id (str): external ID to replace (if found)
         int_id (str): CPG ID, required inside the reformatted VCF
-        fa (str): path to a reference FastA file
-        fa_fai (str): path to the index
     """
-    import gzip
 
-    import hail as hl
-
-    from cpg_utils.hail_batch import init_batch
-
-    # initiate a batch - must be a service backend in a PythonJob?
-    init_batch()
+    # initialise a local hail runtime
+    hl.context.init_local(default_reference='GRCh38')
 
     # use the existing GRCh38 reference hail knows about
     rg_38 = hl.get_reference('GRCh38')
@@ -37,7 +68,7 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, f
         for line in f:
             # alter the sample line in the header
             if line.startswith('#'):
-                if line.startswith('#CHR'):
+                if line.startswith('#CHR') and (ext_id and int_id):
                     line.replace(ext_id, int_id)
 
                 f_out.write(line)
@@ -60,3 +91,8 @@ def modify_sniffles_vcf(file_in: str, file_out: str, ext_id: str, int_id: str, f
             l_split[4] = f'<{info_dict["SVTYPE"]}>'
             # rebuild the string and write as output
             f_out.write('\t'.join(l_split))
+
+
+if __name__ == '__main__':
+    # if called as a script, call through to the ArgParse CLI
+    cli_main()

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -90,7 +90,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         ref_fasta = config_retrieve(['workflow', 'ref_fasta'])
         fasta = get_batch().read_input_group(fa=ref_fasta, fai=f'{ref_fasta}.fai')
 
-        # the console entrypoint for the sniffles modifier script has only existed since 1.25.12, requires >=1.25.12
+        # the console entrypoint for the sniffles modifier script has only existed since 1.25.13, requires >=1.25.13
         modifier_job.command(
             f'modify_sniffles '
             f'--vcf_in {local_vcf} '

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -83,7 +83,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         lr_sv_vcf: str = query_result[sequencing_group.id]
         local_vcf = get_batch().read_input(lr_sv_vcf)
 
-        modifier_job = get_batch().new_python_job(f'Convert {lr_sv_vcf} prior to annotation')
+        modifier_job = get_batch().new_bash_job(f'Convert {lr_sv_vcf} prior to annotation')
         modifier_job.storage('10Gi')
 
         # mandatory argument

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -7,7 +7,6 @@ from functools import cache
 from cpg_utils import Path
 from cpg_utils.config import AR_GUID_NAME, config_retrieve, image_path, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch
-from cpg_workflows.jobs import seqr_loader_long_read
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import queue_annotate_sv_jobs
 from cpg_workflows.targets import Cohort, SequencingGroup
 from cpg_workflows.workflow import CohortStage, SequencingGroupStage, StageInput, StageOutput, stage
@@ -84,21 +83,22 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         lr_sv_vcf: str = query_result[sequencing_group.id]
         local_vcf = get_batch().read_input(lr_sv_vcf)
 
-        py_job = get_batch().new_python_job(f'Convert {lr_sv_vcf} prior to annotation')
-        py_job.storage('10Gi')
+        modifier_job = get_batch().new_python_job(f'Convert {lr_sv_vcf} prior to annotation')
+        modifier_job.storage('10Gi')
 
         # mandatory argument
         ref_fasta = config_retrieve(['workflow', 'ref_fasta'])
         fasta = get_batch().read_input_group(fa=ref_fasta, fai=f'{ref_fasta}.fai')
 
-        py_job.call(
-            seqr_loader_long_read.modify_sniffles_vcf,
-            local_vcf,
-            py_job.output,
-            sequencing_group.external_id,
-            sequencing_group.id,
-            fasta.fa,
-            fasta.fai,
+        # the console entrypoint for the sniffles modifier script has only existed since 1.25.12, requires >=1.25.12
+        modifier_job.command(
+            f'modify_sniffles '
+            f'--vcf_in {local_vcf} '
+            f'--vcf_out {modifier_job.output} '
+            f'--ext_id {sequencing_group.external_id} '
+            f'--int_id {sequencing_group.id} '
+            f'--fa {fasta.fa} '
+            f'--fai {fasta.fai} ',
         )
 
         # block-gzip and index that result
@@ -106,13 +106,13 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         tabix_job.image(image=image_path('bcftools'))
         tabix_job.storage('10Gi')
-        tabix_job.command(f'bcftools view {py_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')  # type: ignore
-        tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')  # type: ignore
+        tabix_job.command(f'bcftools view {modifier_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')
+        tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')
 
         # write from temp storage into GCP
         get_batch().write_output(tabix_job.vcf_out, str(expected_outputs['vcf']).removesuffix('.vcf.bgz'))
 
-        return self.make_outputs(target=sequencing_group, jobs=[py_job, tabix_job], data=expected_outputs)
+        return self.make_outputs(target=sequencing_group, jobs=[modifier_job, tabix_job], data=expected_outputs)
 
 
 @stage(required_stages=ReFormatPacBioSVs)

--- a/setup.py
+++ b/setup.py
@@ -57,4 +57,10 @@ setup(
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
+    entry_points={
+        'console_scripts': [
+            # script for modifying the content of a sniffles VCF, used in Long-Read SV pipeline
+            'modify_sniffles = cpg_workflows.scripts.long_read_sniffles_vcf_modifier:cli_main',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.12',
+    version='1.25.13',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Screw python jobs

- create a standalone script to run the VCF modification
- runs with a hail local context specifically, leaving nothing up to chance
- the path to the script it set as an entrypoint in the cpg_workflows package - exact path to the file inside the container isn't required

The output file still goes through recompression and indexing in a subsequent job

This is a departure from the way we do a lot of things, but it removes the need to use python_jobs or query_command, leaving a simple CLI interface