### PR TITLE
Replace bazam with samtools

### DIFF
--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -492,7 +492,7 @@ def extract_fastq(
     j.image(image_path('samtools'))
     # TODO: add ability to detect reference used in current BAM/CRAM and provide error handling
     if isinstance(alignment_input, CramPath):
-        reference_flag = f'--reference f{b.read_input(str(alignment_input.reference_assembly))}'
+        reference_flag = f'--reference {b.read_input(str(alignment_input.reference_assembly))}'
     else:
         reference_flag = ''
     res = STANDARD.request_resources(ncpu=16)

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -84,7 +84,7 @@ def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
                 path,
                 reference_assembly=_get_cram_reference_from_version(realign_cram_ver),
             )
-    if realign_from_cram := get_config()['workflow'].get('realign_from_cram'):
+    elif realign_from_cram := get_config()['workflow'].get('realign_from_cram'):
         alignment_input = CramPath(
             path=(sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram'),
             reference_assembly=get_config()['workflow']['ref_fasta'],

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -87,7 +87,11 @@ def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
                 path,
                 reference_assembly=_get_cram_reference_from_version(realign_cram_ver),
             )
-
+    if realign_from_cram := get_config()['workflow'].get('realign_from_cram'):
+        alignment_input = CramPath(
+            (sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram'),
+        )
+        logging.info(f'Realigning from CRAM {alignment_input.path}')
     if not alignment_input:
         raise MissingAlignmentInputException(
             f'No alignment inputs found for sequencing group {sequencing_group}'

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -316,7 +316,7 @@ def storage_for_align_job(alignment_input: AlignmentInput) -> int | None:
 
 
 def _align_one(
-    b,
+    b: hb.Batch,
     job_name: str,
     alignment_input: FastqPair | CramPath | BamPath,
     requested_nthreads: int,
@@ -336,7 +336,7 @@ def _align_one(
     """
     job_attrs = (job_attrs or {}) | dict(label=job_name, tool=aligner.name)
     job_name = f'{job_name} {alignment_input}'
-    j = b.new_job(job_name, job_attrs)
+    j: Job = b.new_job(job_name, job_attrs)
 
     if get_config()['resource_overrides'].get('align_use_highmem'):
         align_machine_type = HIGHMEM
@@ -479,7 +479,7 @@ def _align_one(
 def extract_fastq(
     b,
     bam_or_cram_group: hb.ResourceGroup,
-    alignment_input: FastqPair | CramPath | BamPath,
+    alignment_input: CramPath | BamPath,
     ext: str = 'cram',
     job_attrs: dict | None = None,
 ) -> Job:

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -89,8 +89,9 @@ def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
             )
     if realign_from_cram := get_config()['workflow'].get('realign_from_cram'):
         alignment_input = CramPath(
-            (sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram'),
-            (sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram.crai'),
+            path=(sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram'),
+            index_path=(sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram.crai'),
+            reference_assembly=get_config()['workflow']['ref_fasta'],
         )
         logging.info(f'Realigning from CRAM {alignment_input.path}')
     if not alignment_input:

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -377,10 +377,10 @@ def _align_one(
             """,
             )
             use_interleaved = True
-
-        prepare_fastq_cmd = ''
-        r1_param = 'r1'
-        r2_param = ''
+        else:
+            prepare_fastq_cmd = ''
+            r1_param = 'r1'
+            r2_param = ''
 
     else:  # only for BAMs that are missing index
         assert isinstance(alignment_input, FastqPair)

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -90,6 +90,7 @@ def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
     if realign_from_cram := get_config()['workflow'].get('realign_from_cram'):
         alignment_input = CramPath(
             (sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram'),
+            (sequencing_group.dataset.prefix() / 'cram' / f'{sequencing_group.id}.cram.crai'),
         )
         logging.info(f'Realigning from CRAM {alignment_input.path}')
     if not alignment_input:

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -13,7 +13,7 @@ from hailtop.batch.job import Job
 
 from cpg_utils import Path
 from cpg_utils.config import get_config, image_path, reference_path
-from cpg_utils.hail_batch import command, fasta_res_group
+from cpg_utils.hail_batch import command, fasta_res_group, output_path
 from cpg_workflows.filetypes import (
     AlignmentInput,
     BamPath,
@@ -104,6 +104,46 @@ def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
     return alignment_input
 
 
+def subset_cram(
+    b: hb.Batch,
+    bam_or_cram_group: hb.ResourceGroup,
+    alignment_input: FastqPair | CramPath | BamPath,
+    sequencing_group: SequencingGroup,
+    chr: str,
+    output_bucket: str = 'tmp',
+) -> Job:
+    logging.info(f'alignment_input: {type(alignment_input)}')
+    subset_cram_j = b.new_job('subset_tob_cram')
+    subset_cram_j.image(image_path('samtools'))
+    subset_cram_j.cpu(2)
+    subset_cram_j.storage('150G')
+    subset_cram_j.memory('standard')
+    if isinstance(alignment_input, FastqPair):
+        ref_path = fasta_res_group(b)['base']
+        logging.info(f'Reference path: {ref_path}')
+    if isinstance(alignment_input, CramPath | BamPath):
+        ref_path = b.read_input(alignment_input.reference_assembly)
+        logging.info(f'Reference path: {ref_path}')
+    subset_cram_j.declare_resource_group(
+        cram_output={
+            'cram': '{root}.cram',
+            'cram.crai': '{root}.cram.crai',
+        },
+    )
+    subset_cmd = f"""
+    samtools view -T {ref_path} -C -o {subset_cram_j.cram_output.cram} {bam_or_cram_group['cram']} {chr} && \
+    samtools index {subset_cram_j.cram_output.cram}
+    """
+    subset_cram_j.command(command(subset_cmd))
+
+    if output_bucket:
+        path = f'subset_{chr}/{sequencing_group.id}_{chr}'
+        logging.info(f'Writing subset cram output to {output_path(path, "tmp")}')
+        b.write_output(subset_cram_j.cram_output, output_path(path, 'tmp'))
+
+    return subset_cram_j
+
+
 def align(
     b,
     sequencing_group: SequencingGroup,
@@ -154,26 +194,19 @@ def align(
     # if number of threads is not requested, using whole instance
     requested_nthreads = requested_nthreads or STANDARD.max_threads()
 
-    if get_config()['workflow']['sequencing_type'] == 'genome':
-        realignment_shards_num = 10
-    else:
-        assert get_config()['workflow']['sequencing_type'] == 'exome'
-        realignment_shards_num = 1
-
     sharded_fq = isinstance(alignment_input, FastqPairs) and len(alignment_input) > 1
-    sharded_bazam = (
-        isinstance(alignment_input, CramPath | BamPath) and alignment_input.index_path and realignment_shards_num > 1
-    )
-    sharded = sharded_fq or sharded_bazam
 
     jobs: list[Job] = []
     sharded_align_jobs = []
     sorted_bams = []
 
-    if not sharded:  # Just running one alignment job
+    if not sharded_fq:  # Just running one alignment job
         if isinstance(alignment_input, FastqPairs):
             alignment_input = alignment_input[0]
         assert isinstance(alignment_input, FastqPair | BamPath | CramPath)
+        extract_reads = False
+        if isinstance(alignment_input, CramPath | BamPath):
+            extract_reads = True
         align_j, align_cmd = _align_one(
             b=b,
             job_name=base_job_name,
@@ -183,10 +216,12 @@ def align(
             job_attrs=job_attrs,
             aligner=aligner,
             should_sort=False,
+            extract_reads=extract_reads,
         )
         stdout_is_sorted = False
         output_fmt = 'sam'
         jobs.append(align_j)
+        logging.info('Aligning single job. No need to merge')
         merge_or_align_j = align_j
 
     else:  # Aligning in parallel and merging afterwards
@@ -206,28 +241,6 @@ def align(
                     should_sort=True,
                 )
                 assert isinstance(j, Job)
-                j.command(command(cmd, monitor_space=True))  # type: ignore
-                sorted_bams.append(j.sorted_bam)
-                sharded_align_jobs.append(j)
-
-        elif sharded_bazam:  # Using BAZAM to shard CRAM
-            assert realignment_shards_num, realignment_shards_num
-            assert isinstance(alignment_input, CramPath | BamPath)
-            for shard_number in range(realignment_shards_num):
-                j, cmd = _align_one(
-                    b=b,
-                    job_name=base_job_name,
-                    alignment_input=alignment_input,
-                    sequencing_group_name=sequencing_group.id,
-                    job_attrs=job_attrs,
-                    aligner=aligner,
-                    requested_nthreads=requested_nthreads,
-                    number_of_shards_for_realignment=realignment_shards_num,
-                    shard_number=shard_number,
-                    should_sort=True,
-                )
-                # Sorting with samtools, but not adding deduplication yet, because we
-                # need to merge first.
                 j.command(command(cmd, monitor_space=True))  # type: ignore
                 sorted_bams.append(j.sorted_bam)
                 sharded_align_jobs.append(j)
@@ -309,9 +322,8 @@ def _align_one(
     sequencing_group_name: str,
     job_attrs: dict | None = None,
     aligner: Aligner = Aligner.BWA,
-    number_of_shards_for_realignment: int | None = None,
-    shard_number: int | None = None,
     should_sort: bool = False,
+    extract_reads: bool = False,
 ) -> tuple[Job, str]:
     """
     Creates a job that (re)aligns reads to hg38. Returns the job object and a command
@@ -321,13 +333,7 @@ def _align_one(
     Note: When this function is called within the align function, DRAGMAP is used as the default
     tool.
     """
-
-    if number_of_shards_for_realignment is not None:
-        assert number_of_shards_for_realignment > 1, number_of_shards_for_realignment
-
     job_attrs = (job_attrs or {}) | dict(label=job_name, tool=aligner.name)
-    if shard_number is not None and number_of_shards_for_realignment is not None:
-        job_name = f'{job_name} {shard_number + 1}/{number_of_shards_for_realignment} '
     job_name = f'{job_name} {alignment_input}'
     j = b.new_job(job_name, job_attrs)
 
@@ -348,21 +354,26 @@ def _align_one(
     #   Replace process substitution with named-pipes (FIFO)
     #   This is named-pipe name -> command to populate it
     fifo_commands: dict[str, str] = {}
-
+    use_interleaved = False
     if isinstance(alignment_input, CramPath | BamPath):
-        use_bazam = True
-        if number_of_shards_for_realignment and number_of_shards_for_realignment > 1:
-            assert shard_number is not None and shard_number >= 0, (
-                shard_number,
-                sequencing_group_name,
+        if extract_reads:
+            logging.info("Using samtools to extract FASTQs from CRAM/BAM")
+            logging.info(f"Alignment input: {alignment_input.path} {alignment_input.index_path}")
+            bam_or_cram_group = alignment_input.resource_group(b)
+            extract_fastq_j = extract_fastq(
+                b,
+                bam_or_cram_group,
+                alignment_input,
             )
-            shard_param = f' -s {shard_number + 1},{number_of_shards_for_realignment}'
-        else:
-            shard_param = ''
-
-        bazam_ref_cmd = ''
-        samtools_ref_cmd = ''
-        if isinstance(alignment_input, CramPath):
+            interleaved_fastq = extract_fastq_j.all_reads
+            interleave_param = '$BATCH_TMPDIR/all_reads.fq.gz'
+            # Need file names to end with ".gz" for DRAGMAP to parse correctly:
+            prepare_fastq_cmd = dedent(
+                f"""\
+            mv {interleaved_fastq} {interleave_param}
+            """,
+            )
+            use_interleaved = True
             assert (
                 alignment_input.reference_assembly
             ), f'The reference input for the alignment input "{alignment_input.path}" was not set'
@@ -370,7 +381,6 @@ def _align_one(
                 base=str(alignment_input.reference_assembly),
                 fai=str(alignment_input.reference_assembly) + '.fai',
             ).base
-            bazam_ref_cmd = f'-Dsamjdk.reference_fasta={reference_inp}'
             samtools_ref_cmd = f'--reference {reference_inp}'
 
         group = alignment_input.resource_group(b)
@@ -389,33 +399,22 @@ def _align_one(
             mv $BATCH_TMPDIR/sorted.{alignment_input.ext} {group[alignment_input.ext]}
             rm -rf $BATCH_TMPDIR/sort_tmp
 
-            # bazam requires an index at foo.crai (not foo.cram.crai) so we must set the
-            # path explicitly. We can not access the localized cram file's basename via the
-            # Input ResourceGroup so using shell magic to strip the trailing "m" and add an
-            # "i" to the alignment_path. This should work for both .cram and .bam files.
             alignment_path="{group[alignment_input.ext]}"
-            samtools index -@{nthreads - 1} $alignment_path  ${{alignment_path%m}}i
+            alignment_index_path="{group[alignment_input.index_ext]}"
+            samtools index -@{nthreads - 1} $alignment_path  $alignment_index_path
             """,
             )
 
-        bazam_cmd = dedent(
-            f"""\
-        bazam -Xmx16g {bazam_ref_cmd} \
-        -n{min(nthreads, 6)} -bam {group[alignment_input.ext]}{shard_param} \
-        """,
-        )
         prepare_fastq_cmd = ''
         r1_param = 'r1'
         r2_param = ''
-        fifo_commands[r1_param] = bazam_cmd
 
     else:  # only for BAMs that are missing index
         assert isinstance(alignment_input, FastqPair)
         fastq_pair = alignment_input.as_resources(b)
-        use_bazam = False
         r1_param = '$BATCH_TMPDIR/R1.fq.gz'
         r2_param = '$BATCH_TMPDIR/R2.fq.gz'
-        # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
+        # Need file names to end with ".gz" for DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""\
         mv {fastq_pair.r1} {r1_param}
@@ -443,7 +442,7 @@ def _align_one(
         cmd = f"""\
         {prepare_fastq_cmd}
         {tool_name} mem -K 100000000 \\
-        {'-p' if use_bazam else ''} -t{nthreads - 1} -Y -R '{rg_line}' \\
+        -t{nthreads - 1} -Y -R '{rg_line}' \\
         {bwa_reference.base} {r1_param} {r2_param}
         """
 
@@ -455,8 +454,8 @@ def _align_one(
                 for k in DRAGMAP_INDEX_FILES
             },
         )
-        if use_bazam:
-            input_params = f'--interleaved=1 -b {r1_param}'
+        if use_interleaved:
+            input_params = f'--interleaved=1 -b {interleave_param}'
         else:
             input_params = f'-1 {r1_param} -2 {r2_param}'
         # TODO: consider reverting to use of all threads if node capacity
@@ -509,37 +508,36 @@ def _align_one(
 def extract_fastq(
     b,
     bam_or_cram_group: hb.ResourceGroup,
+    alignment_input: FastqPair | CramPath | BamPath,
     ext: str = 'cram',
     job_attrs: dict | None = None,
-    output_fq1: str | Path | None = None,
-    output_fq2: str | Path | None = None,
 ) -> Job:
     """
     Job that converts a BAM or a CRAM file to a pair of compressed fastq files.
     """
     j = b.new_job('Extract fastq', (job_attrs or {}) | dict(tool='samtools'))
     j.image(image_path('samtools'))
+    # TODO: add ability to detect reference used in current BAM/CRAM and provide error handling
+    if isinstance(alignment_input, CramPath | BamPath):
+        reference_path = b.read_input(str(alignment_input.reference_assembly))
+    else:
+        reference_path = fasta_res_group(b)['base']
     res = STANDARD.request_resources(ncpu=16)
-    if get_config()['workflow']['sequencing_type'] == 'genome':
+    if get_config()['workflow'].get('align', {})['sequencing_type'] == 'genome':
         res.attach_disk_storage_gb = 700
     res.set_to_job(j)
     tmp_prefix = '$BATCH_TMPDIR/collate'
     cmd = f"""
-    samtools collate -@{res.get_nthreads() - 1} -u -O \
+    samtools collate --reference {reference_path} -@{res.get_nthreads() - 1} -u -O \
     {bam_or_cram_group[ext]} {tmp_prefix} | \\
     samtools fastq -@{res.get_nthreads() - 1} \
-    -1 $BATCH_TMPDIR/R1.fq.gz -2 $BATCH_TMPDIR/R2.fq.gz \
-    -0 /dev/null -s /dev/null -n
+    -0 /dev/null -n | gzip > $BATCH_TMPDIR/all_reads.fq.gz
     # Can't write directly to j.fq1 and j.fq2 because samtools-fastq requires the
     # file names to end with ".gz" in order to create compressed outputs.
-    mv $BATCH_TMPDIR/R1.fq.gz {j.fq1}
-    mv $BATCH_TMPDIR/R2.fq.gz {j.fq2}
+    mv $BATCH_TMPDIR/all_reads.fq.gz {j.all_reads}
     """
     j.command(command(cmd, monitor_space=True))
-    if output_fq1 or output_fq2:
-        assert output_fq1 and output_fq2, (output_fq1, output_fq2)
-        b.write_output(j.fq1, str(output_fq1))
-        b.write_output(j.fq2, str(output_fq2))
+
     return j
 
 

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -204,10 +204,14 @@ def align(
         extract_reads = False
         if isinstance(alignment_input, CramPath | BamPath):
             extract_reads = True
+            if isinstance(alignment_input, CramPath):
+                assert (
+                    alignment_input.reference_assembly
+                ), f'The reference input for the alignment input "{alignment_input.path}" was not set'
         align_j, align_cmd = _align_one(
             b=b,
             job_name=base_job_name,
-            alignment_input=alignment_input,
+            alignment_input=alignment_input,  # type: ignore[arg-type]
             requested_nthreads=requested_nthreads,
             sequencing_group_name=sequencing_group.id,
             job_attrs=job_attrs,
@@ -371,9 +375,6 @@ def _align_one(
             """,
             )
             use_interleaved = True
-            assert (
-                alignment_input.reference_assembly
-            ), f'The reference input for the alignment input "{alignment_input.path}" was not set'
 
         prepare_fastq_cmd = ''
         r1_param = 'r1'

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -357,10 +357,10 @@ def _align_one(
     fifo_commands: dict[str, str] = {}
     use_interleaved = False
     if isinstance(alignment_input, CramPath | BamPath):
+        bam_or_cram_group = alignment_input.resource_group(b)
         if extract_reads:
             logging.info("Using samtools to extract FASTQs from CRAM/BAM")
             logging.info(f"Alignment input: {alignment_input.path} {alignment_input.index_path}")
-            bam_or_cram_group = alignment_input.resource_group(b)
             extract_fastq_j = extract_fastq(
                 b,
                 bam_or_cram_group,
@@ -377,12 +377,15 @@ def _align_one(
             """,
             )
             use_interleaved = True
+        ###TODO: CONFIRM I NEED THIS ELSE STATEMENT
         else:
             prepare_fastq_cmd = ''
             r1_param = 'r1'
             r2_param = ''
+        # DON'T NEED TO INDEX CRAMS/BAMS BEFORE ANYMORE
+        # TODO: DOUBLE CHECK IF DRAGEN MAKES INDEXES
 
-    else:  # only for BAMs that are missing index
+    else:  # FastqPair
         assert isinstance(alignment_input, FastqPair)
         fastq_pair = alignment_input.as_resources(b)
         r1_param = '$BATCH_TMPDIR/R1.fq.gz'

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -365,7 +365,9 @@ def _align_one(
                 b,
                 bam_or_cram_group,
                 alignment_input,
+                ext=alignment_input.ext,
             )
+            j.depends_on(extract_fastq_j)
             interleaved_fastq = extract_fastq_j.all_reads
             interleave_param = '$BATCH_TMPDIR/all_reads.fq.gz'
             # Need file names to end with ".gz" for DRAGMAP to parse correctly:

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -226,7 +226,7 @@ class TestPreProcessing:
         ref = re.escape(expected_ref)
         file = re.escape(expected_cram)
         cmd = get_command_str(extract_fastq_j)
-        pattern = fr'samtools collate --reference ${{BATCH_TMPDIR}}/inputs/\w+/{expected_ref} -@15 -u -O ${{BATCH_TMPDIR}}/inputs/\w+/{expected_cram} $BATCH_TMPDIR/collate'
+        pattern = fr'samtools collate --reference \${{BATCH_TMPDIR}}/inputs/\w+/{ref} -@15 -u -O \${{BATCH_TMPDIR}}/inputs/\w+/{file} \$BATCH_TMPDIR/collate'
 
         assert re.search(pattern, cmd)
 

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -230,6 +230,10 @@ class TestPreProcessing:
 
         assert re.search(pattern, cmd)
 
+    # THIS TEST WILL BE REDUNDANT BECAUSE WE WILL NOT BE USING BAZAM AND WE ONLY INDEXED BEFORE ALIGNMENT
+    # BECAUSE BAZAM REQUIRED IT.
+    # ALSO, EXTRACTING READS FROM BAMS DOES NOT NEED A REFERENCE ASSEMBLY BUT FROM CRAMS IT DOES. HENCE WHY
+    # CREATE_BAM_INPUT DOESN'T NEED A REFERENCE_ASSEMBLY ARGUMENT FOR THE BAMPATH OBJECT.
     def test_indexes_bam_if_index_does_not_exist(self, tmp_path: Path):
         """
         Test that the `align` function sorts and indexes the BAM input when index is

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -150,20 +150,6 @@ class TestPreProcessing:
         assert 'samtools collate' in cmd
         assert '--reference' not in cmd
 
-    def test_bazam_flags_correctly_set_when_extracting_reads(self, tmp_path: Path):
-        config = default_config()
-        batch, sg = setup_test(config, tmp_path, alignment_input='bam')
-
-        jobs = align(b=batch, sequencing_group=sg)
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 10
-
-        file = re.escape('SAMPLE1.bam')
-        for i, job in enumerate(align_jobs):
-            cmd = get_command_str(job)
-            pattern = fr'bazam .* -bam \${{BATCH_TMPDIR}}/inputs/\w+/{file} -s {i+1},10 > r1'
-            assert re.search(pattern, cmd)
-
     @pytest.mark.parametrize(
         'realignment_config,create_realignment_cram,expected_cram,expected_ref',
         [
@@ -196,7 +182,7 @@ class TestPreProcessing:
             ),
         ],
     )
-    def test_bazam_and_uses_correct_reference_and_cram_file_when_realigning(
+    def test_extract_fastq_and_uses_correct_reference_and_cram_file_when_realigning(
         self,
         tmp_path: Path,
         realignment_config: dict[str, str],


### PR DESCRIPTION
Bazam has a bug in it that is [summarised in this post](https://centrepopgen.slack.com/archives/C063WDT5HT4/p1718170029722189) and it has been decided to replace bazam with `samtools fastq`.

A [subsequent post](https://centrepopgen.slack.com/archives/C063WDT5HT4/p1720413842196729) covers covers validation of this replacement.

This PR is part of a series of PRs that aim to simplify the align job (#843 and #844), this was initially one big PR but has since been split out into these subsequent ones.

**Notes**
- I have included a function `subset_cram()` that was useful for testing purposes. This is for future use-cases
- Bubbled up the checking of crams that they have a `cram.reference_assembly`
- Added a config parameter `realign_from_cram` that allows for us to realign from the 'base' cram as the previous implementation (kept in for completeness) did not allow for this to happen.
- Removed indexing of cram/bam prior to alignment as bazam required an index


This PR makes minimal changes to the current cram retrieval logic as significant changes to versioning and config logic will likely adjust how we approach this.