### PR TITLE
Correction to GATK-SV PED file name

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -90,7 +90,7 @@ def query_for_spicy_vcf(dataset: str) -> str | None:
 @stage(analysis_keys=['cohort_ped'], analysis_type='custom')
 class MakeCohortCombinedPed(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return {'cohort_ped': self.get_stage_cohort_prefix(cohort) / 'combined_pedigree.ped'}
+        return {'cohort_ped': self.get_stage_cohort_prefix(cohort) / 'ped_with_ref_panel.ped'}
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
         output = self.expected_outputs(cohort)
@@ -104,7 +104,7 @@ class MakeCohortCombinedPed(CohortStage):
 @stage(analysis_keys=['multicohort_ped'], analysis_type='custom')
 class MakeMultiCohortCombinedPed(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
-        return {'multicohort_ped': self.prefix / 'combined_pedigree.ped'}
+        return {'multicohort_ped': self.prefix / 'ped_with_ref_panel.ped'}
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
         output = self.expected_outputs(multicohort)


### PR DESCRIPTION
When this was moved to MultiCohorts I changed the structure a little here - instead of each Stage creating its own copy of the Ped file, I made a couple of new stages, each of which writes a pedigree file for use across the whole pipeline.

I slipped up and failed to realise that the name of that pedigree file is hard coded in that method, so I couldn't easily just come up with a new name for it.

See contents of `gs://cpg-bioheart-main/gatk_sv/COH716/MakeCohortCombinedPed`

Cromwell error:

```
ERROR: (gcloud.storage.cp) The following URLs matched no objects or files:
-gs://cpg-bioheart-main/gatk_sv/COH716/MakeCohortCombinedPed/combined_pedigree.ped
```

