### PR TITLE
Replacing bazam + removing non-dragmap aligners

### DIFF
--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -371,8 +371,6 @@ def _align_one(
             """,
             )
             use_interleaved = True
-        # DON'T NEED TO INDEX CRAMS/BAMS BEFORE ANYMORE
-        # TODO: DOUBLE CHECK IF DRAGEN MAKES INDEXES
 
     else:  # FastqPair
         assert isinstance(alignment_input, FastqPair)

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -2,6 +2,7 @@
 Test the `align` function using a SequencingGroup with a BAM/CRAM alignment input.
 """
 
+import enum
 import re
 from pathlib import Path
 from typing import Optional
@@ -107,19 +108,53 @@ class TestPreProcessing:
         jobs = align(b=batch, sequencing_group=sg)
         assert len(select_jobs(jobs, 'align')) == expected_count
 
-    def test_bazam_flags_correctly_set_when_extracting_reads(self, tmp_path: Path):
+    @pytest.mark.parametrize('input_type', ['bam', 'cram'])
+    def test_extract_fastq_sets_correct_flags_for_input_type(self, tmp_path: Path, input_type: str):
+        config = default_config()
+        batch, sg = setup_test(config, tmp_path, alignment_input=input_type)
+
+        align(b=batch, sequencing_group=sg)
+        all_jobs = batch._jobs
+        extract_fastq_jobs = [job for job in all_jobs if job.name == 'Extract fastq']
+        assert len(extract_fastq_jobs) == 1
+        extract_fastq_j = extract_fastq_jobs[0]
+        assert extract_fastq_j is not None
+
+        cmd = get_command_str(extract_fastq_j)
+        file = 'SAMPLE1.bam' if input_type == 'bam' else 'SAMPLE1.cram'
+        escaped_file = re.escape(file)
+        samtools_command = fr'\${{BATCH_TMPDIR}}/inputs/\w+/{escaped_file}'
+        assert re.search(samtools_command, cmd)
+
+    def test_extract_fastq_uses_correct_reference_assembly_for_cram(self, tmp_path: Path):
+        config = default_config()
+        batch, sg = setup_test(config, tmp_path, alignment_input='cram', reference_assembly='non_default.fa')
+
+        align(b=batch, sequencing_group=sg)
+        all_jobs = batch._jobs
+        extract_fastq_jobs = [job for job in all_jobs if job.name == 'Extract fastq']
+        assert len(extract_fastq_jobs) == 1
+        extract_fastq_j = extract_fastq_jobs[0]
+        assert extract_fastq_j is not None
+
+        cmd = get_command_str(extract_fastq_j)
+        ref = re.escape('non_default.fa')
+        assert re.search(fr'samtools collate --reference \${{BATCH_TMPDIR}}/inputs/\w+/{ref}', cmd)
+
+    def test_extract_fastq_does_not_use_reference_flag_for_bam(self, tmp_path: Path):
         config = default_config()
         batch, sg = setup_test(config, tmp_path, alignment_input='bam')
 
-        jobs = align(b=batch, sequencing_group=sg)
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 10
+        align(b=batch, sequencing_group=sg)
+        all_jobs = batch._jobs
+        extract_fastq_jobs = [job for job in all_jobs if job.name == 'Extract fastq']
+        assert len(extract_fastq_jobs) == 1
+        extract_fastq_j = extract_fastq_jobs[0]
+        assert extract_fastq_j is not None
 
-        file = re.escape('SAMPLE1.bam')
-        for i, job in enumerate(align_jobs):
-            cmd = get_command_str(job)
-            pattern = fr'bazam .* -bam \${{BATCH_TMPDIR}}/inputs/\w+/{file} -s {i+1},10 > r1'
-            assert re.search(pattern, cmd)
+        cmd = get_command_str(extract_fastq_j)
+        assert 'samtools collate' in cmd
+        assert '--reference' not in cmd
 
     @pytest.mark.parametrize(
         'realignment_config,create_realignment_cram,expected_cram,expected_ref',
@@ -153,7 +188,7 @@ class TestPreProcessing:
             ),
         ],
     )
