### PR TITLE
sr_bothsides_pass -> sr_bothside_pass

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -725,7 +725,7 @@ class MakeCohortVcf(MultiCohortStage):
 
         pesr_vcfs = [genotypebatch_outputs[cohort]['genotyped_pesr_vcf'] for cohort in all_batch_names]
         depth_vcfs = [genotypebatch_outputs[cohort]['genotyped_depth_vcf'] for cohort in all_batch_names]
-        sr_pass = [genotypebatch_outputs[cohort]['sr_bothsides_pass'] for cohort in all_batch_names]
+        sr_pass = [genotypebatch_outputs[cohort]['sr_bothside_pass'] for cohort in all_batch_names]
         sr_fail = [genotypebatch_outputs[cohort]['sr_background_fail'] for cohort in all_batch_names]
         depth_depth_cutoff = [
             genotypebatch_outputs[cohort]['trained_genotype_depth_depth_sepcutoff'] for cohort in all_batch_names


### PR DESCRIPTION
See https://batch.hail.populationgenomics.org.au/batches/466741/jobs/1

in GATK-SV https://github.com/search?q=repo%3Abroadinstitute%2Fgatk-sv%20sr_bothside_pass&type=code

At some point I unintentionally changed this argument name to "sr_bothsides_pass", which I think is grammatically better, but is not the correct variable name. The workflow writes to the correct key, but when it tries to find that output later it uses an incorrect key