### PR TITLE
GATK SV MultiSample JoinRawCalls input dict typo fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.26
+current_version = 1.25.27
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.25.26
+  VERSION: 1.25.27
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -873,7 +873,7 @@ class JoinRawCalls(MultiCohortStage):
             input_dict[f'clustered_{caller}_vcfs'] = [
                 clusterbatch_outputs[cohort][f'clustered_{caller}_vcf'] for cohort in all_batch_names
             ]
-            input_dict[f'clustered_{caller}_vcfs_indexes'] = [
+            input_dict[f'clustered_{caller}_vcf_indexes'] = [
                 clusterbatch_outputs[cohort][f'clustered_{caller}_vcf_index'] for cohort in all_batch_names
             ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.25.26',
+    version='1.25.27',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The GATK SV multisample pipeline broke at the JoinRawCalls stage. Looking at the cromwell logs, it's because of an extra character in the dict keys.
https://batch.hail.populationgenomics.org.au/batches/474452?q=state%3Dfailed
```
WARNING: Unexpected input provided: JoinRawCalls.clustered_wham_vcfs_indexes
WARNING: Unexpected input provided: JoinRawCalls.clustered_depth_vcfs_indexes
WARNING: Unexpected input provided: JoinRawCalls.clustered_manta_vcfs_indexes
WARNING: Unexpected input provided: JoinRawCalls.clustered_scramble_vcfs_indexes
```
In the expected inputs, we have these keys, but "vcf" is not pluralized. 
```
expected inputs: [JoinRawCalls.SVCluster.mixed_breakend_window, JoinRawCalls.ConcatInputVcfs.sites_only, JoinRawCalls.clustered_manta_vcf_indexes, JoinRawCalls.SVCluster.mixed_interval_overlap, JoinRawCalls.FormatVcfForGatk.chr_y, JoinRawCalls.ConcatVcfs.sort_vcf_list, JoinRawCalls.chr_x, JoinRawCalls.FormatVcfForGatk.runtime_attr_scatter, JoinRawCalls.ConcatInputVcfs.generate_index, JoinRawCalls.SVCluster.insertion_length_summary_strategy, JoinRawCalls.FormatVcfForGatk.runtime_attr_create_ploidy, JoinRawCalls.SVCluster.alt_allele_summary_strategy, JoinRawCalls.SVCluster.default_no_call, JoinRawCalls.sv_base_mini_docker, JoinRawCalls.FormatVcfForGatk.records_per_shard, JoinRawCalls.FormatVcfForGatk.runtime_override_concat, JoinRawCalls.runtime_override_concat_vcfs_pesr, JoinRawCalls.SVCluster.enable_cnv, JoinRawCalls.ConcatVcfs.sites_only, JoinRawCalls.clustered_scramble_vcfs, JoinRawCalls.chr_y, JoinRawCalls.clustered_depth_vcf_indexes, JoinRawCalls.SVCluster.mixed_size_similarity, JoinRawCalls.ConcatVcfs.generate_index, JoinRawCalls.FormatVcfForGatk.runtime_override_hail_merge_step1, JoinRawCalls.SVCluster.pesr_interval_overlap, JoinRawCalls.SVCluster.defrag_padding_fraction, JoinRawCalls.SVCluster.depth_breakend_window, JoinRawCalls.clustered_scramble_vcf_indexes, JoinRawCalls.runtime_attr_svcluster, JoinRawCalls.clustered_melt_vcfs, JoinRawCalls.ConcatVcfs.allow_overlaps, JoinRawCalls.clustered_manta_vcfs, JoinRawCalls.gatk_docker, JoinRawCalls.prefix, JoinRawCalls.SVCluster.vcfs_tar, JoinRawCalls.FormatVcfForGatk.runtime_attr_format, JoinRawCalls.FormatVcfForGatk.formatter_args, JoinRawCalls.reference_fasta_fai, JoinRawCalls.contig_list, JoinRawCalls.clustered_wham_vcf_indexes, JoinRawCalls.ConcatInputVcfs.sort_vcf_list, JoinRawCalls.SVCluster.depth_interval_overlap, JoinRawCalls.SVCluster.depth_size_similarity, JoinRawCalls.ped_file, JoinRawCalls.clustered_wham_vcfs, JoinRawCalls.runtime_attr_create_ploidy, JoinRawCalls.FormatVcfForGatk.chr_x, JoinRawCalls.reference_dict, JoinRawCalls.SVCluster.breakpoint_summary_strategy, JoinRawCalls.reference_fasta, JoinRawCalls.java_mem_fraction, JoinRawCalls.runtime_attr_prepare_truth, JoinRawCalls.FormatVcfForGatk.runtime_override_preconcat_step1, JoinRawCalls.CreatePloidyTableFromPed.script, JoinRawCalls.ConcatInputVcfs.naive, JoinRawCalls.SVCluster.pesr_breakend_window, JoinRawCalls.clustered_melt_vcf_indexes, JoinRawCalls.FormatVcfForGatk.svtk_to_gatk_script, JoinRawCalls.SVCluster.omit_members, JoinRawCalls.SVCluster.pesr_size_similarity, JoinRawCalls.sv_pipeline_docker, JoinRawCalls.clustered_depth_vcfs, JoinRawCalls.SVCluster.defrag_sample_overlap, JoinRawCalls.runtime_override_concat_input_vcfs, JoinRawCalls.FormatVcfForGatk.runtime_override_fix_header_step1, JoinRawCalls.FormatVcfForGatk.contigs_header]
```