### PR TITLE
Investigate background pop overwritting

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -14,7 +14,7 @@ from cpg_workflows.utils import can_reuse
 from gnomad.sample_qc.ancestry import assign_population_pcs, run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
-MIN_N_SAMPLES = 10
+MIN_N_SAMPLES = 1
 
 
 def reorder_columns(ht: hl.Table, reference_table: hl.Table) -> hl.Table:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -93,23 +93,11 @@ def add_background(
                 logging.info('No related samples to drop from background dataset')
 
             # save metadata info before merging dense and background datasets
-            logging.info(
-                f'background_mt n_cols is {background_mt.count_cols()} and n_rows {background_mt.count_rows()} after filtering and before selecting: {background_mt.show()}',
-            )
             ht = background_mt.cols()
             background_mt = background_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
             background_mt = background_mt.naive_coalesce(5000)
             # combine dense dataset with background population dataset
-            logging.info(
-                f'background_mt n_cols is {background_mt.count_cols()} and n_rows {background_mt.count_rows()} after selecting: {background_mt.show()}',
-            )
-            logging.info(
-                f'dense_mt n_cols is {dense_mt.count_cols()} and n_rows {dense_mt.count_rows()} before union_cols: {dense_mt.show()}',
-            )
             dense_mt = dense_mt.union_cols(background_mt)
-            logging.info(
-                f'dense_mt n_cols is {dense_mt.count_cols()} and n_rows {dense_mt.count_rows()} after union_cols: {dense_mt.show()}',
-            )
             sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -84,6 +84,7 @@ def add_background(
                 logging.info(
                     f'Removing related samples from background dataset {dataset}. Background relateds to drop: {background_relateds_to_drop}',
                 )
+                logging.info(f'background_relateds_to_drop: {background_relateds_to_drop.show()}')
                 background_relateds_to_drop_ht = hl.read_table(background_relateds_to_drop)
                 background_mt = background_mt.filter_cols(
                     ~hl.is_defined(background_relateds_to_drop_ht[background_mt.col_key]),
@@ -92,15 +93,22 @@ def add_background(
                 logging.info('No related samples to drop from background dataset')
 
             # save metadata info before merging dense and background datasets
-            logging.info(f'background_mt after filtering and before selecting: {background_mt.show()}')
+            logging.info(
+                f'background_mt n_cols is {background_mt.count_cols()} and n_rows {background_mt.count_rows()} after filtering and before selecting: {background_mt.show()}',
+            )
             ht = background_mt.cols()
             background_mt = background_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
             background_mt = background_mt.naive_coalesce(5000)
             # combine dense dataset with background population dataset
-            logging.info(f'background_mt after selecting: {background_mt.show()}')
+            logging.info(
+                f'background_mt n_cols is {background_mt.count_cols()} and n_rows {background_mt.count_rows()} after selecting: {background_mt.show()}',
+            )
+            logging.info(
+                f'dense_mt n_cols is {dense_mt.count_cols()} and n_rows {dense_mt.count_rows()} before union_cols: {dense_mt.show()}',
+            )
             dense_mt = dense_mt.union_cols(background_mt)
             logging.info(
-                f'Finished combining dense and background datasets, dense_mt after union_cols: {dense_mt.show()}',
+                f'dense_mt n_cols is {dense_mt.count_cols()} and n_rows {dense_mt.count_rows()} after union_cols: {dense_mt.show()}',
             )
             sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
         else:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -41,6 +41,7 @@ def add_background(
         dataset_dict = get_config()['large_cohort']['pca_background'][dataset]
         path = dataset_dict['dataset_path']
         logging.info(f'Adding background dataset {path}')
+        logging.info(f'Current dataset: {dataset}')
         if to_path(path).suffix == '.mt':
             background_mt = hl.read_matrix_table(str(path))
             background_mt = hl.split_multi(background_mt, filter_changed_loci=True)
@@ -62,8 +63,10 @@ def add_background(
                 # annotate background mt with metadata info derived from SampleQC stage
             metadata_tables = []
             for path in dataset_dict['metadata_table']:
+                logging.info(f'Adding metadata table to background dataset: {path}')
                 sample_qc_background = hl.read_table(path)
                 metadata_tables.append(sample_qc_background)
+                logging.info(f'{metadata_tables}')
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             metadata_tables = reorder_columns(metadata_tables, sample_qc_ht)
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -60,7 +60,7 @@ def add_background(
                 background_mt = hl.vds.to_dense_mt(background_vds)
                 logging.info(f'Checkpointing background_mt to {background_mt_checkpoint_path}')
                 background_mt = background_mt.checkpoint(str(background_mt_checkpoint_path), overwrite=True)
-                logging.info('Finished checkpointing densified_background_mt')
+                logging.info(f'Finished checkpointing {dataset}_densified_background_mt.mt')
                 # annotate background mt with metadata info derived from SampleQC stage
             metadata_tables: list[hl.Table] = []
             for path in dataset_dict['metadata_table']:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -14,7 +14,7 @@ from cpg_workflows.utils import can_reuse
 from gnomad.sample_qc.ancestry import assign_population_pcs, run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
-MIN_N_SAMPLES = 1
+MIN_N_SAMPLES = 10
 
 
 def reorder_columns(ht: hl.Table, reference_table: hl.Table) -> hl.Table:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -84,8 +84,8 @@ def add_background(
                 logging.info(
                     f'Removing related samples from background dataset {dataset}. Background relateds to drop: {background_relateds_to_drop}',
                 )
-                logging.info(f'background_relateds_to_drop: {background_relateds_to_drop.show()}')
                 background_relateds_to_drop_ht = hl.read_table(background_relateds_to_drop)
+                logging.info(f'background_relateds_to_drop: {background_relateds_to_drop_ht.show()}')
                 background_mt = background_mt.filter_cols(
                     ~hl.is_defined(background_relateds_to_drop_ht[background_mt.col_key]),
                 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ black
 pytest
 pytest_mock
 mypy
+cpg-utils>=5.0.11

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'cpg-utils>=5.0.4',
+        'cpg-utils>=5.0.11',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
         'hail==0.2.132',  # Pin Hail at CPG's installed version


### PR DESCRIPTION
In attempting to remove related individuals from supplied background populations (`hgdp` and `thousand-genomes`) there is a bug where only the last supplied dataset is having related individuals removed. 

The fix is to indent the subset of the `dense_mt` to within the for-loop where we are removing related individuals from background populations.

Relevant Slack threads here:
- https://centrepopgen.slack.com/archives/C03FA2M1MR9/p1722387137408999
- https://centrepopgen.slack.com/archives/C03FA2M1MR9/p1722893919945029 (refers to Dataproc issue that cropped up while trying to fix this issue)