### PR TITLE
SVAnnotate requires single alt alleles

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.16
+current_version = 1.25.17
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.16
+  VERSION: 1.25.17
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -67,7 +67,9 @@ def modify_sniffles_vcf(
             # alter the sample line in the header
             if line.startswith('#'):
                 if line.startswith('#CHR') and (ext_id and int_id):
-                    line.replace(ext_id, int_id)
+                    line = line.replace(ext_id, int_id)
+                    print('Modified header line')
+                    print(line)
 
                 f_out.write(line)
                 continue

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -60,8 +60,8 @@ class ReFormatPacBioSVs(SequencingGroupStage):
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
         return {
-            'vcf': self.prefix / f'{sequencing_group.id}_reformatted_lr_svs.vcf.bgz',
-            'index': self.prefix / f'{sequencing_group.id}_reformatted_lr_svs.vcf.bgz.tbi',
+            'vcf': self.prefix / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz',
+            'index': self.prefix / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -161,7 +161,7 @@ class MergeLongReadSVs(CohortStage):
         # -0: compression level
         merge_job.command(
             f'bcftools merge {" ".join(batch_vcfs)} -Oz -o '
-            f'{merge_job.output["vcf.bgz"]} --threads 4 -m all -0',  # type: ignore
+            f'{merge_job.output["vcf.bgz"]} --threads 4 -m none -0',  # type: ignore
         )
         merge_job.command(f'tabix {merge_job.output["vcf.bgz"]}')  # type: ignore
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.16',
+    version='1.25.17',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
It's a day ending in Y, so it's about time we had a LR SV commit

2 issues resolved here

- really dumb: `str.replace(A, B)` returns the new String, rather than doing an in-place change. This means that the VCFs produced so far don't have updated SG IDs in the header
  - the vcfs already created here have been recorded in metamist. They should probably be deleted on file and in metamist, but I've altered the expected output filename instead to force recreation of these intermediate files.
- less dumb? The bcftools merge was failing before due to reference base issues (now thankfully resolved), so I never got far enough to stress test the SV annotation step - the `merge` was done with `-m all` (merge all alts into a single row). That behaviour is fine with VEP, it's not fine with SVAnnotate

```
java.lang.IllegalArgumentException: Expected single ALT allele, found multiple: [<INS>, <DEL>]
```

Easy fix, just change the -m argument. No need to follow the merge with a normalisation step