### PR TITLE
Pass plain string to PythonJob

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -955,7 +955,7 @@ class GeneratePloidyTable(MultiCohortStage):
             ploidy_table_from_ped.generate_ploidy_table,
             str(pedigree_input),
             contig_path,
-            expected_d['ploidy_table'],
+            str(expected_d['ploidy_table']),
         )
 
         return self.make_outputs(multicohort, data=expected_d, jobs=py_job)


### PR DESCRIPTION
One path param is being passed to a PythonJob as a `GSPath` object instead of a String. This is expected as a String, so this is a light correction anyway. This has not stopped the bioheart pipeline starting up, so I don't think this can possibly explain the seqr project recursion error, but... maybe it does?