### PR TITLE
Allow for sniffles breakends

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.18
+current_version = 1.25.19
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.18
+  VERSION: 1.25.19
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -78,7 +78,9 @@ def modify_sniffles_vcf(
             l_split = line.split('\t')
 
             # set the reference allele to be the correct reference base
-            new_base = fasta_client.get_seq(l_split[0], int(l_split[1]), int(l_split[1]))
+            chrom = l_split[0]
+            position = int(l_split[1])
+            new_base = fasta_client.get_seq(chrom, position, position)
 
             # a quick check, if we can
             if l_split[3] != 'N':
@@ -94,12 +96,18 @@ def modify_sniffles_vcf(
                     key, value = entry.split('=')
                     info_dict[key] = value
 
+            # get the SVTYPE, always present
+            sv_type = info_dict['SVTYPE']
+
             # replace the alt with a symbolic String
-            l_split[4] = f'<{info_dict["SVTYPE"]}>'
+            l_split[4] = f'<{sv_type}>'
+
+            # breakends (BND) aren't annotated with an END or SVLEN so we use an identical position for both ends
+            end_position = info_dict.get('END', position)
 
             # replace the UID with something meaningful: type_chrom_pos_end
             # this is required as GATK-SV's annotation module sorts on ID, not on anything useful
-            l_split[2] = f'{info_dict["SVTYPE"]}_{l_split[0]}_{l_split[1]}_{info_dict["END"]}'
+            l_split[2] = f'{sv_type}_{chrom}_{position}_{end_position}'
 
             # rebuild the string and write as output
             f_out.write('\t'.join(l_split))

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -106,9 +106,11 @@ def modify_sniffles_vcf(
             # breakends (BND) aren't annotated with an END or SVLEN, so we use the CHR2 value
             if 'END' in info_dict:
                 end_position = info_dict['END']
-            else:
+            elif 'CHR2' in info_dict:
                 # No END in INFO, using CHR2
                 end_position = info_dict['CHR2']
+            else:
+                end_position = str(position)
 
             # replace the UID with something meaningful: type_chrom_pos_end
             # this is required as GATK-SV's annotation module sorts on ID, not on anything useful

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -67,6 +67,7 @@ def modify_sniffles_vcf(
             # alter the sample line in the header
             if line.startswith('#'):
                 if line.startswith('#CHR') and (ext_id and int_id):
+                    print(line)
                     line = line.replace(ext_id, int_id)
                     print('Modified header line')
                     print(line)
@@ -102,8 +103,12 @@ def modify_sniffles_vcf(
             # replace the alt with a symbolic String
             l_split[4] = f'<{sv_type}>'
 
-            # breakends (BND) aren't annotated with an END or SVLEN so we use an identical position for both ends
-            end_position = info_dict.get('END', position)
+            # breakends (BND) aren't annotated with an END or SVLEN, so we use the CHR2 value
+            if 'END' in info_dict:
+                end_position = info_dict['END']
+            else:
+                # No END in INFO, using CHR2
+                end_position = info_dict['CHR2']
 
             # replace the UID with something meaningful: type_chrom_pos_end
             # this is required as GATK-SV's annotation module sorts on ID, not on anything useful

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.18',
+    version='1.25.19',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
N+1

This change allows for BND variant types in the data - these don't have an END attribute, instead they have a `CHR2` attribute pointing to the location of the other breakpoint.

Hopefully all situations accounted for - 
- END present? Use END
- CHR2 present? Use CHR2
- Neither present? Repeat Start position

I've tested this locally (again), so IDs work predictably, but I can't easily confirm whether the ID in this format will satisfy the GATK-SV annotation ordering