### PR TITLE
Multicohorts everywhere

### DIFF
--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -102,7 +102,7 @@ def _populate_cohort(cohort: Cohort, sgs_by_dataset_for_cohort, read_pedigree: b
     assert cohort.get_sequencing_groups()
 
 
-def deprecated_create_cohort() -> Cohort:
+def deprecated_create_cohort() -> MultiCohort:
     """
     Add datasets in the cohort. There exists only one cohort for the workflow run.
     """
@@ -120,8 +120,8 @@ def deprecated_create_cohort() -> Cohort:
         logging.warning('Using dataset will soon be deprecated. Use input_cohorts instead.')
 
     dataset_names = [d for d in dataset_names if d not in skip_datasets]
-
-    cohort = Cohort()
+    multi_cohort = MultiCohort()
+    cohort = multi_cohort.create_cohort(analysis_dataset_name)
 
     for dataset_name in dataset_names:
         dataset = cohort.create_dataset(dataset_name)
@@ -156,8 +156,8 @@ def deprecated_create_cohort() -> Cohort:
     _populate_analysis(cohort)
     if config.get('read_pedigree', True):
         _populate_pedigree(cohort)
-    assert cohort.get_sequencing_groups()
-    return cohort
+    assert multi_cohort.get_sequencing_groups()
+    return multi_cohort
 
 
 def _combine_assay_meta(assays: list[Assay]) -> dict:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -11,7 +11,6 @@ from .metamist import AnalysisType, Assay, MetamistError, get_metamist, parse_re
 from .targets import Cohort, MultiCohort, PedigreeInfo, SequencingGroup, Sex
 from .utils import exists
 
-_cohort: Cohort | None = None
 _multicohort: MultiCohort | None = None
 
 
@@ -23,12 +22,12 @@ def actual_get_multicohort() -> MultiCohort:
     return _multicohort
 
 
-def deprecated_get_cohort() -> Cohort:
+def deprecated_get_cohort() -> MultiCohort:
     """Return the cohort object"""
-    global _cohort
-    if not _cohort:
-        _cohort = deprecated_create_cohort()
-    return _cohort
+    global _multicohort
+    if not _multicohort:
+        _multicohort = deprecated_create_cohort()
+    return _multicohort
 
 
 def get_multicohort() -> Cohort | MultiCohort:

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -108,9 +108,9 @@ class MultiCohort(Target):
         # NOTE: For a cohort, we simply pull the dataset name from the config.
         input_cohorts = get_config()['workflow'].get('input_cohorts', [])
         if input_cohorts:
-            cohorts_string = '_'.join(sorted(input_cohorts))
-
-        self.name = cohorts_string or get_config()['workflow']['dataset']
+            self.name = '_'.join(sorted(input_cohorts))
+        else:
+            self.name = get_config()['workflow']['dataset']
 
         assert self.name, 'Ensure cohorts or dataset is defined in the config file.'
 

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -282,6 +282,8 @@ class StageInput:
                 f'{self.stage.name}. Is {stage.__name__} in the `required_stages`'
                 f'decorator? Available: {self._outputs_by_target_by_stage}',
             )
+        print(self._outputs_by_target_by_stage[stage.__name__])
+        print(target.target_id)
         if not self._outputs_by_target_by_stage[stage.__name__].get(target.target_id):
             raise StageInputNotFoundError(
                 f'Not found output for {target} from stage {stage.__name__}, required for stage {self.stage.name}',

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -282,8 +282,6 @@ class StageInput:
                 f'{self.stage.name}. Is {stage.__name__} in the `required_stages`'
                 f'decorator? Available: {self._outputs_by_target_by_stage}',
             )
