### PR TITLE
Long Read SVs through to MT

### DIFF
--- a/configs/defaults/long_read_sv_annotation.toml
+++ b/configs/defaults/long_read_sv_annotation.toml
@@ -7,6 +7,13 @@ status_reporter = 'metamist'
 # github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
 external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
 external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
+noncoding_bed = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed'
+strvctvre_phylop = 'gs://cpg-common-test/references/hg38.phyloP100way.bw'
+
+# a couple of annotation arguments are not files
+# github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
+external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
+external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -2,7 +2,6 @@
 Hail Query Batch-Backend jobs for seqr-loader.
 """
 
-from hailtop.batch import Batch
 from hailtop.batch.job import Job
 
 from cpg_utils import Path

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -93,7 +93,7 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str
     mt = checkpoint_hail(mt, 'initial_annotation_round.mt', checkpoint_prefix)
 
     # get the Gene-Symbol mapping dict
-    gene_id_mapping_file = download_gencode_gene_id_mapping(get_config().get('gencode_release', '42'))
+    gene_id_mapping_file = download_gencode_gene_id_mapping(get_config().get('gencode_release', '46'))
     gene_id_mapping = parse_gtf_from_local(gene_id_mapping_file)
 
     # find all the column names which contain Gene symbols

--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -251,7 +251,7 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str |
     mt = checkpoint_hail(mt, 'initial_annotation_round.mt', checkpoint_prefix)
 
     # get the Gene-Symbol mapping dict
-    gene_id_mapping_file = download_gencode_gene_id_mapping(get_config().get('gencode_release', '42'))
+    gene_id_mapping_file = download_gencode_gene_id_mapping(get_config().get('gencode_release', '46'))
     gene_id_mapping = parse_gtf_from_local(gene_id_mapping_file)
 
     # OK, NOW IT'S BUSINESS TIME

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -326,3 +326,45 @@ def queue_annotate_sv_jobs(
         labels=labels,
     )
     return jobs
+
+
+def queue_annotate_strvctvre_job(
+    input_vcf,
+    output_path: str,
+    job_attrs: dict | None = None,
+    name: str = 'AnnotateVcfWithStrvctvre',
+) -> Job:
+    """
+
+    Args:
+        input_vcf (ResourceFile): part of a resource group with the corresponding index
+        output_path ():
+        job_attrs (dict|None): job attributes
+        name (str): name of the job
+
+    Returns:
+        The Strvctvre job
+    """
+
+    job_attrs = job_attrs or {}
+    strv_job = get_batch().new_job('StrVCTVRE', job_attrs | {'tool': 'strvctvre'})
+
+    strv_job.image(image_path('strvctvre'))
+    strv_job.storage(config_retrieve(['resource_overrides', name, 'storage'], '10Gi'))
+    strv_job.memory(config_retrieve(['resource_overrides', name, 'memory'], '16Gi'))
+
+    strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
+    assert isinstance(strvctvre_phylop, str)
+
+    local_phylop = get_batch().read_input(strvctvre_phylop)
+
+    strv_job.declare_resource_group(output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
+
+    # run strvctvre
+    strv_job.command(
+        f'python StrVCTVRE.py -i {input_vcf} -o {strv_job.output["vcf.gz"]} -f vcf -p {local_phylop}',  # type: ignore
+    )
+    strv_job.command(f'tabix {strv_job.output_vcf["vcf.gz"]}')  # type: ignore
+
+    get_batch().write_output(strv_job.output_vcf, str(output_path).replace('.vcf.gz', ''))
+    return strv_job

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -22,6 +22,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
     get_ref_panel,
     get_references,
     make_combined_ped,
+    queue_annotate_strvctvre_job,
     queue_annotate_sv_jobs,
 )
 from cpg_workflows.stages.seqr_loader import es_password
@@ -1122,17 +1123,6 @@ class AnnotateVcfWithStrvctvre(MultiCohortStage):
         }
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
-        strv_job = get_batch().new_job('StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'})
-
-        strv_job.image(image_path('strvctvre'))
-        config_retrieve(['resource_overrides', self.name, 'storage'], '20Gi')
-        strv_job.storage(config_retrieve(['resource_overrides', self.name, 'storage'], '20Gi'))
-        strv_job.memory(config_retrieve(['resource_overrides', self.name, 'memory'], '16Gi'))
-
-        strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
-        assert isinstance(strvctvre_phylop, str)
-
-        phylop_in_batch = get_batch().read_input(strvctvre_phylop)
 
         input_dict = inputs.as_dict(multicohort, AnnotateVcf)
         expected_d = self.expected_outputs(multicohort)
@@ -1143,21 +1133,9 @@ class AnnotateVcfWithStrvctvre(MultiCohortStage):
             vcf_index=str(input_dict['annotated_vcf_index']),
         )['vcf']
 
-        strv_job.declare_resource_group(output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
+        strvctvre_job = queue_annotate_strvctvre_job(input_vcf, str(expected_d['strvctvre_vcf']), self.get_job_attrs())
 
-        # run strvctvre
-        strv_job.command(
-            f'python StrVCTVRE.py -i {input_vcf} '
-            f'-o {strv_job.output_vcf["vcf.gz"]} '  # type: ignore
-            f'-f vcf -p {phylop_in_batch}',
-        )
-        strv_job.command(f'tabix {strv_job.output_vcf["vcf.gz"]}')  # type: ignore
-
-        get_batch().write_output(strv_job.output_vcf, str(expected_d['strvctvre_vcf']).replace('.vcf.gz', ''))
-        return self.make_outputs(multicohort, data=expected_d, jobs=strv_job)
-
-
-# insert spicy-naming here instead
+        return self.make_outputs(multicohort, data=expected_d, jobs=strvctvre_job)
 
 
 @stage(required_stages=AnnotateVcfWithStrvctvre, analysis_type='sv', analysis_keys=['new_id_vcf'])

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -59,7 +59,7 @@ def query_for_sv_vcfs(dataset_name: str) -> dict[str, str]:
     return return_dict
 
 
-@stage(analysis_keys=['vcf'])
+@stage
 class ReFormatPacBioSVs(SequencingGroupStage):
     """
     take each of the long-read SV VCFs, and re-format the contents