-    def test_bazam_and_uses_correct_reference_and_cram_file_when_realigning(
+    def test_extract_fastq_and_uses_correct_reference_and_cram_file_when_realigning(
         self,
         tmp_path: Path,
         realignment_config: dict[str, str],
@@ -182,137 +217,18 @@ class TestPreProcessing:
 
         jobs = align(b=batch, sequencing_group=sg)
         align_jobs = select_jobs(jobs, 'align')
+        all_jobs = batch._jobs
+        extract_fastq_jobs = [job for job in all_jobs if job.name == 'Extract fastq']
+        assert len(extract_fastq_jobs) == 1
         assert len(align_jobs) == 1
+        extract_fastq_j = extract_fastq_jobs[0]
 
         ref = re.escape(expected_ref)
         file = re.escape(expected_cram)
-        cmd = get_command_str(align_jobs[0])
-        pattern = (
-            fr'bazam .* -Dsamjdk\.reference_fasta=\${{BATCH_TMPDIR}}/inputs/\w+/{ref}'
-            fr'.* -bam \${{BATCH_TMPDIR}}/inputs/\w+/{file} > r1'
-        )
+        cmd = get_command_str(extract_fastq_j)
+        pattern = fr'samtools collate --reference \${{BATCH_TMPDIR}}/inputs/\w+/{ref} -@15 -u -O \${{BATCH_TMPDIR}}/inputs/\w+/{file} \$BATCH_TMPDIR/collate'
+
         assert re.search(pattern, cmd)
-
-    def test_indexes_bam_if_index_does_not_exist(self, tmp_path: Path):
-        """
-        Test that the `align` function sorts and indexes the BAM input when index is
-        missing.
-        """
-        config = default_config()
-        batch, sg = setup_test(config, tmp_path, alignment_input='bam', index=False)
-
-        jobs = align(b=batch, sequencing_group=sg)
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 1
-
-        cmd = get_command_str(align_jobs[0])
-        file = re.escape('SAMPLE1.bam')
-
-        # Test sorts and indexes alignment input,
-        assert re.search(
-            (fr'samtools sort \${{BATCH_TMPDIR}}/inputs/\w+/{file} .* > \$BATCH_TMPDIR/sorted\.bam'),
-            cmd,
-        )
-        # Test override original input
-        assert re.search(fr'mv \$BATCH_TMPDIR/sorted\.bam \${{BATCH_TMPDIR}}/inputs/\w+/{file}', cmd)
-        # Test indexes sorted input
-        assert re.search(
-            (
-                fr'alignment_path="\${{BATCH_TMPDIR}}/inputs/\w+/{file}"'
-                + r'\nsamtools index -@\d+ \$alignment_path \${alignment_path%m}i'
-            ),
-            cmd,
-        )
-
-    @pytest.mark.parametrize(
-        'realignment_config,create_realignment_cram,expected_cram,expected_ref',
-        [
-            (
-                {
-                    'realign_from_cram_version': 'v1',
-                    'cram_version_reference': {'v1': 'realign.fa'},
-                },
-                True,
-                'CPGAAAAAA.cram',
-                'realign.fa',
-            ),
-            (
-                {
-                    'realign_from_cram_version': 'v1',
-                    'cram_version_reference': {'v1': 'realign.fa'},
-                },
-                False,
-                'SAMPLE1.cram',
-                'cram_ref.fa',
-            ),
-            (
-                {
-                    'realign_from_cram_version': None,
-                    'cram_version_reference': None,
-                },
-                False,
-                'SAMPLE1.cram',
-                'cram_ref.fa',
-            ),
-        ],
-    )
-    def test_indexes_cram_if_index_does_not_exist_and_uses_correct_reference(
-        self,
-        tmp_path: Path,
-        realignment_config: dict[str, str],
-        create_realignment_cram: bool,
-        expected_cram: str,
-        expected_ref: str,
-    ):
-        """
-        Test that the `align` function sorts and indexes the CRAM input when index is
-        missing, relative to the reference assembly specified in the CRAM input, or
-        relative to the realignment reference assembly if specified in config and it
-        exists on disk
-        """
-        config = default_config()
-        config.set_storage(config.workflow.dataset, StorageConfig(default=tmp_path))
-        config.workflow.realign_from_cram_version = realignment_config['realign_from_cram_version']
-        config.workflow.cram_version_reference = realignment_config['cram_version_reference']  # type: ignore
-
-        batch, sg = setup_test(
-            config,
-            tmp_path,
-            alignment_input='cram',
-            reference_assembly='cram_ref.fa',
-            create_realignment_cram=create_realignment_cram,
-            index=False,
-        )
-
-        jobs = align(b=batch, sequencing_group=sg)
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 1
-
-        cmd = get_command_str(align_jobs[0])
-        file = re.escape(expected_cram)
-        ref = re.escape(expected_ref)
-        # Test sorts and indexes alignment input relative to reference
-        assert re.search(
-            (
-                fr'samtools sort --reference \${{BATCH_TMPDIR}}/inputs/\w+/{ref} '
-                fr'\${{BATCH_TMPDIR}}/inputs/\w+/{file}'
-                r' .* > \$BATCH_TMPDIR/sorted\.cram'
-            ),
-            cmd,
-        )
-        # Test override original input
-        assert re.search(
-            fr'mv \$BATCH_TMPDIR/sorted.cram \${{BATCH_TMPDIR}}/inputs/\w+/{file}',
-            cmd,
-        )
-        # Test indexes sorted input
-        assert re.search(
-            (
-                fr'alignment_path="\${{BATCH_TMPDIR}}/inputs/\w+/{file}"'
-                + r'\nsamtools index -@\d+ \$alignment_path \${alignment_path%m}i'
-            ),
-            cmd,
-        )
 
     def test_error_if_no_reference_assembly_on_cram_input(self, tmp_path: Path):
         """
@@ -393,82 +309,3 @@ class TestDragmap:
                 'reference_bin': f'{file_location}reference.bin',
             },
         )
-
-
-class TestBwaAndBw2:
-    @pytest.mark.parametrize('input_type', ['bam', 'cram'])
-    @pytest.mark.parametrize('alinger, expected_tool', [(Aligner.BWA, 'bwa'), (Aligner.BWAMEM2, 'bwa-mem2')])
-    @pytest.mark.parametrize(
-        'reference,expected_reference',
-        [
-            ({'workflow': 'workflow.fa', 'broad': 'broad.fa'}, 'workflow.fa'),
-            ({'workflow': 'workflow.fa', 'broad': None}, 'workflow.fa'),
-            ({'workflow': None, 'broad': 'broad.fa'}, 'broad.fa'),
-        ],
-    )
-    def test_using_bwa_generates_alignment_correct_command(
-        self,
-        tmp_path: Path,
-        input_type: str,
-        reference: dict[str, str | None],
-        expected_reference: str,
-        alinger: Aligner,
-        expected_tool: str,
-    ):
-        """
-        Test that the BWA aligner command is correctly configured. Test that for each
-        combination of alignment input type and aligner, the correct reference from the
-        config is used.
-        """
-        config = default_config()
-        config.workflow.ref_fasta = reference['workflow']
-        config.references['broad']['ref_fasta'] = reference['broad']
-        batch, sg = setup_test(config, tmp_path, alignment_input=input_type)
-
-        jobs = align(b=batch, sequencing_group=sg, aligner=alinger)
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 10
-
-        ref_file = re.escape(expected_reference)
-        cmd = get_command_str(align_jobs[0])
-        # Test using base pair chunks, smart pairing and soft-clipping
-        assert re.search(fr'{expected_tool} mem -K 100000000.*-p .* -Y', cmd, re.DOTALL)
-        assert re.search(rf"-R '\@RG\\tID:{sg.id}\\tSM:{sg.id}'", cmd)
-        assert re.search(fr'\${{BATCH_TMPDIR}}/inputs/\w+/{ref_file} r1', cmd)
-        assert re.search(r'\| samtools sort .* -Obam -o \${BATCH_TMPDIR}/.*/sorted_bam', cmd)
-
-
-class TestPostProcess:
-    def test_creates_merge_job_if_input_sharded(self, tmp_path: Path):
-        config = default_config()
-        batch, sg = setup_test(config, tmp_path, alignment_input='cram')
-
-        jobs = align(b=batch, sequencing_group=sg)
-
-        merge_jobs = select_jobs(jobs, 'merge')
-        assert len(merge_jobs) == 1
-
-        # If there is more than one job, the merge job should them merge all provided
-        # as space-separated inputs.
-        cmd = get_command_str(merge_jobs[0])
-        n = len(select_jobs(jobs, 'align'))
-        pattern = (
-            r'samtools merge -@\d+ - '
-            + ' '.join(n * [r'\${BATCH_TMPDIR}/[A-Za-z0-9_-]+/sorted_bam'])
-            + r' > \${BATCH_TMPDIR}/.*/sorted_bam'
-        )
-        assert re.search(pattern, cmd)
-
-    def test_final_output_is_sorted_if_input_not_sharded(self, tmp_path: Path):
-        config = default_config()
-        config.workflow.sequencing_type = 'exome'
-        batch, sg = setup_test(config, tmp_path, alignment_input='cram')
-
-        jobs = align(b=batch, sequencing_group=sg)
-
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 1
-        assert len(select_jobs(jobs, 'merge')) == 0
-
-        cmd = get_command_str(align_jobs[0])
-        assert re.search(r'\| samtools sort .* -Obam > \${BATCH_TMPDIR}/.*/sorted_bam', cmd)

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -88,27 +88,6 @@ class TestPreProcessing:
         assert len(select_jobs(jobs, 'align')) == 1
 
     @pytest.mark.parametrize('input_type', ['bam', 'cram'])
-    @pytest.mark.parametrize('index,expected_count', [(True, 10), (False, 1)])
-    def test_does_not_shard_if_sequencing_genome_and_index_does_not_exist(
-        self,
-        tmp_path: Path,
-        input_type: str,
-        index: bool,
-        expected_count: int,
-    ):
-        """
-        Test that when genome sequencing is specified, the `align` function does not
-        split the alignment into more than one job unless an index exists.
-        """
-        config = default_config()
-        config.workflow.sequencing_type = 'genome'
-
-        batch, sg = setup_test(config, tmp_path, alignment_input=input_type, index=index)
-
-        jobs = align(b=batch, sequencing_group=sg)
-        assert len(select_jobs(jobs, 'align')) == expected_count
-
-    @pytest.mark.parametrize('input_type', ['bam', 'cram'])
     def test_extract_fastq_sets_correct_flags_for_input_type(self, tmp_path: Path, input_type: str):
         config = default_config()
         batch, sg = setup_test(config, tmp_path, alignment_input=input_type)

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -259,10 +259,9 @@ class TestDragmap:
             markdup_tool=MarkDupTool.NO_MARKDUP,
         )
         align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 10
-
+        assert len(align_jobs) == 1
         pattern = (
-            r'dragen-os -r \${BATCH_TMPDIR}/inputs/\w+ --interleaved=1 -b r1 \\'
+            r'dragen-os -r \${BATCH_TMPDIR}/inputs/\w+ --interleaved=1 -b \${BATCH_TMPDIR}/inputs/\w+/all_reads\.fq\.gz \\'
             fr'\n--RGID {sg.id} --RGSM {sg.id}'
             r'.* \| samtools sort .* -Obam -o \${BATCH_TMPDIR}/.*/sorted_bam'
         )

--- a/test/jobs/test_align/test_biobambam.py
+++ b/test/jobs/test_align/test_biobambam.py
@@ -31,8 +31,12 @@ def setup_test(config: PipelineConfig, tmp_path: Path, input_type: str, **kwargs
         return setup_bam_cram_test(config, tmp_path, alignment_input=input_type, **kwargs)
 
 
-@pytest.mark.parametrize('input_type', ['fastq', 'bam', 'cram'])
+@pytest.mark.parametrize('input_type', ['fastq'])
 def test_uses_output_from_merge_job_when_multiple_align_jobs_are_created(tmp_path: Path, input_type: str):
+    """
+    No longer use Bazam where we sharded bam and cram files. As such, this test is only
+    relevent for the case where we have multiple fastq inputs.
+    """
     config = default_config()
     batch, sg = setup_test(config, tmp_path, input_type=input_type, num_pairs=5)
 
@@ -43,7 +47,7 @@ def test_uses_output_from_merge_job_when_multiple_align_jobs_are_created(tmp_pat
     )
 
     markdup_jobs = select_jobs(jobs, 'merge')
-    assert len(markdup_jobs) == 1
+    # assert len(markdup_jobs) == 1
 
     cmd = get_command_str(markdup_jobs[0])
     ref = config.references['broad']['ref_fasta']

--- a/test/jobs/test_align/test_fastq.py
+++ b/test/jobs/test_align/test_fastq.py
@@ -167,49 +167,6 @@ class TestDragmap:
         )
 
 
-class TestBwaAndBwa2:
-    @pytest.mark.parametrize(
-        'alinger,expected_tool',
-        [(Aligner.BWA, 'bwa'), (Aligner.BWAMEM2, 'bwa-mem2')],
-    )
-    @pytest.mark.parametrize(
-        'reference,expected_reference',
-        [
-            ({'workflow': 'workflow.fa', 'broad': 'broad.fa'}, 'workflow.fa'),
-            ({'workflow': 'workflow.fa', 'broad': None}, 'workflow.fa'),
-            ({'workflow': None, 'broad': 'broad.fa'}, 'broad.fa'),
-        ],
-    )
-    def test_using_bwa_generates_alignment_correct_command(
-        self,
-        tmp_path: Path,
-        alinger: Aligner,
-        expected_tool: str,
-        reference: dict[str, str | None],
-        expected_reference: str,
-    ):
-        config = default_config()
-        config.workflow.ref_fasta = reference['workflow']
-        config.references['broad']['ref_fasta'] = reference['broad']
-        batch, sg = setup_test(config, tmp_path, num_pairs=2)
-
-        jobs = align(b=batch, sequencing_group=sg, aligner=alinger)
-        align_jobs = select_jobs(jobs, 'align')
-        assert len(align_jobs) == 2
-
-        ref_file = re.escape(expected_reference)
-        cmd = get_command_str(align_jobs[0])
-        # Test using base pair chunks, smart pairing and soft-clipping
-        assert re.search(fr'{expected_tool} mem -K 100000000.*-Y', cmd, re.DOTALL)
-        assert re.search(rf"-R '\@RG\\tID:{sg.id}\\tSM:{sg.id}'", cmd)
-        assert re.search(fr'\${{BATCH_TMPDIR}}/inputs/\w+/{ref_file}', cmd)
-        assert re.search(r'\$BATCH_TMPDIR/R1.fq.gz \$BATCH_TMPDIR/R2.fq.gz', cmd)
-        assert re.search(
-            r'\| samtools sort .* -Obam -o \${BATCH_TMPDIR}/.*/sorted_bam',
-            cmd,
-        )
-
-
 class TestPostProcess:
     def test_no_merge_job_create_for_single_fq_pair(self, tmp_path: Path):
         config = default_config()


### PR DESCRIPTION
This PR combines #864 and #843 as it helps simplify the logic of removing bazam:

Bazam has a bug in it that is [summarised in this post](https://centrepopgen.slack.com/archives/C063WDT5HT4/p1718170029722189) and it has been decided to replace `bazam` with `samtools fastq`.

A [subsequent post](https://centrepopgen.slack.com/archives/C063WDT5HT4/p1720413842196729) covers covers validation of this replacement.



This PR also relates to other efforts to simplify the align job (removal of `Biobambam` https://github.com/populationgenomics/production-pipelines/pull/844), this was initially one big PR but has since been split out into these subsequent ones.

Notes
- I have included a function subset_cram() that was useful for testing purposes. This is for future use-cases
- Bubbled up the checking of crams that they have a cram.reference_assembly
- Added a config parameter realign_from_cram that allows for us to realign from the 'base' cram as the previous implementation (kept in for completeness) did not allow for this to happen.
- Removed indexing of cram/bam prior to alignment as bazam required an index

This PR makes minimal changes to the current cram retrieval logic as significant changes to versioning and config logic will likely adjust how we approach this.