-        print(self._outputs_by_target_by_stage[stage.__name__])
-        print(target.target_id)
         if not self._outputs_by_target_by_stage[stage.__name__].get(target.target_id):
             raise StageInputNotFoundError(
                 f'Not found output for {target} from stage {stage.__name__}, required for stage {self.stage.name}',

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -295,24 +295,24 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     from cpg_workflows.inputs import get_multicohort
     from cpg_workflows.targets import SequencingGroup, Sex
 
-    cohort = get_multicohort()
+    multicohort = get_multicohort()
 
-    assert cohort
-    assert isinstance(cohort, Cohort)
+    assert multicohort
+    assert isinstance(multicohort, MultiCohort)
 
     # Testing Cohort Information
-    assert len(cohort.get_sequencing_groups()) == 2
-    assert cohort.get_sequencing_group_ids() == ['CPGLCL17', 'CPGLCL25']
+    assert len(multicohort.get_sequencing_groups()) == 2
+    assert multicohort.get_sequencing_group_ids() == ['CPGLCL17', 'CPGLCL25']
 
-    for sg in cohort.get_sequencing_groups():
+    for sg in multicohort.get_sequencing_groups():
         assert sg.dataset.name == 'fewgenomes'
         assert not sg.forced
         assert sg.cram is None
         assert sg.gvcf is None
 
     # Test SequenceGroup Population
-    test_sg = cohort.get_sequencing_groups()[0]
-    test_sg2 = cohort.get_sequencing_groups()[1]
+    test_sg = multicohort.get_sequencing_groups()[0]
+    test_sg2 = multicohort.get_sequencing_groups()[1]
     assert test_sg.id == 'CPGLCL17'
     assert test_sg.external_id == 'NA12340'
     assert test_sg.participant_id == '8'
@@ -336,12 +336,12 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     assert test_sg.pedigree.dad.participant_id == '14'
 
     # Test _sequencing_group_by_id attribute
-    assert cohort.get_datasets()[0]._sequencing_group_by_id.keys() == {
+    assert multicohort.get_datasets()[0]._sequencing_group_by_id.keys() == {
         'CPGLCL17',
         'CPGLCL25',
     }
-    assert cohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL17'].id == 'CPGLCL17'
-    assert cohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL25'].id == 'CPGLCL25'
+    assert multicohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL17'].id == 'CPGLCL17'
+    assert multicohort.get_datasets()[0]._sequencing_group_by_id['CPGLCL25'].id == 'CPGLCL25'
 
     # Test reads
     # TODO: As above

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -125,10 +125,10 @@ SEQR_LOADER_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'default
 
 def _mock_cohort():
     from cpg_workflows.filetypes import BamPath, FastqPair, FastqPairs
-    from cpg_workflows.targets import Cohort
-
-    cohort = Cohort()
-    ds = cohort.create_dataset('test-input-dataset')
+    from cpg_workflows.targets import MultiCohort
+    multi_cohort = MultiCohort()
+    cohort = multi_cohort.create_cohort('test-analysis-dataset')
+    ds = cohort.create_dataset('test-analysis-dataset')
     ds.add_sequencing_group(
         'CPGAA',
         'SAMPLE1',
@@ -152,7 +152,7 @@ def _mock_cohort():
             ),
         },
     )
-    return cohort
+    return multi_cohort
 
 
 def selective_mock_open(*args, **kwargs):

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -126,6 +126,7 @@ SEQR_LOADER_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'default
 def _mock_cohort():
     from cpg_workflows.filetypes import BamPath, FastqPair, FastqPairs
     from cpg_workflows.targets import MultiCohort
+
     multi_cohort = MultiCohort()
     cohort = multi_cohort.create_cohort('test-analysis-dataset')
     ds = cohort.create_dataset('test-analysis-dataset')


### PR DESCRIPTION
Stacked change on top of #863 

Those tests are failing because we still have a legacy pipeline setup mode (using `input_datasets` to generate a Cohort instead of a MultiCohort)

In that legacy scenario the workflow doesn't have a MultiCohort so when a DatasetStage follows on from a MultiCohort stage, the chain `dataset.cohort.multicohort` doesn't exist. This is explicitly tested in `test/test_seqr_loader_dry.py`, which was the failing test in #863.

This PR changes the behaviour of `deprecated_create_cohort()` to create a single-Cohort MultiCohort. Instead of creating a Cohort or a MultiCohort (depending on pipeline config), we always generate a MultiCohort. The backbone of a workflow becomes a MultiCohort at all times, but the way it's populated will vary:

- If we supply `input_cohorts`, we create a MultiCohort, containing one or more Cohorts
    - each Cohort is populated with one or more Datasets, as appropriate  
- If we supply `input_datasets`, we create a MultiCohort containing exactly one Cohort
    - within that one Cohort we populate all Datasets

The same samples would be populated either way, but we never risk the situation where we expect a MultiCohort, but because of the way the pipeline was set up we don't have one instantiated.

Change to the test - 

- If a MultiCohort is created, but is populated from the input_datasets, the cohort name will be the analysis-dataset name for the run
- I wouldn't expect an operator to run a CohortStage workflow without input_cohort unless the CohortStage is not yet updated to a MultiCohort Stage, in which case the Cohort and MultiCohort are equivalent - all samples in the run.