@@ -180,7 +180,7 @@ class MergeLongReadSVs(MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=merge_job)
 
 
-@stage(required_stages=MergeLongReadSVs, analysis_type='vcf', analysis_keys=['annotated_vcf'])
+@stage(required_stages=MergeLongReadSVs, analysis_type='sv', analysis_keys=['annotated_vcf'])
 class AnnotateLongReadSVs(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
         return {

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -70,8 +70,9 @@ class ReFormatPacBioSVs(SequencingGroupStage):
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
         return {
-            'vcf': sequencing_group.dataset.prefix() / f'{sequencing_group.id}_updated_lr_svs.vcf.bgz',
-            'index': sequencing_group.dataset.prefix() / f'{sequencing_group.id}_updated_lr_svs.vcf.bgz.tbi',
+            'vcf': sequencing_group.dataset.prefix() / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz',
+            'index': sequencing_group.dataset.prefix()
+            / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -225,7 +225,9 @@ class AnnotateLongReadSVsWithStrvctvre(MultiCohortStage):
         expected_out = self.expected_outputs(multicohort)
 
         strvctvre_job = queue_annotate_strvctvre_job(
-            input_vcf, str(expected_out['strvctvre_vcf']), self.get_job_attrs(),
+            input_vcf,
+            str(expected_out['strvctvre_vcf']),
+            self.get_job_attrs(),
         )
 
         return self.make_outputs(multicohort, data=expected_out, jobs=strvctvre_job)

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -8,7 +8,7 @@ from cpg_utils import Path
 from cpg_utils.config import AR_GUID_NAME, config_retrieve, image_path, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.seqr_loader_sv import annotate_cohort_jobs_sv, annotate_dataset_jobs_sv
-from cpg_workflows.stages.gatk_sv.gatk_sv_common import queue_annotate_sv_jobs, queue_annotate_strvctvre_job
+from cpg_workflows.stages.gatk_sv.gatk_sv_common import queue_annotate_strvctvre_job, queue_annotate_sv_jobs
 from cpg_workflows.targets import Dataset, MultiCohort, SequencingGroup
 from cpg_workflows.workflow import (
     DatasetStage,
@@ -225,7 +225,7 @@ class AnnotateLongReadSVsWithStrvctvre(MultiCohortStage):
         expected_out = self.expected_outputs(multicohort)
 
         strvctvre_job = queue_annotate_strvctvre_job(
-            input_vcf, str(expected_out['strvctvre_vcf']), self.get_job_attrs()
+            input_vcf, str(expected_out['strvctvre_vcf']), self.get_job_attrs(),
         )
 
         return self.make_outputs(multicohort, data=expected_out, jobs=strvctvre_job)


### PR DESCRIPTION
this got a little out of hand... I'd be happy to close this and re-open with a much smaller scope, or as separate PRs. The things we need are:
- Strvctvre annotation (only because the annotateCohort for GATK-SV expects it
- AnnotateCohort (ideally reusing the GATK-SV version)
- AnnotateDataset (ideally reusing the GATK-SV version)
- MtToEs export (pending closure of #829)

Nice to have but not super urgent:
- Making these MultiCohort instead of Cohort stages
- Adding params to the Long-read default config so that can run annotation without the GATK-SV config file being added
- Gencode file version update (used in annotate-cohort)

The full list of changes in this PR as it stands:

- adds a couple of config entries to the long_read_sv default config (I was previously using --config <GATK-SV_config> to provide these, but they are now a standard part of the long-read SV annotation pipeline so should be present in that default)
- changes the LR SV pipeline from Cohort stages to MultiCohort stages. This has been running with just RDNow so far, but in future we would want to produce one unified callset (especially once Jasmine or another pseudo-joint-calling tool gets involved). 
- Updates the gencode version pulled by default from 42 to 46 (current). That's not explicitly relevant to this change, but it was something I spotted while making this change
- Pulls out the Annotate SV VCF with STRVCTVRE job logic into a gatk-sv-common method, so that it can be called by GATK-sv and the long-read pipeline without duplicating code
- Adds long-read SV versions of AnnotateCohort and AnnotateDataset
- pending resolution of the MtToEs changes, this workflow will still need an additional stage to generate ES indexes. I was hesitant to put in the Dataproc boilerplate if we're going to delete it soon anyway