### PR TITLE
Merge input intervals exomes fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.23
+current_version = 1.25.24
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.23
+  VERSION: 1.25.24
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -387,7 +387,7 @@ def _add_joint_genotyper_job(
     """
     if config_retrieve(['workflow', 'sequencing_type']) == 'exome':
         # This is ok to do for exomes, because they shouldn't have genotypes inside centromeres
-        cmd += """
+        cmd += """\
         --merge-input-intervals \\
         """
     if tool == JointGenotyperTool.GnarlyGenotyper:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.23',
+    version='1.25.24',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fixes a bug where an additional linebreak was added into the GenotypeGVCFs command line args, meaning the `--merge-input-intervals` flag (and any options that came after it) were not included in the command. 


See:
https://batch.hail.populationgenomics.org.au/batches/474450/jobs/1

`cmd` string submitted:
```
gatk --java-options "-Xms13351M -Xmx13351M" \
GenotypeGVCFs \
-R ${BATCH_TMPDIR}/inputs/osS7h/Homo_sapiens_assembly38_masked.fasta \
-O ${BATCH_TMPDIR}/GenotypeGVCFs-FhRKS/output_vcf.vcf.gz \
-D gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf \
-V $WORKSPACE \
-L ${BATCH_TMPDIR}/inputs/209Bl/6.interval_list \
--only-output-calls-starting-in-intervals \

--merge-input-intervals \
-G AS_StandardAnnotation
```

Because of the linebreak, the executed command is missing the `--merge-input-intervals` and `-G` options.
```
gatk --java-options '-Xms13351M -Xmx13351M' GenotypeGVCFs -R /io/batch/Homo_sapiens_assembly38_masked.fasta -O /io/batch/GenotypeGVCFs/output_vcf.vcf.gz -D gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf -V gendb:///io/batch/interval_6_outof_1200 -L /io/batch/inputs/209Bl/6.interval_list --only-output-calls-starting-in-intervals
```
