### PR TITLE
DatasetStages run once for each Dataset in the MultiCohort

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.26
+current_version = 1.26.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.26
+  VERSION: 1.26.0
 
 jobs:
   docker:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -44,8 +44,6 @@ def get_multicohort() -> Cohort | MultiCohort:
         if not isinstance(custom_cohort_ids, list):
             raise ValueError('input_cohorts must be a list')
         return actual_get_multicohort()
-    # TODO (mwelland): this should also return a MultiCohort object, containing one Cohort for the whole run?
-    # TODO (mwelland): this would mean we're always returning a MultiCohort, even if there is only one cohort
     return deprecated_get_cohort()
 
 

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -110,7 +110,8 @@ def _populate_cohort(cohort: Cohort, sgs_by_dataset_for_cohort, read_pedigree: b
     if not cohort.get_datasets():
         raise MetamistError('No datasets populated')
 
-    # TODO (mwelland): this should be done one Dataset at a time, not per Datset per Cohort
+    # TODO (mwelland): this should be done one Dataset at a time, not per Dataset per Cohort
+    # TODO (mwelland): by querying per-dataset per-cohort we increase the number of identical requests
     _populate_analysis(cohort)
     if read_pedigree:
         _populate_pedigree(cohort)

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -278,6 +278,7 @@ class Metamist:
             raise MetamistError('We only support one cohort at a time currently')
         sequencing_groups = entries['cohorts'][0]['sequencingGroups']
 
+        # TODO (mwelland): return all the SequencingGroups in the Cohort, no need for stratification
         return sort_sgs_by_project(sequencing_groups)
 
     def get_sg_entries(self, dataset_name: str) -> list[dict]:
@@ -324,6 +325,7 @@ class Metamist:
         analysis.status = status
 
     # NOTE: This isn't used anywhere.
+    # TODO (mwelland): get in the bin
     def find_joint_calling_analysis(
         self,
         sequencing_group_ids: list[str],

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -325,7 +325,6 @@ class Metamist:
         analysis.status = status
 
     # NOTE: This isn't used anywhere.
-    # TODO (mwelland): get in the bin
     def find_joint_calling_analysis(
         self,
         sequencing_group_ids: list[str],

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -278,6 +278,7 @@ class Metamist:
             raise MetamistError('We only support one cohort at a time currently')
         sequencing_groups = entries['cohorts'][0]['sequencingGroups']
 
+        # TODO (mwelland): future optimisation following closure of #860
         # TODO (mwelland): return all the SequencingGroups in the Cohort, no need for stratification
         return sort_sgs_by_project(sequencing_groups)
 

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -163,21 +163,17 @@ class MultiCohort(Target):
 
     def get_sequencing_groups(self, only_active: bool = True) -> list['SequencingGroup']:
         """
-        Gets a flat list of all sequencing groups from all cohorts.
+        Gets a flat list of all sequencing groups from all datasets.
+        uses a dictionary to avoid duplicates (we could have the same sequencing group in multiple cohorts)
         Include only "active" sequencing groups (unless only_active is False)
         """
-        all_sequencing_groups = []
-        for cohort in self.get_cohorts(only_active):
-            print(cohort)
-            print(len(cohort.get_sequencing_groups(only_active)))
-            print([sg.id for sg in cohort.get_sequencing_groups(only_active)])
-            all_sequencing_groups.extend(cohort.get_sequencing_groups(only_active))
-        return all_sequencing_groups
+        all_sequencing_groups: dict[str, 'SequencingGroup'] = {}
+        for dataset in self.get_datasets(only_active):
+            for sg in dataset.get_sequencing_groups(only_active):
+                all_sequencing_groups[sg.id] = sg
+        return list(all_sequencing_groups.values())
 
-    def create_cohort(
-        self,
-        name: str,
-    ):
+    def create_cohort(self, name: str):
         """
         Create a cohort and add it to the multi-cohort.
         """
@@ -253,7 +249,6 @@ class Cohort(Target):
         self.name = name or get_config()['workflow']['dataset']
         self.analysis_dataset = Dataset(name=get_config()['workflow']['dataset'], cohort=self)
         self._datasets_by_name: dict[str, Dataset] = {}
-        self._sg_by_id: dict[str, SequencingGroup] = {}
         self.multicohort = multicohort
 
     def __repr__(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.26',
+    version='1.26.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/stages/__init__.py
+++ b/test/stages/__init__.py
@@ -48,19 +48,26 @@ def mock_multidataset_cohort() -> Cohort:
 def mock_multicohort() -> MultiCohort:
     mc = MultiCohort()
 
-    c = mc.create_cohort('CohortA')
-    ds = c.create_dataset('projecta')
-    ds.add_sequencing_group('CPGXXXX', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGAAAA', external_id='SAMPLE2')
+    # Create a cohort with two datasets
+    cohort_a = mc.create_cohort('CohortA')
+    # Create a dataset in the cohort (legacy)
+    ds = cohort_a.create_dataset('projecta')
+    # Create a dataset in the multicohort (new)
+    dm1 = mc.add_dataset(ds)
+    # Add sequencing groups to the cohort.dataset AND multicohort.dataset
+    dm1.add_sequencing_group_object(ds.add_sequencing_group('CPGXXXX', external_id='SAMPLE1'))
+    dm1.add_sequencing_group_object(ds.add_sequencing_group('CPGAAAA', external_id='SAMPLE2'))
 
-    ds2 = c.create_dataset('projectc')
-    ds2.add_sequencing_group('CPGCCCC', external_id='SAMPLE3')
-    ds2.add_sequencing_group('CPGDDDD', external_id='SAMPLE4')
+    ds2 = cohort_a.create_dataset('projectc')
+    dm2 = mc.add_dataset(ds2)
+    dm2.add_sequencing_group_object(ds2.add_sequencing_group('CPGCCCC', external_id='SAMPLE3'))
+    dm2.add_sequencing_group_object(ds2.add_sequencing_group('CPGDDDD', external_id='SAMPLE4'))
 
-    d = mc.create_cohort('CohortB')
-    ds3 = d.create_dataset('projectb')
-    ds3.add_sequencing_group('CPGEEEEEE', external_id='SAMPLE5')
-    ds3.add_sequencing_group('CPGFFFFFF', external_id='SAMPLE6')
+    cohort_b = mc.create_cohort('CohortB')
+    ds3 = cohort_b.create_dataset('projectb')
+    dm3 = mc.add_dataset(ds3)
+    dm3.add_sequencing_group_object(ds3.add_sequencing_group('CPGEEEEEE', external_id='SAMPLE5'))
+    dm3.add_sequencing_group_object(ds3.add_sequencing_group('CPGFFFFFF', external_id='SAMPLE6'))
 
     return mc
 

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -835,15 +835,16 @@ def test_custom_cohort(mocker: MockFixture, tmp_path, monkeypatch):
 
     from cpg_workflows.inputs import get_multicohort
 
-    cohort = get_multicohort()
+    multicohort = get_multicohort()
 
-    assert cohort
-    assert isinstance(cohort, MultiCohort)
+    assert multicohort
+    assert isinstance(multicohort, MultiCohort)
 
     # Testing Cohort Information
-    assert len(cohort.get_sequencing_groups()) == 2
-    assert cohort.get_sequencing_group_ids() == ['CPGXXXX', 'CPGAAAA']
+    assert len(multicohort.get_sequencing_groups()) == 2
+    assert sorted(multicohort.get_sequencing_group_ids()) == ['CPGAAAA', 'CPGXXXX']
 
     # Test the projects they belong to
-    assert cohort.get_sequencing_groups()[0].dataset.name == 'projecta'
-    assert cohort.get_sequencing_groups()[1].dataset.name == 'projectb'
+    ds_map = {'CPGAAAA': 'projectb', 'CPGXXXX': 'projecta'}
+    for sg in multicohort.get_sequencing_groups():
+        assert sg.dataset.name == ds_map[sg.id]

--- a/test/test_multicohort.py
+++ b/test/test_multicohort.py
@@ -220,10 +220,7 @@ def mock_get_pedigree(*args, **kwargs):  # pylint: disable=unused-argument
     ]
 
 
-def test_multicohort(
-    mocker: MockFixture,
-    tmp_path,
-):
+def test_multicohort(mocker: MockFixture, tmp_path):
     """
     Testing creating a Cohort object from metamist mocks.
     """


### PR DESCRIPTION
Closes #852 

## Description

Since the introduction of MultiCohorts our DatasetStages haven't worked right. Instead of the 'Dataset' Target meaning "All samples in this Dataset", it shifted to "in each Cohort, stratify samples by Dataset, then run each group separately"

In practice this means that if you have 2 Datasets in total, equally split across 2 Cohorts, we run 4 DatasetStages, none of them containing the full Dataset. An additional consequence is that a DatasetStage typically writes to a path `BUCKET/PIPELINE/STAGE/MultiCohortHash/FILENAME` - when we fire off multiple DatasetStages, each with a portion of the overall Dataset, we will attempt to write to the same file path multiple times.

The core issue here is that Cohorts and Datasets need to be at the same level in the hierarchy - a MultiCohort can contain multiple of each, and each can contain multiple SequencingGroups, but there is no real relationship between the two. A `Cohort` is every SG within a CustomCohort in metamist, and a `Dataset` is every SG within a metamist project.

Doc for extended context: https://docs.google.com/document/d/1Zu4QFxuR44M1alRZtA5M9WGROLEUg74gQWorDQjOvTs/edit?usp=sharing

## What This Change Does

1. Currently the MultiCohort contains a dictionary of Cohorts by name, and each Cohort contains a list of Datasets by name. This adds a MultiCohort level Datasets-by-name dictionary.
2. When setting up a MultiCohort we query for each Cohort in turn and populate them with SG objects.
3. Once we've queried for each Cohort in turn we iterate over all the Cohorts and pool the SG objects by Dataset as well.
4. This adds an `add_sequencing_group_object` method that takes the already populated SG object, without re-creating the same object from its raw data
5. `MultiCohort.get_datasets` iterates over Datasets directly, instead of iterating over each Cohort, then each Dataset within that Cohort

This represents a minimal change so that we can restore DatasetStage functionality, without getting too into the weeds about how we should optimise this change. I've scattered a number of TODO statements over the code where we can improve on this change through optimisation. Some methods can be removed, some methods can be simplified, and some Metamist queries can be moved so that we make the minimum number of GraphQL queries.

