### PR TITLE
Use sort-safe ID

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.17
+current_version = 1.25.18
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.17
+  VERSION: 1.25.18
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -96,6 +96,11 @@ def modify_sniffles_vcf(
 
             # replace the alt with a symbolic String
             l_split[4] = f'<{info_dict["SVTYPE"]}>'
+
+            # replace the UID with something meaningful: type_chrom_pos_end
+            # this is required as GATK-SV's annotation module sorts on ID, not on anything useful
+            l_split[2] = f'{info_dict["SVTYPE"]}_{l_split[0]}_{l_split[1]}_{info_dict["END"]}'
+
             # rebuild the string and write as output
             f_out.write('\t'.join(l_split))
 

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -50,7 +50,7 @@ def query_for_sv_vcfs(dataset_name: str) -> dict[str, str]:
     return return_dict
 
 
-@stage(analysis_keys=['vcf'], analysis_type='custom')
+@stage(analysis_keys=['vcf'])
 class ReFormatPacBioSVs(SequencingGroupStage):
     """
     take each of the long-read SV VCFs, and re-format the contents
@@ -135,7 +135,7 @@ class MergeLongReadSVs(CohortStage):
 
         outputs = self.expected_outputs(cohort)
 
-        # do a slapdash bcftools merge on all input files...
+        # do a bcftools merge on all input files
         modified_vcfs = inputs.as_dict_by_target(ReFormatPacBioSVs)
 
         batch_vcfs = [
@@ -143,7 +143,6 @@ class MergeLongReadSVs(CohortStage):
             for each_vcf in [str(modified_vcfs[sgid]['vcf']) for sgid in cohort.get_sequencing_group_ids()]
         ]
 
-        # just gonna create a job and commands here... this could be in a jobs file, but... shrug
         merge_job = get_batch().new_job('Merge Long-Read SV calls', attributes={'tool': 'bcftools'})
         merge_job.image(image=image_path('bcftools'))
 
@@ -171,7 +170,7 @@ class MergeLongReadSVs(CohortStage):
         return self.make_outputs(cohort, data=outputs, jobs=merge_job)
 
 
-@stage(required_stages=MergeLongReadSVs, analysis_type='custom', analysis_keys=['annotated_vcf'])
+@stage(required_stages=MergeLongReadSVs, analysis_type='vcf', analysis_keys=['annotated_vcf'])
 class AnnotateLongReadSVs(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.17',
+    version='1.25.18',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Day ending in Y, yadda yadda...

GATK-SV's annotation is a nightmare of bash and awk file munging. One particular issue (previously solved [here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/jobs/gcnv.py#L610)) is that the IDs assigned to each variant are used to sort (instead of something useful like chr, pos).

I genuinely don't know if that's the cause here, or if it's something else... 

There's a failure when combining the different types of SV (each annotated with AF separately)

```
[E::hts_idx_push] Unsorted positions on sequence #1: 83882 followed by 11467
tbx_index_build failed: COH401.chr5.0.annotated.vcf.gz
```

The relevant bit of GATK-SV command is [here](https://github.com/broadinstitute/gatk-sv/blob/7e7f2f713a669afa40f0763cb1eb52ace35eeaf6/wdl/AnnotateExternalAFPerShard.wdl#L423-L474).

caused by attempting to tabix:

```
chr5	11495	Sniffles2.INS.1S4	T	<INS> ...
chr5	11495	Sniffles2.INS.1S4	T	<INS> ...
chr5	83882	Sniffles2.INS.3S4	C	<INS> ...
chr5	11467	Sniffles2.INS.2S4	A	<INS> ...
```

I don't know if this PR is the solution, I can't explain the current behaviour. I don't know why the first variant is there twice, or why `chr5:83882` barrels in out of absolutely nowhere. This result is doubly unsorted - 83882 _is_ out of order, but so is the following variant, which should come first. This isn't even sorted on ID correctly. 

Nothing about this makes sense to me, but fixing the ID has solved a similar problem in the past, and may solve here.

We can always shelve this and investigate further, but without moving all this data to test we don't have a super robust way to try this out...

Is copying all these LR SV VCFs over to test a valid idea? This is the billionth PR on this topic and I still don't feel like this is in a good state, so more flexible test runs could be perfect.

---

Unrelated, I've removed the registration of these intermediate VCFs in metamist - they're all garbage, and shouldn't be used again. May as well write them in temp. 

I've also changed the merged VCF result from `custom` to `vcf`.
