### PR TITLE
LongRead AnnotateCohort compatibility

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -231,7 +231,7 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str |
             cpx_intervals=hl.or_missing(
                 hl.is_defined(mt.info.CPX_INTERVALS),
                 mt.info.CPX_INTERVALS.map(lambda x: get_cpx_interval(x)),
-            )
+            ),
         )
 
     # reimplementation of

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -73,10 +73,10 @@ class ReFormatPacBioSVs(SequencingGroupStage):
     """
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
+        sgid_prefix = sequencing_group.dataset.prefix() / 'pacbio' / 'modified_vcfs'
         return {
-            'vcf': sequencing_group.dataset.prefix() / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz',
-            'index': sequencing_group.dataset.prefix()
-            / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz.tbi',
+            'vcf': sgid_prefix / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz',
+            'index': sgid_prefix / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:


### PR DESCRIPTION
Not all the fields expected by AnnotateCohortSV are present in the Long-Read VCFs. Hail has methods for `hl.if_defined(...)` which can be used to build conditional paths, but these still require the field to be present in the structure. e.g.

```
value = hl.if_defined(mt.CPX, <something>, <something_else>)
```

this will return `something` if CPX has a non-null value, and `something_else` otherwise. However, if CPX isn't in the MT schema at all it will fail.

To get around this limitation I've identified the situations where annotations required are not present, and conditionally applied a default value. This will not affect GATK-SV's use of this module.

n.b. this still doesn't address the genotype issues - we expect a CN (copy number) in Seqr, but this VCF format doesn't natively contain that

I've been able to run this to completion on the LR SV data in this state.