### PR TITLE
Get N even intervals for JointGenotyping from a Cohort MT

### DIFF
--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -176,6 +176,7 @@ def write_intervals_file(intervals: list[hl.expr.IntervalExpression], output_pat
     with open(output_path, 'w') as f:
         for interval in result:
             f.write(f'{interval["start"]}\t{interval["end"]}\n')
+            print(f'{interval["start"]}\t{interval["end"]}')
 
     print(f'{len(result)} intervals written to {output_path}')
 

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -1,51 +1,165 @@
 """
 Read a matrixtable and split it into even intervals of rows.
-Use the contigs at the start of each interval to define the 
+Use the contigs at the start of each interval to define the
 intervals saved in the output interval_list file.
 
 Hard breaks at centromeres.
 """
 
-import hail as hl
 import argparse
+import json
+
+import hail as hl
+
+from cpg_utils import to_path
+from cpg_utils.config import dataset_path, reference_path
+
+CHROMS = [f'chr{i}' for i in range(1, 23)] + ['chrX', 'chrY']
 
 
-def get_intervals_for_chr()
+def get_intervals_for_chr(
+    mt: hl.MatrixTable,
+    interval_size: int,
+    telomere_positions: dict[str, tuple[int, int]],
+    centromere_position: tuple[int, int],
+) -> list[hl.MatrixTable]:
+    """
+    Evenly split the matrixtable into intervals for variants in a single chromosome.
+    Hard breaks at telomeres and centromeres.
+    """
 
-def get_even_intervals_from_mt(mt: hl.MatrixTable, n_intervals: int, interval_list_file):
+    # The first valid region for genotyping begins after the first telomere and ends before the centromere
+    genotyping_region_1_start = telomere_positions['first'][1] + 1
+    genotyping_region_1_end = centromere_position[0] - 1
+    mt_region_1 = mt.filter_rows(
+        (mt.locus.position >= genotyping_region_1_start) & (mt.locus.position < genotyping_region_1_end),
+    )
+    mt_region_1 = mt_region_1.add_row_index(name='row_idx')
+    mt_region_1 = mt_region_1.rows().select('row_idx', 'locus')
+
+    # The second valid region for genotyping starts after the centromere and ends before the second telomere
+    genotyping_region_2_start = centromere_position[1] + 1
+    genotyping_region_2_end = telomere_positions['second'][0] - 1
+    mt_region_2 = mt.filter_rows(
+        (mt.locus.position >= genotyping_region_2_start) & (mt.locus.position < genotyping_region_2_end),
+    )
+    mt_region_2 = mt_region_2.add_row_index(name='row_idx')
+    mt_region_2 = mt_region_2.rows().select('row_idx', 'locus')
+
+    # Iterate through the first genotyping region mt in intervals of interval_size, using the row_idx
+    intervals = []
+    for mt_region in [mt_region_1, mt_region_2]:
+        for i in range(0, mt_region.count_rows(), interval_size):
+            # Get the interval
+            interval = mt_region.filter_rows((mt_region.row_idx >= i) & (mt_region.row_idx < i + interval_size))
+
+            # Add the interval to the intervals list
+            intervals.append(interval)
+
+    return intervals
+
+
+def get_even_intervals_from_mt(mt: hl.MatrixTable, n_intervals: int, output_intervals_path: str):
     """
     Get even intervals from a matrixtable.
     """
-    # Get the number of rows in the matrixtable        
+    # Get the number of rows in the matrixtable
     n_rows = mt.count_rows()
 
     # Get the number of rows in each interval
     interval_size = n_rows // n_intervals
 
-    for chrom in ['chr1',]:
-        get_intervals_for_chr(mt, chrom, n_intervals, interval_size, centromere_position, interval_list_file)
+    # Get the centromere positions
+    telomere_positions, centromere_positions = get_telomere_and_centromere_start_end_positions()
 
-    # Add the integer index of each row as a new row field.
-    mt = mt.add_row_index(name='row_idx')
-    mt = mt.rows().select('row_idx', 'locus')
-
-    # Iterate through the mt in intervals of interval_size, using the row_idx
-    intervals = []
-    for n in range(n_intervals):
-        # Get the start and end of the interval
-        start = n * interval_size
-        # stop = (n + 1) * interval_size - 1
-
-        intervals.append(
-            mt.filter_rows(mt.row_idx == start)['locus'],
+    intervals = {}
+    for chrom in CHROMS:
+        chrom_intervals = get_intervals_for_chr(
+            mt=mt.filter_rows(mt.locus.contig == chrom),
+            interval_size=interval_size,
+            telomere_positions=telomere_positions[chrom],
+            centromere_position=centromere_positions[chrom],
         )
+        intervals[chrom] = chrom_intervals
 
-    # Evaluate the contig and position of each interval 
-    intervals = [interval.collect()[0] for interval in intervals]
+    # Evaluate the intervals
+    interval_positions_by_chrom = write_intervals_json(intervals, output_intervals_path)
 
-    # Save the intervals to a file
-    # with open(interval_list_file, 'w') as f:
-    #     for interval in intervals:
-    #         f.write(f"{interval.contig}\t{interval.position}\n")
+    return interval_positions_by_chrom
 
-    return intervals
+
+def write_intervals_json(intervals: dict[str, list[hl.MatrixTable]], output_path: str):
+    """
+    Evaluate the list of MatrixTable intervals and save them to a json.
+    """
+    interval_positions: dict[str, list[tuple[int, int]]] = {}
+    for chrom, chrom_intervals in intervals.items():
+        interval_positions[chrom] = []
+        for i, interval in enumerate(chrom_intervals):
+            print(f'Chrom {chrom}, interval {i}: {interval.count_rows()} rows')
+            # Get the start and end position of the interval
+            positions = interval.locus.position.collect()
+            start_pos = positions[0]
+            end_pos = positions[-1]
+            print(f'Interval start: {start_pos}, end: {end_pos}')
+            interval_positions[chrom].append((start_pos, end_pos))
+
+    # Save the interval positions to a file
+    with open(output_path, 'w') as f:
+        json.dump(interval_positions, f)
+
+    print(f'Intervals saved to {output_path}')
+    return interval_positions
+
+
+def get_telomere_and_centromere_start_end_positions() -> (
+    tuple[dict[str, dict[str, tuple[int, int]]], dict[str, tuple[int, int]]]
+):
+    """
+    Get the start and end positions of the telomeres and centromeres in the human genome.
+    """
+    tc_intervals_path = to_path(reference_path('hg38_telomeres_and_centromeres_intervals/interval_list'))
+
+    with open(tc_intervals_path) as f:
+        # Read the intervals from the source file, skip lines starting with '@'
+        tc_intervals = [line.strip().split() for line in f if not line.startswith('@')]
+
+    # Collect the start and end positions of the centromeres and telomeres by chromosome
+    centromeres_by_chrom = {}
+    telomeres_by_chrom: dict[str, dict[str, tuple[int, int]]] = {}
+    for chrom, start, end, _, region in tc_intervals:
+        if 'centromere' in region:
+            centromeres_by_chrom[chrom] = (int(start), int(end))
+        if 'telomere' in region:
+            telomeres_by_chrom[chrom] = {}
+            if start == '1':
+                # If the start position is '1', the telomere is at the start of the chromosome
+                telomeres_by_chrom[chrom].update({'first': (int(start), int(end))})
+            else:
+                # If the start position is not '1', the telomere is at the end of the chromosome
+                telomeres_by_chrom[chrom].update({'second': (int(start), int(end))})
+
+    return telomeres_by_chrom, centromeres_by_chrom
+
+
+def main(args):
+    """
+    Run the script.
+    """
+    output_intervals_path = dataset_path('derived_intervals/hg38_even_intervals.json')
+    hl.init(default_reference='GRCh38')
+    mt = hl.read_matrix_table(args.input_mt)
+    get_even_intervals_from_mt(mt, args.n_intervals, output_intervals_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input-mt', help='Input matrixtable', required=True)
+    parser.add_argument(
+        '--n-intervals',
+        help='Number of intervals to split the matrixtable into',
+        type=int,
+        required=True,
+    )
+    args = parser.parse_args()
+    main(args)

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -36,7 +36,7 @@ def get_intervals_for_chr(
         (mt.locus.position >= genotyping_region_1_start) & (mt.locus.position < genotyping_region_1_end),
     )
     mt_region_1 = mt_region_1.add_row_index(name='row_idx')
-    mt_region_1 = mt_region_1.rows().select('row_idx', 'locus')
+    mt_region_1 = mt_region_1.select_rows(mt_region_1.row_idx, mt_region_1.locus)
 
     # The second valid region for genotyping starts after the centromere and ends before the second telomere
     genotyping_region_2_start = centromere_position[1] + 1
@@ -45,7 +45,7 @@ def get_intervals_for_chr(
         (mt.locus.position >= genotyping_region_2_start) & (mt.locus.position < genotyping_region_2_end),
     )
     mt_region_2 = mt_region_2.add_row_index(name='row_idx')
-    mt_region_2 = mt_region_2.rows().select('row_idx', 'locus')
+    mt_region_2 = mt_region_2.select_rows(mt_region_2.row_idx, mt_region_2.locus)
 
     # Iterate through the first genotyping region mt in intervals of interval_size, using the row_idx
     intervals = []

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -36,7 +36,7 @@ def get_intervals_for_chr(
         (mt.locus.position >= genotyping_region_1_start) & (mt.locus.position < genotyping_region_1_end),
     )
     mt_region_1 = mt_region_1.add_row_index(name='row_idx')
-    mt_region_1 = mt_region_1.select_rows(mt_region_1.row_idx, mt_region_1.locus)
+    mt_region_1 = mt_region_1.select_rows(mt_region_1.row_idx)
 
     # The second valid region for genotyping starts after the centromere and ends before the second telomere
     genotyping_region_2_start = centromere_position[1] + 1
@@ -45,7 +45,7 @@ def get_intervals_for_chr(
         (mt.locus.position >= genotyping_region_2_start) & (mt.locus.position < genotyping_region_2_end),
     )
     mt_region_2 = mt_region_2.add_row_index(name='row_idx')
-    mt_region_2 = mt_region_2.select_rows(mt_region_2.row_idx, mt_region_2.locus)
+    mt_region_2 = mt_region_2.select_rows(mt_region_2.row_idx)
 
     # Iterate through the first genotyping region mt in intervals of interval_size, using the row_idx
     intervals = []

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -124,8 +124,12 @@ def get_telomere_and_centromere_start_end_positions(
     """
     Get the start and end positions of the telomeres and centromeres in the human genome.
     """
-    tc_intervals_path = to_path(tc_intervals_filepath) or to_path(
-        reference_path('hg38_telomeres_and_centromeres_intervals/interval_list'),
+    tc_intervals_path = (
+        to_path(tc_intervals_filepath)
+        if tc_intervals_filepath
+        else to_path(
+            reference_path('hg38_telomeres_and_centromeres_intervals/interval_list'),
+        )
     )
 
     with open(tc_intervals_path) as f:

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -122,7 +122,7 @@ def get_intervals_from_ht(
         pos=intervals_ht.locus.position,
         idx=intervals_ht.global_row_idx,
     )
-    result = ht.aggregate(hl.agg.collect(struct))
+    result = intervals_ht.aggregate(hl.agg.collect(struct))
     chroms = [r.chrom for r in result]
     positions = [r.pos for r in result]
     idx = [r.idx for r in result]

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -130,7 +130,7 @@ def get_intervals_from_ht(
     # Create a dictionary of the interval positions by chromosome
     interval_starts_by_chrom = {}
     interval_ends_by_chrom = {}
-    for counter, chr, pos, i in enumerate(zip(chroms, positions, idx)):
+    for counter, (chr, pos, i) in enumerate(zip(chroms, positions, idx)):
         if chr not in interval_starts_by_chrom:
             interval_starts_by_chrom[chr] = []
             interval_ends_by_chrom[chr] = []

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -144,7 +144,7 @@ def get_intervals_for_chr(
     return intervals
 
 
-def extract_interval_positions(ht: hl.Table, n_intervals: int) -> Generator[IntervalInfo]:
+def extract_interval_positions(ht: hl.Table, n_intervals: int) -> Generator[IntervalInfo, None, None]:
    # Get the number of rows in the table
     n_rows = ht.count()
 

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -1,0 +1,37 @@
+"""
+Read a matrixtable and split it into even intervals of rows.
+Use the contigs at the start of each interval to define the 
+intervals saved in the output interval_list file.
+
+Hard breaks at centromeres.
+"""
+
+import hail as hl
+import argparse
+
+
+def get_even_intervals_from_mt(mt, n_intervals, interval_list_file):
+    """
+    Get even intervals from a matrixtable.
+    """
+    # Get the number of rows in the matrixtable
+    n_rows = mt.count_rows()
+
+    # Get the number of rows in each interval
+    interval_size = n_rows // n_intervals
+
+    # Get the contig and position of the start of each interval
+    intervals = []
+    for i in range(n_intervals):
+        if i == 0:
+            start_locus = mt.locus.collect()[0]
+        else:
+            start_locus = mt.rows().filter(mt.locus.position == 1).collect()[i * interval_size]
+        intervals.append(start_locus)
+
+    # Save the intervals to a file
+    with open(interval_list_file, 'w') as f:
+        for interval in intervals:
+            f.write(f"{interval.contig}\t{interval.position}\n")
+
+    return intervals

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -91,9 +91,11 @@ def get_intervals_from_ht(
     """
     # Get the number of rows in the table
     n_rows = ht.count()
+    logging.info(f'Number of rows in the table: {n_rows}')
 
     # Get the number of rows in each interval
     interval_size = n_rows // n_intervals
+    logging.info(f'Interval size: {interval_size}')
 
     # Get the telomere and centromere positions
     telomere_positions, centromere_positions = get_telomere_and_centromere_start_end_positions(tc_intervals_filepath)
@@ -115,11 +117,15 @@ def get_intervals_from_ht(
     intervals_ht = hl.Table.union(*intervals)
 
     # Collect the positions of the intervals
-    chroms, positions, idx = intervals_ht.aggregate(
-        chroms=hl.agg.collect(intervals_ht.locus.contig),
-        positions=hl.agg.collect(intervals_ht.locus.position),
-        idx=hl.agg.collect(intervals_ht.global_row_idx),
+    struct = hl.struct(
+        chrom=intervals_ht.locus.contig,
+        pos=intervals_ht.locus.position,
+        idx=intervals_ht.global_row_idx,
     )
+    result = ht.aggregate(hl.agg.collect(struct))
+    chroms = [r.chrom for r in result]
+    positions = [r.pos for r in result]
+    idx = [r.idx for r in result]
 
     # Create a dictionary of the interval positions by chromosome
     interval_starts_by_chrom = {}

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -244,7 +244,7 @@ def main(args):
     ht = ht.select().select_globals()
     ht = ht.add_index(name='global_row_idx')
     ht = ht.key_by('locus', 'alleles', 'global_row_idx')
-    with open(args.output_intervals_path, 'w') as f:
+    with to_path(args.output_intervals_path).open('w') as f:
         for interval in extract_interval_positions(ht, n_intervals=args.n_intervals):
             print(f"Interval: {interval.start_idx}-{interval.end_idx}, "
             f"Positions: {interval.start_pos}-{interval.end_pos}, "

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -16,7 +16,6 @@ from cpg_utils import to_path
 from cpg_utils.config import dataset_path, reference_path
 from cpg_utils.hail_batch import init_batch
 
-
 CHROMS = [f'chr{i}' for i in range(1, 23)] + ['chrX', 'chrY']
 
 # Set up logging

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -157,7 +157,7 @@ def get_intervals_from_ht(
 
     # Stack the hail Table intervals into a single Table
     intervals_ht = hl.Table.union(*intervals)
-    intervals_by_chrom = get_intervals_from_intervals_ht(intervals_ht, n_intervals, output_intervals_path)
+    intervals_by_chrom = get_intervals_from_intervals_ht(intervals_ht)
 
     with to_path(output_intervals_path).open('w') as f:
         json.dump(intervals_by_chrom, f)

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -222,7 +222,7 @@ def main(args):
     """
     Run the script.
     """
-    init_batch()
+    init_batch(driver_memory='16G')
     mt = hl.read_matrix_table(args.input_mt)
     logging.info('Read matrixtable')
     ht = mt.rows()

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -162,11 +162,11 @@ def extract_interval_positions(ht: hl.Table, n_intervals: int) -> List[IntervalI
 
     # Join the interval table with our original table
     joined = interval_table.key_by(
-        hl.struct(global_row_idx = hl.if_else(
+        global_row_idx = hl.if_else(
             interval_table.interval_idx == n_intervals - 1,
             interval_table.end_idx,
             interval_table.start_idx,
-        )),
+        ),
     ).join(ht.key_by('global_row_idx'))
 
     # Aggregate to get start and end information for each interval

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -162,11 +162,11 @@ def extract_interval_positions(ht: hl.Table, n_intervals: int) -> List[IntervalI
 
     # Join the interval table with our original table
     joined = interval_table.key_by(
-        global_row_idx = hl.if_else(
+        global_row_idx = hl.int64(hl.if_else(
             interval_table.interval_idx == n_intervals - 1,
             interval_table.end_idx,
             interval_table.start_idx,
-        ),
+        )),
     ).join(ht.key_by('global_row_idx'))
 
     # Aggregate to get start and end information for each interval

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -136,10 +136,11 @@ def get_telomere_and_centromere_start_end_positions(
     centromeres_by_chrom = {}
     telomeres_by_chrom: dict[str, dict[str, tuple[int, int]]] = {}
     for chrom, start, end, _, region in tc_intervals:
+        if chrom not in telomeres_by_chrom:
+            telomeres_by_chrom[chrom] = {}
         if 'centromere' in region:
             centromeres_by_chrom[chrom] = (int(start), int(end))
         if 'telomere' in region:
-            telomeres_by_chrom[chrom] = {}
             if start == '1':
                 # If the start position is '1', the telomere is at the start of the chromosome
                 telomeres_by_chrom[chrom].update({'first': (int(start), int(end))})

--- a/scripts/get_even_intervals_from_mt.py
+++ b/scripts/get_even_intervals_from_mt.py
@@ -10,28 +10,42 @@ import hail as hl
 import argparse
 
 
-def get_even_intervals_from_mt(mt, n_intervals, interval_list_file):
+def get_intervals_for_chr()
+
+def get_even_intervals_from_mt(mt: hl.MatrixTable, n_intervals: int, interval_list_file):
     """
     Get even intervals from a matrixtable.
     """
-    # Get the number of rows in the matrixtable
+    # Get the number of rows in the matrixtable        
     n_rows = mt.count_rows()
 
     # Get the number of rows in each interval
     interval_size = n_rows // n_intervals
 
-    # Get the contig and position of the start of each interval
+    for chrom in ['chr1',]:
+        get_intervals_for_chr(mt, chrom, n_intervals, interval_size, centromere_position, interval_list_file)
+
+    # Add the integer index of each row as a new row field.
+    mt = mt.add_row_index(name='row_idx')
+    mt = mt.rows().select('row_idx', 'locus')
+
+    # Iterate through the mt in intervals of interval_size, using the row_idx
     intervals = []
-    for i in range(n_intervals):
-        if i == 0:
-            start_locus = mt.locus.collect()[0]
-        else:
-            start_locus = mt.rows().filter(mt.locus.position == 1).collect()[i * interval_size]
-        intervals.append(start_locus)
+    for n in range(n_intervals):
+        # Get the start and end of the interval
+        start = n * interval_size
+        # stop = (n + 1) * interval_size - 1
+
+        intervals.append(
+            mt.filter_rows(mt.row_idx == start)['locus'],
+        )
+
+    # Evaluate the contig and position of each interval 
+    intervals = [interval.collect()[0] for interval in intervals]
 
     # Save the intervals to a file
-    with open(interval_list_file, 'w') as f:
-        for interval in intervals:
-            f.write(f"{interval.contig}\t{interval.position}\n")
+    # with open(interval_list_file, 'w') as f:
+    #     for interval in intervals:
+    #         f.write(f"{interval.contig}\t{interval.position}\n")
 
     return intervals


### PR DESCRIPTION
This script takes a cohort mt and a desired number of intervals `N`, and obtains approximately N equally sized regions of the genome, based on the number of rows of the cohort mt. 

First we take the number of rows of the cohort mt and divide that by `N` to get the desired size of our intervals, this value is the `interval_size`.

Then, we subset the cohort mt by chromosome, creating a matrix table for each chromosome. Each chromosome mt is then split into two matrix tables, one before and one after the centromere. From here, we iterate through the rows of the matrix table in steps of size `interval_size`. The start and end position can be collected from these row indexes through the `mt.locus.position` field. These derived intervals can be read by the JointGenotyping jobs in future runs.