### PR TITLE
Seqr loader to MultiCohorts

### DIFF
--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -11,7 +11,6 @@ from .metamist import AnalysisType, Assay, MetamistError, get_metamist, parse_re
 from .targets import Cohort, MultiCohort, PedigreeInfo, SequencingGroup, Sex
 from .utils import exists
 
-_cohort: Cohort | None = None
 _multicohort: MultiCohort | None = None
 
 
@@ -23,12 +22,12 @@ def actual_get_multicohort() -> MultiCohort:
     return _multicohort
 
 
-def deprecated_get_cohort() -> Cohort:
+def deprecated_get_cohort() -> MultiCohort:
     """Return the cohort object"""
-    global _cohort
-    if not _cohort:
-        _cohort = deprecated_create_cohort()
-    return _cohort
+    global _multicohort
+    if not _multicohort:
+        _multicohort = deprecated_create_cohort()
+    return _multicohort
 
 
 def get_multicohort() -> Cohort | MultiCohort:
@@ -102,7 +101,7 @@ def _populate_cohort(cohort: Cohort, sgs_by_dataset_for_cohort, read_pedigree: b
     assert cohort.get_sequencing_groups()
 
 
-def deprecated_create_cohort() -> Cohort:
+def deprecated_create_cohort() -> MultiCohort:
     """
     Add datasets in the cohort. There exists only one cohort for the workflow run.
     """
@@ -120,8 +119,8 @@ def deprecated_create_cohort() -> Cohort:
         logging.warning('Using dataset will soon be deprecated. Use input_cohorts instead.')
 
     dataset_names = [d for d in dataset_names if d not in skip_datasets]
-
-    cohort = Cohort()
+    multi_cohort = MultiCohort()
+    cohort = multi_cohort.create_cohort(analysis_dataset_name)
 
     for dataset_name in dataset_names:
         dataset = cohort.create_dataset(dataset_name)
@@ -156,8 +155,8 @@ def deprecated_create_cohort() -> Cohort:
     _populate_analysis(cohort)
     if config.get('read_pedigree', True):
         _populate_pedigree(cohort)
-    assert cohort.get_sequencing_groups()
-    return cohort
+    assert multi_cohort.get_sequencing_groups()
+    return multi_cohort
 
 
 def _combine_assay_meta(assays: list[Assay]) -> dict:

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -7,29 +7,13 @@ Content relating to the hap.py validation process
 import logging
 
 from cpg_utils.config import get_config
-from cpg_workflows.jobs.validation import (
-    parse_and_post_results,
-    run_happy_on_vcf,
-    validation_mt_to_vcf_job,
-)
-from cpg_workflows.stages.seqr_loader import _sg_vcf_meta
-from cpg_workflows.workflow import (
-    SequencingGroup,
-    SequencingGroupStage,
-    StageInput,
-    StageOutput,
-    get_workflow,
-    stage,
-)
-
-from .. import get_batch
+from cpg_utils.hail_batch import get_batch
+from cpg_workflows.jobs.validation import parse_and_post_results, run_happy_on_vcf, validation_mt_to_vcf_job
+from cpg_workflows.targets import SequencingGroup
+from cpg_workflows.workflow import SequencingGroupStage, StageInput, StageOutput, get_workflow, stage
 
 
-@stage(
-    analysis_type='custom',
-    update_analysis_meta=_sg_vcf_meta,
-    analysis_keys=['vcf'],
-)
+@stage(analysis_type='custom', analysis_keys=['vcf'])
 class ValidationMtToVcf(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
         return {
@@ -69,11 +53,7 @@ class ValidationMtToVcf(SequencingGroupStage):
         return self.make_outputs(sequencing_group, data=exp_outputs, jobs=job)
 
 
-@stage(
-    required_stages=ValidationMtToVcf,
-    analysis_type='qc',
-    analysis_keys=['happy_csv'],
-)
+@stage(required_stages=ValidationMtToVcf, analysis_type='qc', analysis_keys=['happy_csv'])
 class ValidationHappyOnVcf(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
         output_prefix = (

--- a/cpg_workflows/stages/joint_genotyping.py
+++ b/cpg_workflows/stages/joint_genotyping.py
@@ -62,7 +62,7 @@ class JointGenotyping(MultiCohortStage):
             b=get_batch(),
             out_vcf_path=outputs['vcf'],
             out_siteonly_vcf_path=outputs['siteonly'],
-            tmp_bucket=self.prefix / 'tmp',
+            tmp_bucket=self.tmp_prefix / 'tmp',
             gvcf_by_sgid=gvcf_by_sgid,
             tool=(
                 joint_genotyping.JointGenotyperTool.GnarlyGenotyper

--- a/cpg_workflows/stages/joint_genotyping.py
+++ b/cpg_workflows/stages/joint_genotyping.py
@@ -6,48 +6,39 @@ import logging
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch
 from cpg_workflows.filetypes import GvcfPath
 from cpg_workflows.jobs import joint_genotyping
-from cpg_workflows.workflow import (
-    Cohort,
-    CohortStage,
-    StageInput,
-    StageOutput,
-    WorkflowError,
-    stage,
-)
+from cpg_workflows.targets import MultiCohort
+from cpg_workflows.workflow import MultiCohortStage, StageInput, StageOutput, WorkflowError, stage
 
-from .. import get_batch
 from ..resources import joint_calling_scatter_count
 from .genotype import Genotype
 
 
 @stage(required_stages=Genotype)
-class JointGenotyping(CohortStage):
+class JointGenotyping(MultiCohortStage):
     """
     Joint-calling of GVCFs together.
     """
 
-    def expected_outputs(self, cohort: Cohort) -> dict:
+    def expected_outputs(self, multicohort: MultiCohort) -> dict:
         """
         Generate a pVCF and a site-only VCF.
         """
         return {
-            # writing into perm location for late debugging
-            # convert to str to avoid checking existence
-            'tmp_prefix': str(self.prefix / 'tmp'),
             'vcf': to_path(self.prefix / 'full.vcf.gz'),
             'siteonly': to_path(self.prefix / 'siteonly.vcf.gz'),
             'siteonly_part_pattern': str(self.prefix / 'siteonly_parts' / 'part{idx}.vcf.gz'),
         }
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+    def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
         """
         Submit jobs.
         """
         gvcf_by_sgid = {
             sequencing_group.id: GvcfPath(inputs.as_path(target=sequencing_group, stage=Genotype, key='gvcf'))
-            for sequencing_group in cohort.get_sequencing_groups()
+            for sequencing_group in multicohort.get_sequencing_groups()
         }
 
         not_found_gvcfs: list[str] = []
@@ -59,19 +50,19 @@ class JointGenotyping(CohortStage):
             raise WorkflowError(f'Joint genotyping: could not find {len(not_found_gvcfs)} GVCFs, exiting')
 
         jobs = []
-        vcf_path = self.expected_outputs(cohort)['vcf']
-        siteonly_vcf_path = self.expected_outputs(cohort)['siteonly']
-        scatter_count = joint_calling_scatter_count(len(cohort.get_sequencing_groups()))
+
+        # create expected outputs once
+        outputs = self.expected_outputs(multicohort)
+        scatter_count = joint_calling_scatter_count(len(gvcf_by_sgid))
         out_siteonly_vcf_part_paths = [
-            to_path(self.expected_outputs(cohort)['siteonly_part_pattern'].format(idx=idx))
-            for idx in range(scatter_count)
+            to_path(outputs['siteonly_part_pattern'].format(idx=idx)) for idx in range(scatter_count)
         ]
 
         jc_jobs = joint_genotyping.make_joint_genotyping_jobs(
             b=get_batch(),
-            out_vcf_path=vcf_path,
-            out_siteonly_vcf_path=siteonly_vcf_path,
-            tmp_bucket=to_path(self.expected_outputs(cohort)['tmp_prefix']),
+            out_vcf_path=outputs['vcf'],
+            out_siteonly_vcf_path=outputs['siteonly'],
+            tmp_bucket=self.prefix / 'tmp',
             gvcf_by_sgid=gvcf_by_sgid,
             tool=(
                 joint_genotyping.JointGenotyperTool.GnarlyGenotyper
@@ -87,4 +78,4 @@ class JointGenotyping(CohortStage):
         jobs.extend(jc_jobs)
         for job in jobs:
             assert job
-        return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=jobs)
+        return self.make_outputs(multicohort, data=outputs, jobs=jobs)

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -63,17 +63,6 @@ class AnnotateCohort(MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=j)
 
 
-def _sg_vcf_meta(
-    output_path: str,  # pylint: disable=W0613:unused-argument
-) -> dict[str, Any]:
-    """
-    Add meta.type to custom analysis object
-
-    TODO: Replace this once dynamic analysis types land in metamist.
-    """
-    return {'type': 'dataset-vcf'}
-
-
 def _snv_es_index_meta(
     output_path: str,  # pylint: disable=W0613:unused-argument
 ) -> dict[str, Any]:

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -91,7 +91,8 @@ class AnnotateDataset(DatasetStage):
         Annotate MT with genotype and consequence data for Seqr
         """
         assert dataset.cohort
-        mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateCohort, key='mt')
+        assert dataset.cohort.multicohort
+        mt_path = inputs.as_path(target=dataset.cohort.multicohort, stage=AnnotateCohort, key='mt')
 
         jobs = annotate_dataset_jobs(
             mt_path=mt_path,

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -84,10 +84,7 @@ class AnnotateDataset(DatasetStage):
         """
         Expected to generate a matrix table
         """
-        return {
-            'tmp_prefix': str(self.tmp_prefix / dataset.name),
-            'mt': (dataset.prefix() / 'mt' / f'{get_workflow().output_version}-{dataset.name}.mt'),
-        }
+        return {'mt': (dataset.prefix() / 'mt' / f'{get_workflow().output_version}-{dataset.name}.mt')}
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput | None:
         """
@@ -96,13 +93,11 @@ class AnnotateDataset(DatasetStage):
         assert dataset.cohort
         mt_path = inputs.as_path(target=dataset.cohort, stage=AnnotateCohort, key='mt')
 
-        checkpoint_prefix = to_path(self.expected_outputs(dataset)['tmp_prefix']) / 'checkpoints'
-
         jobs = annotate_dataset_jobs(
             mt_path=mt_path,
             sequencing_group_ids=dataset.get_sequencing_group_ids(),
             out_mt_path=self.expected_outputs(dataset)['mt'],
-            tmp_prefix=checkpoint_prefix,
+            tmp_prefix=self.tmp_prefix / dataset.name / 'checkpoints',
             job_attrs=self.get_job_attrs(dataset),
             depends_on=inputs.get_jobs(dataset),
         )

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -15,14 +15,7 @@ from cpg_workflows.jobs.seqr_loader import annotate_dataset_jobs, cohort_to_vcf_
 from cpg_workflows.query_modules import seqr_loader
 from cpg_workflows.targets import Dataset, MultiCohort
 from cpg_workflows.utils import get_logger, tshirt_mt_sizing
-from cpg_workflows.workflow import (
-    DatasetStage,
-    MultiCohortStage,
-    StageInput,
-    StageOutput,
-    get_workflow,
-    stage,
-)
+from cpg_workflows.workflow import DatasetStage, MultiCohortStage, StageInput, StageOutput, get_workflow, stage
 
 from .joint_genotyping import JointGenotyping
 from .vep import Vep
@@ -70,28 +63,6 @@ class AnnotateCohort(MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=j)
 
 
-def _update_meta(
-    output_path: str,  # pylint: disable=W0613:unused-argument
-) -> dict[str, Any]:
-    """
-    Add meta.type to custom analysis object
-
-    TODO: Replace this once dynamic analysis types land in metamist.
-    """
-    return {'type': 'annotated-dataset-callset'}
-
-
-def _dataset_vcf_meta(
-    output_path: str,  # pylint: disable=W0613:unused-argument
-) -> dict[str, Any]:
-    """
-    Add meta.type to custom analysis object
-
-    TODO: Replace this once dynamic analysis types land in metamist.
-    """
-    return {'type': 'dataset-vcf'}
-
-
 def _sg_vcf_meta(
     output_path: str,  # pylint: disable=W0613:unused-argument
 ) -> dict[str, Any]:
@@ -113,12 +84,7 @@ def _snv_es_index_meta(
     return {'seqr-dataset-type': 'VARIANTS'}
 
 
-@stage(
-    required_stages=[AnnotateCohort],
-    analysis_type='custom',
-    update_analysis_meta=_update_meta,
-    analysis_keys=['mt'],
-)
+@stage(required_stages=[AnnotateCohort], analysis_type='custom', analysis_keys=['mt'])
 class AnnotateDataset(DatasetStage):
     """
     Split mt by dataset and annotate dataset-specific fields (only for those datasets
@@ -155,12 +121,7 @@ class AnnotateDataset(DatasetStage):
         return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=jobs)
 
 
-@stage(
-    required_stages=[AnnotateDataset],
-    analysis_type='custom',
-    update_analysis_meta=_dataset_vcf_meta,
-    analysis_keys=['vcf'],
-)
+@stage(required_stages=[AnnotateDataset], analysis_type='custom', analysis_keys=['vcf'])
 class DatasetVCF(DatasetStage):
     """
     Take the per-dataset MT and write out as a VCF

--- a/cpg_workflows/stages/vep.py
+++ b/cpg_workflows/stages/vep.py
@@ -47,7 +47,7 @@ class Vep(MultiCohortStage):
             input_siteonly_vcf_path=inputs.as_path(multicohort, stage=Vqsr, key='siteonly'),
             input_siteonly_vcf_part_paths=input_siteonly_vcf_part_paths,
             out_path=outputs['ht'],
-            tmp_prefix=self.prefix / 'tmp',
+            tmp_prefix=self.tmp_prefix / 'tmp',
             job_attrs=self.get_job_attrs(),
             scatter_count=scatter_count,
         )

--- a/cpg_workflows/stages/vep.py
+++ b/cpg_workflows/stages/vep.py
@@ -5,13 +5,8 @@ VEP stage.
 from cpg_utils import to_path
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs import vep
-from cpg_workflows.workflow import (
-    Cohort,
-    CohortStage,
-    StageInput,
-    StageOutput,
-    stage,
-)
+from cpg_workflows.targets import MultiCohort
+from cpg_workflows.workflow import MultiCohortStage, StageInput, StageOutput, stage
 
 from ..resources import joint_calling_scatter_count
 from .joint_genotyping import JointGenotyping
@@ -19,32 +14,28 @@ from .vqsr import Vqsr
 
 
 @stage(required_stages=[Vqsr, JointGenotyping])
-class Vep(CohortStage):
+class Vep(MultiCohortStage):
     """
     Run VEP on a VCF.
     """
 
-    def expected_outputs(self, cohort: Cohort):
+    def expected_outputs(self, multicohort: MultiCohort):
         """
         Expected to write a hail table.
         """
-        return {
-            # writing into perm location for late debugging
-            # convert to str to avoid checking existence
-            'tmp_prefix': str(self.prefix / 'tmp'),
-            'ht': self.prefix / 'vep.ht',
-        }
+        return {'ht': self.prefix / 'vep.ht'}
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+    def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
         """
         Submit jobs.
         """
-        scatter_count = joint_calling_scatter_count(len(cohort.get_sequencing_groups()))
+        outputs = self.expected_outputs(multicohort)
+        scatter_count = joint_calling_scatter_count(len(multicohort.get_sequencing_groups()))
         input_siteonly_vcf_part_paths = [
             to_path(
                 inputs.as_str(
                     stage=JointGenotyping,
-                    target=cohort,
+                    target=multicohort,
                     key='siteonly_part_pattern',
                 ).format(idx=idx),
             )
@@ -53,11 +44,11 @@ class Vep(CohortStage):
 
         jobs = vep.add_vep_jobs(
             get_batch(),
-            input_siteonly_vcf_path=inputs.as_path(cohort, stage=Vqsr, key='siteonly'),
+            input_siteonly_vcf_path=inputs.as_path(multicohort, stage=Vqsr, key='siteonly'),
             input_siteonly_vcf_part_paths=input_siteonly_vcf_part_paths,
-            out_path=self.expected_outputs(cohort)['ht'],
-            tmp_prefix=to_path(self.expected_outputs(cohort)['tmp_prefix']),
+            out_path=outputs['ht'],
+            tmp_prefix=self.prefix / 'tmp',
             job_attrs=self.get_job_attrs(),
             scatter_count=scatter_count,
         )
-        return self.make_outputs(cohort, self.expected_outputs(cohort), jobs)
+        return self.make_outputs(multicohort, outputs, jobs)

--- a/cpg_workflows/stages/vqsr.py
+++ b/cpg_workflows/stages/vqsr.py
@@ -2,54 +2,46 @@
 Stage that performs AS-VQSR.
 """
 
-from cpg_utils import to_path
+from cpg_utils import Path
 from cpg_utils.config import get_config
+from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs import vqsr
-from cpg_workflows.workflow import (
-    Cohort,
-    CohortStage,
-    StageInput,
-    StageOutput,
-    stage,
-)
+from cpg_workflows.targets import MultiCohort
+from cpg_workflows.workflow import MultiCohortStage, StageInput, StageOutput, stage
 
-from .. import get_batch
 from ..resources import joint_calling_scatter_count
 from .joint_genotyping import JointGenotyping
 
 
 @stage(required_stages=JointGenotyping)
-class Vqsr(CohortStage):
+class Vqsr(MultiCohortStage):
     """
     Variant filtering of joint-called VCF.
     """
 
-    def expected_outputs(self, cohort: Cohort):
+    def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
         """
         Generate a site-only VCF.
         """
-        return {
-            # writing into perm location for late debugging
-            # convert to str to avoid checking existence
-            'tmp_prefix': str(self.prefix / 'tmp'),
-            'siteonly': self.prefix / 'siteonly.vcf.gz',
-        }
+        return {'siteonly': self.prefix / 'siteonly.vcf.gz'}
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+    def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
         """
         Submit jobs.
         """
-        siteonly_vcf_path = inputs.as_path(stage=JointGenotyping, target=cohort, key='siteonly')
+        siteonly_vcf_path = inputs.as_path(stage=JointGenotyping, target=multicohort, key='siteonly')
+        outputs = self.expected_outputs(multicohort)
+        number_of_sgids = len(multicohort.get_sequencing_groups())
 
         jobs = vqsr.make_vqsr_jobs(
             b=get_batch(),
             input_siteonly_vcf_path=siteonly_vcf_path,
-            scatter_count=joint_calling_scatter_count(len(cohort.get_sequencing_groups())),
-            gvcf_count=len(cohort.get_sequencing_groups()),
-            out_path=self.expected_outputs(cohort)['siteonly'],
-            tmp_prefix=to_path(self.expected_outputs(cohort)['tmp_prefix']),
+            scatter_count=joint_calling_scatter_count(number_of_sgids),
+            gvcf_count=number_of_sgids,
+            out_path=outputs['siteonly'],
+            tmp_prefix=self.prefix / 'tmp',
             use_as_annotations=get_config()['workflow'].get('use_as_vqsr', True),
             intervals_path=get_config()['workflow'].get('intervals_path'),
             job_attrs=self.get_job_attrs(),
         )
-        return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=jobs)
+        return self.make_outputs(multicohort, data=outputs, jobs=jobs)

--- a/cpg_workflows/stages/vqsr.py
+++ b/cpg_workflows/stages/vqsr.py
@@ -39,7 +39,7 @@ class Vqsr(MultiCohortStage):
             scatter_count=joint_calling_scatter_count(number_of_sgids),
             gvcf_count=number_of_sgids,
             out_path=outputs['siteonly'],
-            tmp_prefix=self.prefix / 'tmp',
+            tmp_prefix=self.tmp_prefix / 'tmp',
             use_as_annotations=get_config()['workflow'].get('use_as_vqsr', True),
             intervals_path=get_config()['workflow'].get('intervals_path'),
             job_attrs=self.get_job_attrs(),

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -108,9 +108,9 @@ class MultiCohort(Target):
         # NOTE: For a cohort, we simply pull the dataset name from the config.
         input_cohorts = get_config()['workflow'].get('input_cohorts', [])
         if input_cohorts:
-            cohorts_string = '_'.join(sorted(input_cohorts))
-
-        self.name = cohorts_string or get_config()['workflow']['dataset']
+            self.name = '_'.join(sorted(input_cohorts))
+        else:
+            self.name = get_config()['workflow']['dataset']
 
         assert self.name, 'Ensure cohorts or dataset is defined in the config file.'
 

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -295,24 +295,24 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     from cpg_workflows.inputs import get_multicohort
     from cpg_workflows.targets import SequencingGroup, Sex
 
-    cohort = get_multicohort()
+    multicohort = get_multicohort()
 
-    assert cohort
-    assert isinstance(cohort, Cohort)
+    assert multicohort
+    assert isinstance(multicohort, MultiCohort)
 
     # Testing Cohort Information
-    assert len(cohort.get_sequencing_groups()) == 2
-    assert cohort.get_sequencing_group_ids() == ['CPGLCL17', 'CPGLCL25']
+    assert len(multicohort.get_sequencing_groups()) == 2
+    assert multicohort.get_sequencing_group_ids() == ['CPGLCL17', 'CPGLCL25']
 
-    for sg in cohort.get_sequencing_groups():
+    for sg in multicohort.get_sequencing_groups():
         assert sg.dataset.name == 'fewgenomes'
         assert not sg.forced
         assert sg.cram is None
         assert sg.gvcf is None
 
     # Test SequenceGroup Population
-    test_sg = cohort.get_sequencing_groups()[0]
-    test_sg2 = cohort.get_sequencing_groups()[1]
+    test_sg = multicohort.get_sequencing_groups()[0]
+    test_sg2 = multicohort.get_sequencing_groups()[1]
     assert test_sg.id == 'CPGLCL17'
     assert test_sg.external_id == 'NA12340'
     assert test_sg.participant_id == '8'
@@ -336,12 +336,12 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     assert test_sg.pedigree.dad.participant_id == '14'
 
     # Test _sequencing_group_by_id attribute
-    assert cohort.get_datasets()[0]._sequencing_group_by_id.keys() == {
+    assert multicohort.get_datasets()[0]._sequencing_group_by_id.keys() == {
         'CPGLCL17',
         'CPGLCL25',
     }
-    assert cohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL17'].id == 'CPGLCL17'
-    assert cohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL25'].id == 'CPGLCL25'
+    assert multicohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL17'].id == 'CPGLCL17'
+    assert multicohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL25'].id == 'CPGLCL25'
 
     # Test reads
     # TODO: As above

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -125,10 +125,11 @@ SEQR_LOADER_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'default
 
 def _mock_cohort():
     from cpg_workflows.filetypes import BamPath, FastqPair, FastqPairs
-    from cpg_workflows.targets import Cohort
+    from cpg_workflows.targets import MultiCohort
 
-    cohort = Cohort()
-    ds = cohort.create_dataset('test-input-dataset')
+    multi_cohort = MultiCohort()
+    cohort = multi_cohort.create_cohort('test-analysis-dataset')
+    ds = cohort.create_dataset('test-analysis-dataset')
     ds.add_sequencing_group(
         'CPGAA',
         'SAMPLE1',
@@ -152,7 +153,7 @@ def _mock_cohort():
             ),
         },
     )
-    return cohort
+    return multi_cohort
 
 
 def selective_mock_open(*args, **kwargs):


### PR DESCRIPTION
n.b. a test is failing here - that is addressed in #865, but requires a slight restructure and should be evaluated separately

- Changes everything after Genotype and Align to use MultiCohorts
- In general removes a lot of repeat calls to expected_outputs. Instead of:

```
output1 = self.expected_outputs(multicohort)['foo']
output2 = self.expected_outputs(multicohort)['bar']
output3 = self.expected_outputs(multicohort)['baz']
```

I've replaced this with one call to get the dict, and pulling values from it instead:
```
outputs = self.expected_outputs(multicohort)
output1 = outputs['foo']
output2 = outputs['bar']
output3 = outputs['baz']
```

- In general the convention in these Stages of the expected_outputs containing an output path as a `Path` (so that the pipeline will check for presence/absence), and passing a tmp path as a String (so the pipeline won't check it) has been removed - there's no need for tmp_path to be in the output dict, it's created as needed using `self.tmp_prefix` (a property of the Stage itself, not exclusive to the expected_outputs method)

---

JointGenotyping
- Simple, one Stage, turns it into MultiCohorts
- Uses MultiCohorts.get_sequencing_groups instead

VQSR
- Simple(ish) 1-stage workflow
- number_of_sgids is only generated/counted once
- moves from Cohort -> MultiCohort
- The tmp_path here is actually not in tmp. I've not changed the convention here but *maybe we should*

VEP
- Simple(ish) 1-stage workflow
- number_of_sgids is only generated/counted once
- moves from Cohort -> MultiCohort
- The tmp_path here is actually not in tmp. I've not changed the convention here but *maybe we should*

seqr_loader
- Removes some update_analysis_meta callables. I'm ambivalent about this, but I don't think these currently work, and I don't think they're needed
- AnnotateCohort -> MultiCohort
- AnnotateDataset remains as Dataset, but picks up results from `dataset.cohort.multicohort` instead of `dataset.cohort`
- Removes `_sg_vcf_meta` which is imported in (and not really required in) HappyValidation

happy_validation
- Remove the `_sg_vcf_meta` update_analysis_meta callable