### PR TITLE
Scrap Hail in sniffles update

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.14
+current_version = 1.25.15
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.14
+  VERSION: 1.25.15
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -53,6 +53,7 @@ def modify_sniffles_vcf(
         int_id (str): CPG ID, required inside the reformatted VCF
     """
 
+    # as_raw as a specifier here means that get_seq queries are just the sequence, no contig ID attached
     fasta_client = Fasta(filename=fa, indexname=fa_fai, as_raw=True)
 
     # read and write compressed. This is only a single sample VCF, but... it's good practice

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -60,8 +60,9 @@ def modify_sniffles_vcf(
 
         for index, line in enumerate(f):
 
-            if index % 100 == 0:
-                print(f'line {index}')
+            if index % 10000 == 0:
+                print(f'Lines processed: {index}')
+
             # alter the sample line in the header
             if line.startswith('#'):
                 if line.startswith('#CHR') and (ext_id and int_id):

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -84,7 +84,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         local_vcf = get_batch().read_input(lr_sv_vcf)
 
         modifier_job = get_batch().new_bash_job(f'Convert {lr_sv_vcf} prior to annotation')
-        modifier_job.storage('10Gi').memory('highmem').cpu(2)
+        modifier_job.storage('10Gi')
         modifier_job.image(config_retrieve(['workflow', 'driver_image']))
 
         # mandatory argument

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.14',
+    version='1.25.15',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'metamist>=6.9.0',
         'pandas',
         'peddy>=0.4.8',  # Avoid 0.4.7, which is incompatible
+        'pyfaidx>=0.8.1.1',
         'fsspec',
         'slack_sdk',
         'elasticsearch==8.*',


### PR DESCRIPTION
Ok, Hail was a bust - Using Hail to query for individual bases not only blew up the RAM consumption (the VM exploded when it tried to exceed 14GB), it also blew up the time taken (task would fail after 2 hours).

These VCFs only contain ~50k rows...

I've scrapped Hail in this job and used `pyfaidx` ([link](https://pypi.org/project/pyfaidx/)). This is just a pure python implementation of Samtools faidx, using the index file to randomly jump to a base, sequence, contig... It's a super single purpose optimised library, and it is fantastic.

After the last debacle [HERE](https://batch.hail.populationgenomics.org.au/batches/463009) where this stage spun for 2 hours and did nothing but rack up bills, I localised the VCF and tried to check if the Hail process would work on my machine. It would not. Even adding sleeps between every ~5000 variants processed allowed for some memory management in Java, but the tasks still couldn't complete. One attempt got tantalisingly close at 45 mins in, eventually failing only 1000 lines from the end of the file. 

This version with pyfaidx on the same file took 3.5 seconds. F**k Hail reference queries.

I've also dropped in a little validation - for the DELetions we have the Reference bases, so I do a quick check that the pyfaidx reference base matches with the base Sniffles already shoved in the VCF