### PR TITLE
Update Variant ID prefix to be Cohort specific

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -188,7 +188,7 @@ class GatherBatchEvidence(CohortStage):
         pedigree_input = inputs.as_path(target=cohort, stage=MakeCohortCombinedPed, key='cohort_ped')
 
         input_dict: dict[str, Any] = {
-            'batch': get_workflow().output_version,
+            'batch': cohort.name,
             'samples': [sg.id for sg in sequencing_groups],
             'ped_file': str(pedigree_input),
             'counts': [
@@ -296,7 +296,7 @@ class ClusterBatch(CohortStage):
         pedigree_input = inputs.as_path(target=cohort, stage=MakeCohortCombinedPed, key='cohort_ped')
 
         input_dict: dict[str, Any] = {
-            'batch': get_workflow().output_version,
+            'batch': cohort.name,
             'del_bed': str(batch_evidence_d['merged_dels']),
             'dup_bed': str(batch_evidence_d['merged_dups']),
             'ped_file': str(pedigree_input),
@@ -370,7 +370,7 @@ class GenerateBatchMetrics(CohortStage):
         pedigree_input = inputs.as_path(target=cohort, stage=MakeCohortCombinedPed, key='cohort_ped')
 
         input_dict: dict[str, Any] = {
-            'batch': get_workflow().output_version,
+            'batch': cohort.name,
             'baf_metrics': gatherbatchevidence_d['merged_BAF'],
             'discfile': gatherbatchevidence_d['merged_PE'],
             'coveragefile': gatherbatchevidence_d['merged_bincov'],
@@ -473,7 +473,7 @@ class FilterBatch(CohortStage):
         pedigree_input = inputs.as_path(target=cohort, stage=MakeCohortCombinedPed, key='cohort_ped')
 
         input_dict: dict[str, Any] = {
-            'batch': get_workflow().output_version,
+            'batch': cohort.name,
             'ped_file': str(pedigree_input),
             'evidence_metrics': metrics_d['metrics'],
             'evidence_metrics_common': metrics_d['metrics_common'],
@@ -645,7 +645,7 @@ class GenotypeBatch(CohortStage):
         mergebatch_d = inputs.as_dict(this_multicohort, MergeBatchSites)
 
         input_dict: dict[str, Any] = {
-            'batch': get_workflow().output_version,
+            'batch': cohort.name,
             'n_per_split': 5000,
             'n_RD_genotype_bins': 100000,
             'coveragefile': batchevidence_d['merged_bincov'],


### PR DESCRIPTION
I have fallen for one of the classic blunders

When this was a series of CohortStages, and all run separately, the value of `get_workflow().output_version` was unique to each Cohort. This ID is embedded in the variant IDs in VCFs for each Cohort, e.g. 

```
chr1	55662701	a7f4438075b14b7353065b78461a41256da665_241_manta_chr1_00000619	N	<INS>
```

This ID must be unique across all cohorts, as MergeBatchSites joins all variants across all cohorts when tidying up the Batch results. 

The blunder here was not updating `batch = get_workflow().output_version` to be `batch = cohort.name`. This has meant that all the variant IDs in all VCF processed in the Multisample pipeline all have the same prefix. This has resulted in a clash of IDs downstream when multiple Cohorts/Batches are merged together, leading to a Pandas DF.index failure

```
raise ValueError("cannot handle a non-unique multi-index!")
```

This fix will resolve prospectively, but all the Bioheart Multisample pipeline results need to be deleted/repeated with valid variant IDs. 