### PR TITLE
Long-Read SV patches

### DIFF
--- a/configs/defaults/long_read_sv_annotation.toml
+++ b/configs/defaults/long_read_sv_annotation.toml
@@ -10,11 +10,6 @@ external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
 noncoding_bed = 'gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed'
 strvctvre_phylop = 'gs://cpg-common-test/references/hg38.phyloP100way.bw'
 
-# a couple of annotation arguments are not files
-# github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl#L4-L8
-external_af_population = ['ALL', 'AFR', 'AMR', 'EAS', 'EUR']
-external_af_ref_bed_prefix = 'gnomad_v2.1_sv'
-
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -364,7 +364,7 @@ def queue_annotate_strvctvre_job(
     strv_job.command(
         f'python StrVCTVRE.py -i {input_vcf} -o {strv_job.output["vcf.gz"]} -f vcf -p {local_phylop}',  # type: ignore
     )
-    strv_job.command(f'tabix {strv_job.output_vcf["vcf.gz"]}')  # type: ignore
+    strv_job.command(f'tabix {strv_job.output["vcf.gz"]}')  # type: ignore
 
-    get_batch().write_output(strv_job.output_vcf, str(output_path).replace('.vcf.gz', ''))
+    get_batch().write_output(strv_job.output, str(output_path).replace('.vcf.gz', ''))
     return strv_job


### PR DESCRIPTION
2 quick fixes following #850 

- removes duplicate keys in the Long-Read SV default config file
- corrects the output group inside the STRVCTVRE job (output group is called `job.output`, not `job.output_vcf` - not sure how this crept in 🤦)