### PR TITLE
Genotypegvcfs exome merge

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.21
+current_version = 1.25.22
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.21
+  VERSION: 1.25.22
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -385,6 +385,11 @@ def _add_joint_genotyper_job(
     {f'-L {interval} ' if interval else ''} \\
     --only-output-calls-starting-in-intervals \\
     """
+    if config_retrieve(['workflow', 'sequencing_type']) == 'exome':
+        # This is ok to do for exomes, because they shouldn't have genotypes inside centromeres
+        cmd += """
+        --merge-input-intervals \\
+        """
     if tool == JointGenotyperTool.GnarlyGenotyper:
         cmd += """\
     --keep-all-sites \\

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.21',
+    version='1.25.22',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds the `--merge-input-intervals` flag back to the genotypegvcfs jobs for exome joint calling.

Since exomes don't have data in the centromeres, we should feel safe to merge all input intervals when running genotypegvcfs. This flag seems to impact the performance of the genotypegvcfs jobs. 

Without the flag, 1200 scatter count, performance is not very good: https://batch.hail.populationgenomics.org.au/batches/468330?q=name%3D%7Egenotypegvcfs

With the flag, 800 scatter count, performance is fine:
https://batch.hail.populationgenomics.org.au/batches/443610?q=name%3D%7Egenotypegvcfs

Note these two runs have relatively similar number of exomes.

Also noting exome gvcfs were genotyped with the standard exome interval list, which DOES include centromeric regions for some chromosomes. So the gvcfs do have some centromere regions baked into them, which is probably why the performance gets worse when we don't merge the input intervals.