### PR TITLE
Createsamplebatches json sgs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.20
+current_version = 1.25.21
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.20
+  VERSION: 1.25.21
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/sample_batching.py
+++ b/cpg_workflows/jobs/sample_batching.py
@@ -7,7 +7,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from cpg_utils import Path, to_path
+from cpg_utils import to_path
 from cpg_workflows.utils import get_logger
 
 SEX_VALS = {'male', 'female'}

--- a/cpg_workflows/jobs/sample_batching.py
+++ b/cpg_workflows/jobs/sample_batching.py
@@ -7,7 +7,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from cpg_utils import to_path
+from cpg_utils import Path, to_path
 from cpg_workflows.utils import get_logger
 
 SEX_VALS = {'male', 'female'}
@@ -194,7 +194,7 @@ def add_sg_meta_fields(sg_df: pd.DataFrame, sg_meta: dict[str, dict]) -> pd.Data
 
 def partition_batches(
     metadata_files: list[str],
-    sequencing_groups: dict[str, dict],
+    sequencing_groups_json: str,
     output_json: str,
     min_batch_size: int,
     max_batch_size: int,
@@ -208,7 +208,7 @@ def partition_batches(
 
     Args:
         metadata_files (list[str]): paths to the metadata files
-        sequencing_groups (dict[str, dict]): all SGs in scope with their meta
+        sequencing_groups_json (str): path to json of all SGs with their meta
         output_json (str): location to write the batch result
         min_batch_size (int): minimum batch size
         max_batch_size (int): maximum batch size
@@ -220,6 +220,10 @@ def partition_batches(
     # load in the metadata files
     md = pd.concat([pd.read_csv(md_file, sep='\t', low_memory=False) for md_file in metadata_files])
     md.columns = [x.replace('#', '') for x in md.columns]  # type: ignore
+
+    # load the sequencing groups
+    with to_path(sequencing_groups_json).open('r') as f:
+        sequencing_groups = json.load(f)
 
     # filter to the PCR-state SGs we're interested in
     sample_ids = list(sequencing_groups.keys())

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -2,11 +2,12 @@
 single-sample components of the GATK SV workflow
 """
 
+import json
 import logging
 from typing import Any
 
-from cpg_utils import Path
-from cpg_utils.config import AR_GUID_NAME, config_retrieve, try_get_ar_guid
+from cpg_utils import Path, to_path
+from cpg_utils.config import AR_GUID_NAME, config_retrieve, dataset_path, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs import sample_batching
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
@@ -235,10 +236,15 @@ class CreateSampleBatches(MultiCohortStage):
         if config_retrieve(['workflow', 'sequencing_type']) != 'genome':
             raise RuntimeError('This workflow is not intended for Exome data')
 
+        # Get the sequencing groups and write them to a json file in tmp
         sequencing_groups = {
             sequencing_group.id: sequencing_group.meta for sequencing_group in multicohort.get_sequencing_groups()
         }
+        sgs_tmp_json_path = to_path(self.tmp_prefix / 'sgs_meta.json')
+        with sgs_tmp_json_path.open('w') as f:
+            json.dump(sequencing_groups, f)
 
+        # Get the QC tables for each input cohort
         qc_tables = [inputs.as_dict(cohort, EvidenceQC)['qc_table'] for cohort in multicohort.get_cohorts()]
         # get those settings
         min_batch_size = config_retrieve(['workflow', 'min_batch_size'], 100)
@@ -254,7 +260,7 @@ class CreateSampleBatches(MultiCohortStage):
             sample_batching.partition_batches,
             qc_tables,
             sequencing_groups,
-            expected['batch_json'],
+            str(expected['batch_json']),
             min_batch_size,
             max_batch_size,
         )

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 from cpg_utils import Path, to_path
-from cpg_utils.config import AR_GUID_NAME, config_retrieve, dataset_path, try_get_ar_guid
+from cpg_utils.config import AR_GUID_NAME, config_retrieve, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs import sample_batching
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import (

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.20',
+    version='1.25.21',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Updates the `CreateSampleBatches` stage so that it now writes the `{sg['id']: sg['meta']}` dict to a file in the tmp bucket, and passes this file path to the partition_batches function. This is because the sg meta dict was too large to pass through the `pyjob.call`. Writing the data to a json in tmp and then reading from the json in the job will allow for better scaling.