### PR TITLE
Add type, technology, platform to sequencing-groups + simplify logic

### DIFF
--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -86,6 +86,9 @@ def _populate_cohort(cohort: Cohort, sgs_by_dataset_for_cohort, read_pedigree: b
                 external_id=str(entry['sample']['externalId']),
                 participant_id=entry['sample']['participant'].get('externalId'),
                 meta=metadata,
+                sequencing_type=entry['type'],
+                sequencing_technology=entry['technology'],
+                sequencing_platform=entry['platform'],
             )
 
             if reported_sex := entry['sample']['participant'].get('reportedSex'):
@@ -137,6 +140,9 @@ def deprecated_create_cohort() -> Cohort:
                 id=str(entry['id']),
                 external_id=str(entry['sample']['externalId']),
                 participant_id=entry['sample']['participant'].get('externalId'),
+                sequencing_type=entry['type'],
+                sequencing_technology=entry['technology'],
+                sequencing_platform=entry['platform'],
                 meta=metadata,
             )
 
@@ -183,20 +189,12 @@ def _populate_alignment_inputs(
     Populate sequencing inputs for a sequencing group
     """
     assays: list[Assay] = []
-    for assay in entry['assays']:
+
+    for assay in entry.get('assays', []):
         _assay = Assay.parse(assay, sequencing_group.id, run_parse_reads=False)
         assays.append(_assay)
 
-    # Check only one assay type per sequencing group
-    assert len(set([assay.assay_type for assay in assays])) == 1
-    sequencing_group.assays[assays[0].assay_type] = tuple(assays)
-
-    if len(entry['assays']) > 1:
-        _assay_meta = _combine_assay_meta(assays)
-    else:
-        _assay_meta = assays[0].meta
-        if _assay_meta.get('reads'):
-            _assay_meta['reads'] = [_assay_meta['reads']]
+    _assay_meta = _combine_assay_meta(assays)
 
     if _assay_meta.get('reads'):
         alignment_input = parse_reads(
@@ -204,7 +202,7 @@ def _populate_alignment_inputs(
             assay_meta=_assay_meta,
             check_existence=check_existence,
         )
-        sequencing_group.alignment_input_by_seq_type[entry['type']] = alignment_input
+        sequencing_group.alignment_input = alignment_input
     else:
         logging.warning(f'No reads found for sequencing group {sequencing_group.id} of type {entry["type"]}')
 

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -194,7 +194,14 @@ def _populate_alignment_inputs(
         _assay = Assay.parse(assay, sequencing_group.id, run_parse_reads=False)
         assays.append(_assay)
 
-    _assay_meta = _combine_assay_meta(assays)
+    sequencing_group.assays = tuple(assays)
+
+    if len(assays) > 1:
+        _assay_meta = _combine_assay_meta(assays)
+    else:
+        _assay_meta = assays[0].meta
+        if _reads := _assay_meta.get('reads'):
+            _assay_meta['reads'] = [_reads]
 
     if _assay_meta.get('reads'):
         alignment_input = parse_reads(

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -76,8 +76,7 @@ class MissingAlignmentInputException(Exception):
 def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
     """Given a sequencing group, will return an AlignmentInput object that
     represents the path to a relevant input (e.g. CRAM/BAM path)"""
-    sequencing_type = get_config()['workflow']['sequencing_type']
-    alignment_input = sequencing_group.alignment_input_by_seq_type.get(sequencing_type)
+    alignment_input = sequencing_group.alignment_input
     if realign_cram_ver := get_config()['workflow'].get('realign_from_cram_version'):
         if (
             path := (sequencing_group.dataset.prefix() / 'cram' / realign_cram_ver / f'{sequencing_group.id}.cram')

--- a/cpg_workflows/stages/fastqc.py
+++ b/cpg_workflows/stages/fastqc.py
@@ -37,8 +37,7 @@ def _collect_fastq_outs(sequencing_group: SequencingGroup) -> list[OneFastqc]:
     """
     Collect input and output paths for FASTQC for all paths in alignment inputs.
     """
-    sequencing_type = get_config()['workflow']['sequencing_type']
-    if not (alignment_input := sequencing_group.alignment_input_by_seq_type.get(sequencing_type)):
+    if not (alignment_input := sequencing_group.alignment_input):
         # Only running FASTQC if sequencing inputs are available.
         return []
 

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -45,7 +45,10 @@ class BamToCram(SequencingGroupStage):
         Using the existing `bam_to_cram` function from the `jobs` module.
         """
         b = get_batch()
-        input_bam = b.read_input_group(bam=str(sequencing_group.alignment_input_by_seq_type.get('genome')))
+        assert (
+            sequencing_group.sequencing_type == 'genome'
+        ), f'Only genome sequencing type is supported for BAM to CRAM conversion, unavailable for {sequencing_group.id}'
+        input_bam = b.read_input_group(bam=str(sequencing_group.alignment_input))
         job, output_cram = bam_to_cram.bam_to_cram(
             b=get_batch(),
             input_bam=input_bam,

--- a/cpg_workflows/stages/trim_align.py
+++ b/cpg_workflows/stages/trim_align.py
@@ -27,8 +27,7 @@ def get_trim_inputs(sequencing_group: SequencingGroup) -> FastqPairs | None:
     """
     Get the input FASTQ file pairs for trimming
     """
-    sequencing_type = get_config()['workflow']['sequencing_type']
-    alignment_input = sequencing_group.alignment_input_by_seq_type.get(sequencing_type)
+    alignment_input = sequencing_group.alignment_input
     if (
         not alignment_input
         or (get_config()['workflow'].get('check_inputs', True) and not alignment_input.exists())

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -586,7 +586,7 @@ class SequencingGroup(Target):
         sex: Sex | None = None,
         pedigree: Optional['PedigreeInfo'] = None,
         alignment_input: AlignmentInput | None = None,
-        assays: dict[str, tuple[Assay, ...]] | None = None,
+        assays: tuple[Assay, ...] | None = None,
         forced: bool = False,
     ):
         super().__init__()
@@ -608,7 +608,7 @@ class SequencingGroup(Target):
         if sex:
             self.pedigree.sex = sex
         self.alignment_input: AlignmentInput | None = alignment_input
-        self.assays: dict[str, tuple[Assay, ...]] = assays or {}
+        self.assays: tuple[Assay, ...] | None = assays
         self.forced = forced
         self.active = True
         # Only set if the file exists / found in Metamist:

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -634,15 +634,16 @@ class SequencingGroup(Target):
 
     def __str__(self):
         ai_tag = ''
-        ai_tag += f'|SEQ={self.sequencing_type}:'
-        if isinstance(self.alignment_input, CramPath):
-            ai_tag += 'CRAM'
-        elif isinstance(self.alignment_input, BamPath):
-            ai_tag += 'BAM'
-        elif isinstance(self.alignment_input, FastqPairs):
-            ai_tag += f'{len(self.alignment_input)}FQS'
-        else:
-            raise ValueError(f'Unrecognised alignment input type {type(self.alignment_input)}')
+        if self.alignment_input:
+            ai_tag += f'|SEQ={self.sequencing_type}:'
+            if isinstance(self.alignment_input, CramPath):
+                ai_tag += 'CRAM'
+            elif isinstance(self.alignment_input, BamPath):
+                ai_tag += 'BAM'
+            elif isinstance(self.alignment_input, FastqPairs):
+                ai_tag += f'{len(self.alignment_input)}FQS'
+            else:
+                raise ValueError(f'Unrecognised alignment input type {type(self.alignment_input)}')
 
         ext_id = f'|{self._external_id}' if self._external_id else ''
         return f'SequencingGroup({self.dataset.name}/{self.id}{ext_id}{ai_tag})'

--- a/test/factories/sequencing_group.py
+++ b/test/factories/sequencing_group.py
@@ -20,7 +20,12 @@ def create_sequencing_group(
     meta: dict | None = None,
     sex: Sex | None = None,
     pedigree: PedigreeInfo | None = None,
+    # 2024-07-25 mfranklin: I don't think _generally_ the sequencing group should be
+    #   limited to the SequencingType[genome, exome] list. Maybe for specific stages,
+    #   but not in general for the tests, but I'll leave it here.
     sequencing_type: SequencingType = 'genome',
+    sequencing_technology: str = 'short-read',
+    sequencing_platform: str = 'illumina',
     alignment_input: FastqPair | FastqPairs | CramPath | BamPath | None = None,
     gvcf: GvcfPath | Literal['auto'] | None = None,
     cram: CramPath | Literal['auto'] | None = None,
@@ -55,12 +60,10 @@ def create_sequencing_group(
             `None`.
 
         sequencing_type (SequencingType):
-            The type of sequencing performed used as the key in the property
-            `alignment_input_by_seq_type` on the new instance. Defaults to 'genome'.
+            The sequencing_type of the group of assays. Defaults to 'genome'.
 
         alignment_input (FastqPair | FastqPairs | CramPath | BamPath | None, optional):
-            The alignment input data. Defaults to `None`. If `None`, the property
-            `alignment_input_by_seq_type` on the new instance will be `None`.
+            The alignment input data. Defaults to `None`.
 
         gvcf (GvcfPath | Literal['auto'] | None, optional):
             Path to a gVCF file path for the sequencing group that will be used to save
@@ -97,12 +100,15 @@ def create_sequencing_group(
         id=id,
         external_id=external_id,
         participant_id=participant_id,
+        sequencing_type=sequencing_type,
+        sequencing_technology=sequencing_technology,
+        sequencing_platform=sequencing_platform,
         dataset=dataset,
         meta=meta,
         sex=sex,
         pedigree=pedigree,
         forced=forced,
-        alignment_input_by_seq_type=({sequencing_type: alignment_input} if alignment_input else None),
+        alignment_input=alignment_input,
     )
 
     if gvcf == 'auto':

--- a/test/jobs/somalier/test_check_pedigree.py
+++ b/test/jobs/somalier/test_check_pedigree.py
@@ -45,7 +45,13 @@ def setup_pedigree_test(tmp_path: Path, config: PipelineConfig | None = None):
     dataset_id = config.workflow.dataset
 
     dataset = create_dataset(name=dataset_id)
-    dataset.add_sequencing_group(id='CPGABCD', external_id='SAMPLE1')
+    dataset.add_sequencing_group(
+        id='CPGABCD',
+        external_id='SAMPLE1',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
     batch = create_local_batch(tmp_path)
 
     sg_id = dataset.get_sequencing_group_ids()[0]
@@ -196,7 +202,12 @@ class TestSomalierCheckPedigree:
 
         dataset_id = config.workflow.dataset
         dataset = create_dataset(name=dataset_id)
-        dataset.add_sequencing_group(id='CPGABCD')
+        dataset.add_sequencing_group(
+            id='CPGABCD',
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
+        )
 
         pedigree_jobs = pedigree(
             dataset=dataset,

--- a/test/jobs/somalier/test_relate.py
+++ b/test/jobs/somalier/test_relate.py
@@ -45,7 +45,13 @@ def setup_pedigree_test(tmp_path: Path, config: PipelineConfig | None = None):
     dataset_id = config.workflow.dataset
 
     dataset = create_dataset(name=dataset_id)
-    dataset.add_sequencing_group(id='CPGAAAAAA', external_id='SAMPLE1')
+    dataset.add_sequencing_group(
+        id='CPGAAAAAA',
+        external_id='SAMPLE1',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
     batch = create_local_batch(tmp_path)
 
     sg_id = dataset.get_sequencing_group_ids()[0]

--- a/test/stages/__init__.py
+++ b/test/stages/__init__.py
@@ -81,7 +81,7 @@ def mock_multicohort() -> MultiCohort:
     sg1 = add_sg(ds, 'CPGXXXX', external_id='SAMPLE1')
     sg2 = add_sg(ds, 'CPGAAAA', external_id='SAMPLE2')
     dm1.add_sequencing_group_object(sg1)
-    dm1.add_sequencing_group_object(ds.add_sequencing_group('CPGAAAA', external_id='SAMPLE2'))
+    dm1.add_sequencing_group_object(sg2)
 
     ds2 = cohort_a.create_dataset('projectc')
     dm2 = mc.add_dataset(ds2)

--- a/test/stages/__init__.py
+++ b/test/stages/__init__.py
@@ -22,11 +22,22 @@ from cpg_workflows.workflow import (
 )
 
 
+def add_sg(ds, id, external_id: str):
+    sg = ds.add_sequencing_group(
+        id=id,
+        external_id=external_id,
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
+    return sg
+
+
 def mock_cohort() -> Cohort:
     c = Cohort()
 
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
+    add_sg(ds, 'CPGAA', external_id='SAMPLE1')
 
     return c
 
@@ -35,12 +46,12 @@ def mock_multidataset_cohort() -> Cohort:
     c = Cohort()
 
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
+    add_sg(ds, 'CPGAA', external_id='SAMPLE1')
+    add_sg(ds, 'CPGBB', external_id='SAMPLE2')
 
     ds2 = c.create_dataset('my_dataset2')
-    ds2.add_sequencing_group('CPGCC', external_id='SAMPLE3')
-    ds2.add_sequencing_group('CPGDD', external_id='SAMPLE4')
+    add_sg(ds2, 'CPGCC', external_id='SAMPLE3')
+    add_sg(ds2, 'CPGDD', external_id='SAMPLE4')
 
     return c
 
@@ -50,17 +61,17 @@ def mock_multicohort() -> MultiCohort:
 
     c = mc.create_cohort('CohortA')
     ds = c.create_dataset('projecta')
-    ds.add_sequencing_group('CPGXXXX', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGAAAA', external_id='SAMPLE2')
+    add_sg(ds, 'CPGXXXX', external_id='SAMPLE1')
+    add_sg(ds, 'CPGAAAA', external_id='SAMPLE2')
 
     ds2 = c.create_dataset('projectc')
-    ds2.add_sequencing_group('CPGCCCC', external_id='SAMPLE3')
-    ds2.add_sequencing_group('CPGDDDD', external_id='SAMPLE4')
+    add_sg(ds2, 'CPGCCCC', external_id='SAMPLE3')
+    add_sg(ds2, 'CPGDDDD', external_id='SAMPLE4')
 
     d = mc.create_cohort('CohortB')
     ds3 = d.create_dataset('projectb')
-    ds3.add_sequencing_group('CPGEEEEEE', external_id='SAMPLE5')
-    ds3.add_sequencing_group('CPGFFFFFF', external_id='SAMPLE6')
+    add_sg(ds3, 'CPGEEEEEE', external_id='SAMPLE5')
+    add_sg(ds3, 'CPGFFFFFF', external_id='SAMPLE6')
 
     return mc
 

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -75,8 +75,18 @@ def mock_create_analysis(_, project, analysis) -> int:
 def mock_deprecated_create_cohort() -> Cohort:
     c = Cohort()
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAAA', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGBBB', external_id='SAMPLE2')
+
+    def add_sg(id, external_id):
+        ds.add_sequencing_group(
+            id=id,
+            external_id=external_id,
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
+        )
+
+    add_sg('CPGAAA', external_id='SAMPLE1')
+    add_sg('CPGBBB', external_id='SAMPLE2')
     return c
 
 

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -321,9 +321,10 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     assert test_sg.meta == {'sg_meta': 'is_fun', 'participant_meta': 'is_here', 'phenotypes': {}}
 
     # Test Assay Population
-    assert test_sg.assays['sequencing'][0].sequencing_group_id == 'CPGLCL17'
-    assert test_sg.assays['sequencing'][0].id == '1'
-    assert test_sg.assays['sequencing'][0].meta['fluid_x_tube_id'] == '220405_FS28'
+    assert test_sg.assays
+    assert test_sg.assays[0].sequencing_group_id == 'CPGLCL17'
+    assert test_sg.assays[0].id == '1'
+    assert test_sg.assays[0].meta['fluid_x_tube_id'] == '220405_FS28'
 
     assert test_sg.participant_id == '8'
     # TODO/NOTE: The sex in the pedigree will overwrite the sex in the
@@ -490,9 +491,10 @@ def test_missing_reads(mocker: MockFixture, tmp_path):
     assert test_sg.meta == {'sg_meta': 'is_fun', 'participant_meta': 'is_here', 'phenotypes': {}}
 
     # Test Assay Population
-    assert test_sg.assays['sequencing'][0].sequencing_group_id == 'CPGLCL17'
-    assert test_sg.assays['sequencing'][0].id == '1'
-    assert test_sg.assays['sequencing'][0].meta['fluid_x_tube_id'] == '220405_FS28'
+    assert test_sg.assays
+    assert test_sg.assays[0].sequencing_group_id == 'CPGLCL17'
+    assert test_sg.assays[0].id == '1'
+    assert test_sg.assays[0].meta['fluid_x_tube_id'] == '220405_FS28'
 
     assert test_sg.participant_id == '8'
     assert test_sg.pedigree.sex == Sex.MALE

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -79,6 +79,7 @@ def mock_get_sgs(*args, **kwargs) -> list[dict]:  # pylint: disable=unused-argum
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12340',
                 'participant': {
@@ -130,6 +131,7 @@ def mock_get_sgs(*args, **kwargs) -> list[dict]:  # pylint: disable=unused-argum
             'meta': {'sample_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12489',
                 'participant': {
@@ -360,6 +362,7 @@ def mock_get_sgs_with_missing_reads(*args, **kwargs) -> list[dict]:  # pylint: d
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12340',
                 'participant': {
@@ -411,6 +414,7 @@ def mock_get_sgs_with_missing_reads(*args, **kwargs) -> list[dict]:  # pylint: d
             'meta': {'sample_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12489',
                 'participant': {
@@ -516,6 +520,7 @@ def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: dis
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12340',
                 'participant': {
@@ -567,6 +572,7 @@ def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: dis
             'meta': {'sample_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12489',
                 'participant': {
@@ -600,6 +606,7 @@ def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: dis
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'exome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA1000',
                 'participant': {
@@ -710,6 +717,7 @@ def test_unknown_data(mocker: MockFixture, tmp_path, caplog):
                 'meta': {'sg_meta': 'is_fun'},
                 'platform': 'illumina',
                 'type': 'genome',
+                'technology': 'short-read',
                 'sample': {
                     'externalId': 'NA12340',
                     'participant': {
@@ -744,6 +752,7 @@ def test_unknown_data(mocker: MockFixture, tmp_path, caplog):
                 'meta': {'sg_meta': 'is_fun'},
                 'platform': 'illumina',
                 'type': 'exome',
+                'technology': 'short-read',
                 'sample': {
                     'externalId': 'NA1000',
                     'participant': {

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -506,7 +506,7 @@ def test_missing_reads(mocker: MockFixture, tmp_path):
     # assert test_sg.alignment_input_by_seq_type['genome'][0].r1 == CloudPath(
     #     'gs://cpg-fewgenomes-main/HG3FMDSX3_2_220405_FS28_Homo-sapiens_AACGAGGCCG-ATCCAGGTAT_R_220208_BINKAN1_FEWGENOMES_M001_R1.fastq.gz'
     # )
-    assert test_sg2.alignment_input_by_seq_type == {}
+    assert test_sg2.alignment_input is None
 
 
 def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: disable=unused-argument
@@ -687,7 +687,7 @@ def test_mixed_reads(mocker: MockFixture, tmp_path, caplog):
     #     'gs://cpg-fewgenomes-main/exomeexample_r1.fastq.gz'
     # )
 
-    assert test_none.alignment_input_by_seq_type == {}
+    assert test_none.alignment_input is None
     assert re.search(
         r'WARNING\s+root:inputs\.py:\d+\s+No reads found for sequencing group CPGbbb of type genome',
         caplog.text,

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -111,6 +111,9 @@ def _mock_cohort(dataset_id: str):
         sequencing_group = dataset.add_sequencing_group(
             id=sequencing_group_id,
             external_id=sequencing_group_id.replace('CPG', 'EXT'),
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
         )
         sequencing_group.gvcf = GvcfPath(gvcf_path)
     return cohort

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -131,26 +131,30 @@ def _mock_cohort():
     ds = cohort.create_dataset('test-input-dataset')
     ds.add_sequencing_group(
         'CPGAA',
-        'SAMPLE1',
-        alignment_input_by_seq_type={'genome': BamPath('gs://test-input-dataset-upload/sample1.bam')},
+        external_id='SAMPLE1',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+        alignment_input=BamPath('gs://test-input-dataset-upload/sample1.bam'),
     )
     ds.add_sequencing_group(
         'CPGBB',
-        'SAMPLE2',
-        alignment_input_by_seq_type={
-            'genome': FastqPairs(
-                [
-                    FastqPair(
-                        'gs://test-input-dataset-upload/sample2_L1_R1.fq.gz',
-                        'gs://test-input-dataset-upload/sample2_L1_R2.fq.gz',
-                    ),
-                    FastqPair(
-                        'gs://test-input-dataset-upload/sample2_L2_R1.fq.gz',
-                        'gs://test-input-dataset-upload/sample2_L2_R2.fq.gz',
-                    ),
-                ],
-            ),
-        },
+        external_id='SAMPLE2',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+        alignment_input=FastqPairs(
+            [
+                FastqPair(
+                    'gs://test-input-dataset-upload/sample2_L1_R1.fq.gz',
+                    'gs://test-input-dataset-upload/sample2_L1_R2.fq.gz',
+                ),
+                FastqPair(
+                    'gs://test-input-dataset-upload/sample2_L2_R1.fq.gz',
+                    'gs://test-input-dataset-upload/sample2_L2_R2.fq.gz',
+                ),
+            ],
+        ),
     )
     return cohort
 

--- a/test/test_size.py
+++ b/test/test_size.py
@@ -1,0 +1,27 @@
+import hailtop.batch as hb
+
+
+def test_python_function(*values):
+    # making this smaller with 101 jobs means it passes
+    print(*values)
+    h = hash(values)
+    print(f'Hash is {h}')
+    # this return is important, otherwise it submits successfully
+    return h
+
+
+if __name__ == '__main__':
+    b = hb.Batch(
+        'Scale size recursion test',
+        backend=hb.ServiceBackend(
+            billing_project='michaelfranklin-trial',
+            remote_tmpdir='gs://cpg-michael-hail-dev/tmp',
+        ),
+        default_python_image='python-image-with-dill',
+    )
+    # 101 submits, 102 fails
+    for i in range(102):
+        j = b.new_python_job(f'Function call {i+1}')
+        j.call(test_python_function, i + 1)
+
+    submitted = b.run(wait=False)

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -66,8 +66,18 @@ def _common(mocker, tmp_path):
     def mock_create_cohort() -> Cohort:
         c = Cohort()
         ds = c.create_dataset('my_dataset')
-        ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-        ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
+
+        def add(id, external_id):
+            ds.add_sequencing_group(
+                id,
+                external_id=external_id,
+                sequencing_type='genome',
+                sequencing_technology='short-read',
+                sequencing_platform='illumina',
+            )
+
+        add('CPGAA', external_id='SAMPLE1')
+        add('CPGBB', external_id='SAMPLE2')
         return c
 
     mocker.patch('cpg_workflows.inputs.deprecated_create_cohort', mock_create_cohort)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -39,8 +39,18 @@ backend = 'local'
 def mock_deprecated_create_cohort() -> Cohort:
     c = Cohort()
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
+
+    def add_sg(id, external_id):
+        ds.add_sequencing_group(
+            id=id,
+            external_id=external_id,
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
+        )
+
+    add_sg('CPGAA', external_id='SAMPLE1')
+    add_sg('CPGBB', external_id='SAMPLE2')
     return c
 
 


### PR DESCRIPTION
Noticed the sequencing_type wasn't on the SequencingGroup object, so:

- Add this (and the technology / platform), 
- This is already present on the GraphQL query,
- Simplify `alignment_inputs_by_seq_type` to just `alignment_input` as a sequencing group can by definition only be one type.
- Require keyword arguments when constructing a sequencing_group using the helpers, to remove ambiguity of arg order
- Add these fields to a bunch of tests,
- hopes and prayers

