### PR TITLE
Dataset stage fix patch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.0
+current_version = 1.26.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.0
+  VERSION: 1.26.1
 
 jobs:
   docker:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -30,7 +30,7 @@ def deprecated_get_cohort() -> MultiCohort:
     return _multicohort
 
 
-def get_multicohort() -> Cohort | MultiCohort:
+def get_multicohort() -> MultiCohort:
     """
     Return the cohort or multicohort object based on the workflow configuration.
     """

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -167,7 +167,7 @@ class MultiCohort(Target):
         uses a dictionary to avoid duplicates (we could have the same sequencing group in multiple cohorts)
         Include only "active" sequencing groups (unless only_active is False)
         """
-        all_sequencing_groups: dict[str, 'SequencingGroup'] = {}
+        all_sequencing_groups: dict[str, SequencingGroup] = {}
         for dataset in self.get_datasets(only_active):
             for sg in dataset.get_sequencing_groups(only_active):
                 all_sequencing_groups[sg.id] = sg

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -1287,7 +1287,7 @@ class SequencingGroupStage(Stage[SequencingGroup], ABC):
         if not (active_sgs := multicohort.get_sequencing_groups()):
             all_sgs = len(multicohort.get_sequencing_groups(only_active=False))
             logging.warning(
-                f'{active_sgs}/{all_sgs} usable (active=True) SGs found in the multicohort. '
+                f'{len(active_sgs)}/{all_sgs} usable (active=True) SGs found in the multicohort. '
                 'Check that input_cohorts` or `input_datasets` are provided and not skipped',
             )
             return output_by_target

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.0',
+    version='1.26.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/stages/__init__.py
+++ b/test/stages/__init__.py
@@ -22,27 +22,34 @@ from cpg_workflows.workflow import (
 )
 
 
-def mock_cohort() -> Cohort:
-    c = Cohort()
+def mock_cohort() -> MultiCohort:
+    m = MultiCohort()
+    c = m.create_cohort('fewgenomes')
+    ds = c.create_dataset('my_dataset')
+    sg1 = ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
+    m_ds = m.add_dataset(ds)
+    m_ds.add_sequencing_group_object(sg1)
+    return m
+
+
+def mock_multidataset_cohort() -> MultiCohort:
+    m = MultiCohort()
+    c = m.create_cohort('fewgenomes')
 
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-
-    return c
-
-
-def mock_multidataset_cohort() -> Cohort:
-    c = Cohort()
-
-    ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
+    sg1 = ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
+    sg2 = ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
+    m_ds_1 = m.add_dataset(ds)
+    m_ds_1.add_sequencing_group_object(sg1)
+    m_ds_1.add_sequencing_group_object(sg2)
 
     ds2 = c.create_dataset('my_dataset2')
-    ds2.add_sequencing_group('CPGCC', external_id='SAMPLE3')
-    ds2.add_sequencing_group('CPGDD', external_id='SAMPLE4')
-
-    return c
+    sg3 = ds2.add_sequencing_group('CPGCC', external_id='SAMPLE3')
+    sg4 = ds2.add_sequencing_group('CPGDD', external_id='SAMPLE4')
+    m_ds_2 = m.add_dataset(ds2)
+    m_ds_2.add_sequencing_group_object(sg3)
+    m_ds_2.add_sequencing_group_object(sg4)
+    return m
 
 
 def mock_multicohort() -> MultiCohort:

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pytest_mock import MockFixture
 
 from cpg_utils import to_path
-from cpg_workflows.targets import Cohort
+from cpg_workflows.targets import MultiCohort
 
 from . import set_config
 
@@ -72,12 +72,16 @@ def mock_create_analysis(_, project, analysis) -> int:
     return 1  # metamist "analysis" entry ID
 
 
-def mock_deprecated_create_cohort() -> Cohort:
-    c = Cohort()
+def mock_deprecated_create_cohort() -> MultiCohort:
+    m = MultiCohort()
+    c = m.create_cohort('fewgenomes')
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAAA', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGBBB', external_id='SAMPLE2')
-    return c
+    m_ds = m.add_dataset(ds)
+    sg1 = ds.add_sequencing_group('CPGAAA', external_id='SAMPLE1')
+    m_ds.add_sequencing_group_object(sg1)
+    sg2 = ds.add_sequencing_group('CPGBBB', external_id='SAMPLE2')
+    m_ds.add_sequencing_group_object(sg2)
+    return m
 
 
 def test_attributes(mocker: MockFixture, tmp_path):

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -1,206 +1,209 @@
-# """
-# Test large-cohort workflow.
-# """
-#
-# import os
-# from os.path import exists
-# from pathlib import Path
-#
-# from pytest_mock import MockFixture
-#
-# from cpg_utils import Path as CPGPath
-# from cpg_utils import to_path
-# from cpg_utils.hail_batch import start_query_context
-# from cpg_workflows.filetypes import GvcfPath
-# from cpg_workflows.large_cohort import (
-#     ancestry_pca,
-#     ancestry_plots,
-#     combiner,
-#     dense_subset,
-#     relatedness,
-#     sample_qc,
-#     site_only_vcf,
-# )
-# from cpg_workflows.targets import Cohort
-#
-# from . import set_config
-# from .factories.config import HailConfig, PipelineConfig, StorageConfig, WorkflowConfig
-# from .factories.types import SequencingType
-#
-# ref_prefix = to_path(__file__).parent / 'data/large_cohort/reference'
-# gnomad_prefix = ref_prefix / 'gnomad/v0'
-# broad_prefix = ref_prefix / 'hg38/v0'
-#
-#
-# DEFAULT_CONFIG = Path(to_path(__file__).parent.parent / 'cpg_workflows' / 'defaults.toml')
-# LARGE_COHORT_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'defaults' / 'large_cohort.toml')
-#
-#
-# def create_config(
-#     tmp_path: Path,
-#     seq_type: SequencingType,
-#     gnomad_prefix: CPGPath,
-#     broad_prefix: CPGPath,
-# ) -> PipelineConfig:
-#     return PipelineConfig(
-#         workflow=WorkflowConfig(
-#             dataset='large-cohort-test',
-#             access_level='test',
-#             sequencing_type=seq_type,
-#             check_intermediates=True,
-#         ),
-#         hail=HailConfig(query_backend='spark_local'),
-#         storage={
-#             'default': StorageConfig(
-#                 default=tmp_path,
-#                 web=tmp_path / 'web',
-#                 analysis=tmp_path / 'analysis',
-#                 tmp=tmp_path / 'test-tmp',
-#             ),
-#             'large-cohort-test': StorageConfig(
-#                 default=tmp_path,
-#                 web=tmp_path / 'web',
-#                 analysis=tmp_path / 'analysis',
-#                 tmp=tmp_path / 'test-tmp',
-#             ),
-#         },
-#         references={
-#             'genome_build': 'GRCh38',
-#             'ancestry': {
-#                 'sites_table': (gnomad_prefix / 'sample_qc-test' / 'pre_ld_pruning_qc_variants.ht'),
-#             },
-#             'gnomad': {
-#                 'tel_and_cent_ht': (
-#                     gnomad_prefix / 'telomeres_and_centromeres' / 'hg38.telomeresAndMergedCentromeres.ht'
-#                 ),
-#                 'lcr_intervals_ht': (gnomad_prefix / 'lcr_intervals' / 'LCRFromHengHg38.ht'),
-#                 'seg_dup_intervals_ht': (gnomad_prefix / 'seg_dup_intervals' / 'GRCh38_segdups.ht'),
-#                 'clinvar_ht': (gnomad_prefix / 'clinvar' / 'clinvar_20190923.ht'),
-#                 'hapmap_ht': (gnomad_prefix / 'hapmap' / 'hapmap_3.3.hg38.ht'),
-#                 'kgp_omni_ht': (gnomad_prefix / 'kgp' / '1000G_omni2.5.hg38.ht'),
-#                 'kgp_hc_ht': (gnomad_prefix / 'kgp' / '1000G_phase1.snps.high_confidence.hg38.ht'),
-#                 'mills_ht': (gnomad_prefix / 'mills' / 'Mills_and_1000G_gold_standard.indels.hg38.ht'),
-#             },
-#             'gatk_sv': {
-#                 'protein_coding_gtf': (
-#                     broad_prefix / 'sv-resources' / 'resources' / 'v1' / 'MANE.GRCh38.v0.95.select_ensembl_genomic.gtf'
-#                 ),
-#             },
-#             'broad': {
-#                 'genome_calling_interval_lists': (broad_prefix / 'wgs_calling_regions.hg38.interval_list'),
-#             },
-#         },
-#         large_cohort={
-#             'n_pcs': 3,
-#             'sample_qc_cutoffs': {
-#                 'min_n_snps': 2500,
-#             },
-#             'combiner': {'intervals': ['chr20:start-end', 'chrX:start-end', 'chrY:start-end']},
-#         },
-#     )
-#
-#
-# def _mock_cohort(dataset_id: str):
-#     cohort = Cohort()
-#     dataset = cohort.create_dataset(dataset_id)
-#     gvcf_root = to_path(__file__).parent / 'data' / 'large_cohort' / 'gvcf'
-#     found_gvcf_paths = list(gvcf_root.glob('*.g.vcf.gz'))
-#     assert len(found_gvcf_paths) > 0, gvcf_root
-#     for gvcf_path in found_gvcf_paths:
-#         sequencing_group_id = gvcf_path.name.split('.')[0]
-#         sequencing_group = dataset.add_sequencing_group(
-#             id=sequencing_group_id,
-#             external_id=sequencing_group_id.replace('CPG', 'EXT'),
-#         )
-#         sequencing_group.gvcf = GvcfPath(gvcf_path)
-#     return cohort
-#
-#
-# class TestAllLargeCohortMethods:
-#     def test_with_sample_data(self, mocker: MockFixture, tmp_path: Path):
-#         """
-#         Run entire workflow in a local mode.
-#         """
-#         conf = create_config(tmp_path, 'genome', gnomad_prefix, broad_prefix)
-#         set_config(
-#             conf,
-#             tmp_path / 'config.toml',
-#             merge_with=[DEFAULT_CONFIG, LARGE_COHORT_CONFIG],
-#         )
-#
-#         mocker.patch(
-#             'cpg_workflows.inputs.deprecated_create_cohort',
-#             lambda: _mock_cohort(conf.workflow.dataset),
-#         )
-#         # skip can_reuse, implicit skip of existence checks
-#         mocker.patch('cpg_workflows.large_cohort.combiner.can_reuse', lambda x: False)
-#         mocker.patch('cpg_workflows.large_cohort.relatedness.can_reuse', lambda x: False)
-#         mocker.patch('cpg_workflows.large_cohort.site_only_vcf.can_reuse', lambda x: False)
-#
-#         start_query_context()
-#
-#         res_pref = tmp_path
-#         vds_path = res_pref / 'v01.vds'
-#         combiner.run(out_vds_path=vds_path, tmp_prefix=res_pref / 'tmp')
-#
-#         sample_qc_ht_path = res_pref / 'sample_qc.ht'
-#         sample_qc.run(
-#             vds_path=str(vds_path),
-#             out_sample_qc_ht_path=str(sample_qc_ht_path),
-#             tmp_prefix=os.path.join(res_pref, 'tmp'),
-#         )
-#
-#         dense_mt_path = res_pref / 'dense.mt'
-#         dense_subset.run(
-#             vds_path=str(vds_path),
-#             out_dense_mt_path=str(dense_mt_path),
-#         )
-#
-#         relateds_to_drop_ht_path = res_pref / 'relateds_to_drop.ht'
-#         relatedness.run(
-#             dense_mt_path=dense_mt_path,
-#             sample_qc_ht_path=sample_qc_ht_path,
-#             out_relatedness_ht_path=res_pref / 'relatedness.ht',
-#             out_relateds_to_drop_ht_path=relateds_to_drop_ht_path,
-#             tmp_prefix=res_pref / 'tmp',
-#         )
-#
-#         scores_ht_path = res_pref / 'scores.ht'
-#         eigenvalues_ht_path = res_pref / 'eigenvalues.ht'
-#         loadings_ht_path = res_pref / 'loadings.ht'
-#         inferred_pop_ht_path = res_pref / 'inferred_pop.ht'
-#         ancestry_sample_qc_ht_path = res_pref / 'ancestry_sample_qc.ht'
-#
-#         ancestry_pca.run(
-#             dense_mt_path=dense_mt_path,
-#             sample_qc_ht_path=sample_qc_ht_path,
-#             relateds_to_drop_ht_path=relateds_to_drop_ht_path,
-#             tmp_prefix=res_pref / 'tmp',
-#             out_scores_ht_path=scores_ht_path,
-#             out_eigenvalues_ht_path=eigenvalues_ht_path,
-#             out_loadings_ht_path=loadings_ht_path,
-#             out_inferred_pop_ht_path=inferred_pop_ht_path,
-#             out_sample_qc_ht_path=ancestry_sample_qc_ht_path,
-#         )
-#         ancestry_plots.run(
-#             out_path_pattern=res_pref / 'plots' / '{scope}_pc{pci}_{pca_suffix}.{ext}',
-#             sample_qc_ht_path=ancestry_sample_qc_ht_path,
-#             scores_ht_path=scores_ht_path,
-#             eigenvalues_ht_path=eigenvalues_ht_path,
-#             loadings_ht_path=loadings_ht_path,
-#             inferred_pop_ht_path=inferred_pop_ht_path,
-#             relateds_to_drop_ht_path=relateds_to_drop_ht_path,
-#         )
-#
-#         siteonly_vcf_path = res_pref / 'siteonly.vcf.bgz'
-#         site_only_vcf.run(
-#             vds_path=str(vds_path),
-#             sample_qc_ht_path=str(sample_qc_ht_path),
-#             relateds_to_drop_ht_path=str(relateds_to_drop_ht_path),
-#             out_vcf_path=str(siteonly_vcf_path),
-#             tmp_prefix=str(res_pref / 'tmp'),
-#         )
-#
-#         assert exists(vds_path)
-#         assert exists(res_pref / 'plots' / 'dataset_pc1_hgdp_1kg_sites.html')
-#         assert exists(siteonly_vcf_path)
+"""
+Test large-cohort workflow.
+"""
+
+import os
+from os.path import exists
+from pathlib import Path
+
+from pytest_mock import MockFixture
+
+from cpg_utils import Path as CPGPath
+from cpg_utils import to_path
+from cpg_utils.hail_batch import start_query_context
+from cpg_workflows.filetypes import GvcfPath
+from cpg_workflows.large_cohort import (
+    ancestry_pca,
+    ancestry_plots,
+    combiner,
+    dense_subset,
+    relatedness,
+    sample_qc,
+    site_only_vcf,
+)
+from cpg_workflows.targets import MultiCohort
+
+from . import set_config
+from .factories.config import HailConfig, PipelineConfig, StorageConfig, WorkflowConfig
+from .factories.types import SequencingType
+
+ref_prefix = to_path(__file__).parent / 'data/large_cohort/reference'
+gnomad_prefix = ref_prefix / 'gnomad/v0'
+broad_prefix = ref_prefix / 'hg38/v0'
+
+
+DEFAULT_CONFIG = Path(to_path(__file__).parent.parent / 'cpg_workflows' / 'defaults.toml')
+LARGE_COHORT_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'defaults' / 'large_cohort.toml')
+
+
+def create_config(
+    tmp_path: Path,
+    seq_type: SequencingType,
+    gnomad_prefix: CPGPath,
+    broad_prefix: CPGPath,
+) -> PipelineConfig:
+    return PipelineConfig(
+        workflow=WorkflowConfig(
+            dataset='large-cohort-test',
+            access_level='test',
+            sequencing_type=seq_type,
+            check_intermediates=True,
+        ),
+        hail=HailConfig(query_backend='spark_local'),
+        storage={
+            'default': StorageConfig(
+                default=tmp_path,
+                web=tmp_path / 'web',
+                analysis=tmp_path / 'analysis',
+                tmp=tmp_path / 'test-tmp',
+            ),
+            'large-cohort-test': StorageConfig(
+                default=tmp_path,
+                web=tmp_path / 'web',
+                analysis=tmp_path / 'analysis',
+                tmp=tmp_path / 'test-tmp',
+            ),
+        },
+        references={
+            'genome_build': 'GRCh38',
+            'ancestry': {
+                'sites_table': (gnomad_prefix / 'sample_qc-test' / 'pre_ld_pruning_qc_variants.ht'),
+            },
+            'gnomad': {
+                'tel_and_cent_ht': (
+                    gnomad_prefix / 'telomeres_and_centromeres' / 'hg38.telomeresAndMergedCentromeres.ht'
+                ),
+                'lcr_intervals_ht': (gnomad_prefix / 'lcr_intervals' / 'LCRFromHengHg38.ht'),
+                'seg_dup_intervals_ht': (gnomad_prefix / 'seg_dup_intervals' / 'GRCh38_segdups.ht'),
+                'clinvar_ht': (gnomad_prefix / 'clinvar' / 'clinvar_20190923.ht'),
+                'hapmap_ht': (gnomad_prefix / 'hapmap' / 'hapmap_3.3.hg38.ht'),
+                'kgp_omni_ht': (gnomad_prefix / 'kgp' / '1000G_omni2.5.hg38.ht'),
+                'kgp_hc_ht': (gnomad_prefix / 'kgp' / '1000G_phase1.snps.high_confidence.hg38.ht'),
+                'mills_ht': (gnomad_prefix / 'mills' / 'Mills_and_1000G_gold_standard.indels.hg38.ht'),
+            },
+            'gatk_sv': {
+                'protein_coding_gtf': (
+                    broad_prefix / 'sv-resources' / 'resources' / 'v1' / 'MANE.GRCh38.v0.95.select_ensembl_genomic.gtf'
+                ),
+            },
+            'broad': {
+                'genome_calling_interval_lists': (broad_prefix / 'wgs_calling_regions.hg38.interval_list'),
+            },
+        },
+        large_cohort={
+            'n_pcs': 3,
+            'sample_qc_cutoffs': {
+                'min_n_snps': 2500,
+            },
+            'combiner': {'intervals': ['chr20:start-end', 'chrX:start-end', 'chrY:start-end']},
+        },
+    )
+
+
+def _mock_cohort(dataset_id: str):
+    mc = MultiCohort()
+    cohort = mc.create_cohort('large-cohort-test')
+    dataset = cohort.create_dataset(dataset_id)
+    mc_dataset = mc.add_dataset(dataset)
+    gvcf_root = to_path(__file__).parent / 'data' / 'large_cohort' / 'gvcf'
+    found_gvcf_paths = list(gvcf_root.glob('*.g.vcf.gz'))
+    assert len(found_gvcf_paths) > 0, gvcf_root
+    for gvcf_path in found_gvcf_paths:
+        sequencing_group_id = gvcf_path.name.split('.')[0]
+        sequencing_group = dataset.add_sequencing_group(
+            id=sequencing_group_id,
+            external_id=sequencing_group_id.replace('CPG', 'EXT'),
+        )
+        sequencing_group.gvcf = GvcfPath(gvcf_path)
+        mc_dataset.add_sequencing_group_object(sequencing_group)
+    return mc
+
+
+class TestAllLargeCohortMethods:
+    def test_with_sample_data(self, mocker: MockFixture, tmp_path: Path):
+        """
+        Run entire workflow in a local mode.
+        """
+        conf = create_config(tmp_path, 'genome', gnomad_prefix, broad_prefix)
+        set_config(
+            conf,
+            tmp_path / 'config.toml',
+            merge_with=[DEFAULT_CONFIG, LARGE_COHORT_CONFIG],
+        )
+
+        mocker.patch(
+            'cpg_workflows.inputs.deprecated_create_cohort',
+            lambda: _mock_cohort(conf.workflow.dataset),
+        )
+        # skip can_reuse, implicit skip of existence checks
+        mocker.patch('cpg_workflows.large_cohort.combiner.can_reuse', lambda x: False)
+        mocker.patch('cpg_workflows.large_cohort.relatedness.can_reuse', lambda x: False)
+        mocker.patch('cpg_workflows.large_cohort.site_only_vcf.can_reuse', lambda x: False)
+
+        start_query_context()
+
+        res_pref = tmp_path
+        vds_path = res_pref / 'v01.vds'
+        combiner.run(out_vds_path=vds_path, tmp_prefix=res_pref / 'tmp')
+
+        sample_qc_ht_path = res_pref / 'sample_qc.ht'
+        sample_qc.run(
+            vds_path=str(vds_path),
+            out_sample_qc_ht_path=str(sample_qc_ht_path),
+            tmp_prefix=os.path.join(res_pref, 'tmp'),
+        )
+
+        dense_mt_path = res_pref / 'dense.mt'
+        dense_subset.run(
+            vds_path=str(vds_path),
+            out_dense_mt_path=str(dense_mt_path),
+        )
+
+        relateds_to_drop_ht_path = res_pref / 'relateds_to_drop.ht'
+        relatedness.run(
+            dense_mt_path=dense_mt_path,
+            sample_qc_ht_path=sample_qc_ht_path,
+            out_relatedness_ht_path=res_pref / 'relatedness.ht',
+            out_relateds_to_drop_ht_path=relateds_to_drop_ht_path,
+            tmp_prefix=res_pref / 'tmp',
+        )
+
+        scores_ht_path = res_pref / 'scores.ht'
+        eigenvalues_ht_path = res_pref / 'eigenvalues.ht'
+        loadings_ht_path = res_pref / 'loadings.ht'
+        inferred_pop_ht_path = res_pref / 'inferred_pop.ht'
+        ancestry_sample_qc_ht_path = res_pref / 'ancestry_sample_qc.ht'
+
+        ancestry_pca.run(
+            dense_mt_path=dense_mt_path,
+            sample_qc_ht_path=sample_qc_ht_path,
+            relateds_to_drop_ht_path=relateds_to_drop_ht_path,
+            tmp_prefix=res_pref / 'tmp',
+            out_scores_ht_path=scores_ht_path,
+            out_eigenvalues_ht_path=eigenvalues_ht_path,
+            out_loadings_ht_path=loadings_ht_path,
+            out_inferred_pop_ht_path=inferred_pop_ht_path,
+            out_sample_qc_ht_path=ancestry_sample_qc_ht_path,
+        )
+        ancestry_plots.run(
+            out_path_pattern=res_pref / 'plots' / '{scope}_pc{pci}_{pca_suffix}.{ext}',
+            sample_qc_ht_path=ancestry_sample_qc_ht_path,
+            scores_ht_path=scores_ht_path,
+            eigenvalues_ht_path=eigenvalues_ht_path,
+            loadings_ht_path=loadings_ht_path,
+            inferred_pop_ht_path=inferred_pop_ht_path,
+            relateds_to_drop_ht_path=relateds_to_drop_ht_path,
+        )
+
+        siteonly_vcf_path = res_pref / 'siteonly.vcf.bgz'
+        site_only_vcf.run(
+            vds_path=str(vds_path),
+            sample_qc_ht_path=str(sample_qc_ht_path),
+            relateds_to_drop_ht_path=str(relateds_to_drop_ht_path),
+            out_vcf_path=str(siteonly_vcf_path),
+            tmp_prefix=str(res_pref / 'tmp'),
+        )
+
+        assert exists(vds_path)
+        assert exists(res_pref / 'plots' / 'dataset_pc1_hgdp_1kg_sites.html')
+        assert exists(siteonly_vcf_path)

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -1,206 +1,206 @@
-"""
-Test large-cohort workflow.
-"""
-
-import os
-from os.path import exists
-from pathlib import Path
-
-from pytest_mock import MockFixture
-
-from cpg_utils import Path as CPGPath
-from cpg_utils import to_path
-from cpg_utils.hail_batch import start_query_context
-from cpg_workflows.filetypes import GvcfPath
-from cpg_workflows.large_cohort import (
-    ancestry_pca,
-    ancestry_plots,
-    combiner,
-    dense_subset,
-    relatedness,
-    sample_qc,
-    site_only_vcf,
-)
-from cpg_workflows.targets import Cohort
-
-from . import set_config
-from .factories.config import HailConfig, PipelineConfig, StorageConfig, WorkflowConfig
-from .factories.types import SequencingType
-
-ref_prefix = to_path(__file__).parent / 'data/large_cohort/reference'
-gnomad_prefix = ref_prefix / 'gnomad/v0'
-broad_prefix = ref_prefix / 'hg38/v0'
-
-
-DEFAULT_CONFIG = Path(to_path(__file__).parent.parent / 'cpg_workflows' / 'defaults.toml')
-LARGE_COHORT_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'defaults' / 'large_cohort.toml')
-
-
-def create_config(
-    tmp_path: Path,
-    seq_type: SequencingType,
-    gnomad_prefix: CPGPath,
-    broad_prefix: CPGPath,
-) -> PipelineConfig:
-    return PipelineConfig(
-        workflow=WorkflowConfig(
-            dataset='large-cohort-test',
-            access_level='test',
-            sequencing_type=seq_type,
-            check_intermediates=True,
-        ),
-        hail=HailConfig(query_backend='spark_local'),
-        storage={
-            'default': StorageConfig(
-                default=tmp_path,
-                web=tmp_path / 'web',
-                analysis=tmp_path / 'analysis',
-                tmp=tmp_path / 'test-tmp',
-            ),
-            'large-cohort-test': StorageConfig(
-                default=tmp_path,
-                web=tmp_path / 'web',
-                analysis=tmp_path / 'analysis',
-                tmp=tmp_path / 'test-tmp',
-            ),
-        },
-        references={
-            'genome_build': 'GRCh38',
-            'ancestry': {
-                'sites_table': (gnomad_prefix / 'sample_qc-test' / 'pre_ld_pruning_qc_variants.ht'),
-            },
-            'gnomad': {
-                'tel_and_cent_ht': (
-                    gnomad_prefix / 'telomeres_and_centromeres' / 'hg38.telomeresAndMergedCentromeres.ht'
-                ),
-                'lcr_intervals_ht': (gnomad_prefix / 'lcr_intervals' / 'LCRFromHengHg38.ht'),
-                'seg_dup_intervals_ht': (gnomad_prefix / 'seg_dup_intervals' / 'GRCh38_segdups.ht'),
-                'clinvar_ht': (gnomad_prefix / 'clinvar' / 'clinvar_20190923.ht'),
-                'hapmap_ht': (gnomad_prefix / 'hapmap' / 'hapmap_3.3.hg38.ht'),
-                'kgp_omni_ht': (gnomad_prefix / 'kgp' / '1000G_omni2.5.hg38.ht'),
-                'kgp_hc_ht': (gnomad_prefix / 'kgp' / '1000G_phase1.snps.high_confidence.hg38.ht'),
-                'mills_ht': (gnomad_prefix / 'mills' / 'Mills_and_1000G_gold_standard.indels.hg38.ht'),
-            },
-            'gatk_sv': {
-                'protein_coding_gtf': (
-                    broad_prefix / 'sv-resources' / 'resources' / 'v1' / 'MANE.GRCh38.v0.95.select_ensembl_genomic.gtf'
-                ),
-            },
-            'broad': {
-                'genome_calling_interval_lists': (broad_prefix / 'wgs_calling_regions.hg38.interval_list'),
-            },
-        },
-        large_cohort={
-            'n_pcs': 3,
-            'sample_qc_cutoffs': {
-                'min_n_snps': 2500,
-            },
-            'combiner': {'intervals': ['chr20:start-end', 'chrX:start-end', 'chrY:start-end']},
-        },
-    )
-
-
-def _mock_cohort(dataset_id: str):
-    cohort = Cohort()
-    dataset = cohort.create_dataset(dataset_id)
-    gvcf_root = to_path(__file__).parent / 'data' / 'large_cohort' / 'gvcf'
-    found_gvcf_paths = list(gvcf_root.glob('*.g.vcf.gz'))
-    assert len(found_gvcf_paths) > 0, gvcf_root
-    for gvcf_path in found_gvcf_paths:
-        sequencing_group_id = gvcf_path.name.split('.')[0]
-        sequencing_group = dataset.add_sequencing_group(
-            id=sequencing_group_id,
-            external_id=sequencing_group_id.replace('CPG', 'EXT'),
-        )
-        sequencing_group.gvcf = GvcfPath(gvcf_path)
-    return cohort
-
-
-class TestAllLargeCohortMethods:
-    def test_with_sample_data(self, mocker: MockFixture, tmp_path: Path):
-        """
-        Run entire workflow in a local mode.
-        """
-        conf = create_config(tmp_path, 'genome', gnomad_prefix, broad_prefix)
-        set_config(
-            conf,
-            tmp_path / 'config.toml',
-            merge_with=[DEFAULT_CONFIG, LARGE_COHORT_CONFIG],
-        )
-
-        mocker.patch(
-            'cpg_workflows.inputs.deprecated_create_cohort',
-            lambda: _mock_cohort(conf.workflow.dataset),
-        )
-        # skip can_reuse, implicit skip of existence checks
-        mocker.patch('cpg_workflows.large_cohort.combiner.can_reuse', lambda x: False)
-        mocker.patch('cpg_workflows.large_cohort.relatedness.can_reuse', lambda x: False)
-        mocker.patch('cpg_workflows.large_cohort.site_only_vcf.can_reuse', lambda x: False)
-
-        start_query_context()
-
-        res_pref = tmp_path
-        vds_path = res_pref / 'v01.vds'
-        combiner.run(out_vds_path=vds_path, tmp_prefix=res_pref / 'tmp')
-
-        sample_qc_ht_path = res_pref / 'sample_qc.ht'
-        sample_qc.run(
-            vds_path=str(vds_path),
-            out_sample_qc_ht_path=str(sample_qc_ht_path),
-            tmp_prefix=os.path.join(res_pref, 'tmp'),
-        )
-
-        dense_mt_path = res_pref / 'dense.mt'
-        dense_subset.run(
-            vds_path=str(vds_path),
-            out_dense_mt_path=str(dense_mt_path),
-        )
-
-        relateds_to_drop_ht_path = res_pref / 'relateds_to_drop.ht'
-        relatedness.run(
-            dense_mt_path=dense_mt_path,
-            sample_qc_ht_path=sample_qc_ht_path,
-            out_relatedness_ht_path=res_pref / 'relatedness.ht',
-            out_relateds_to_drop_ht_path=relateds_to_drop_ht_path,
-            tmp_prefix=res_pref / 'tmp',
-        )
-
-        scores_ht_path = res_pref / 'scores.ht'
-        eigenvalues_ht_path = res_pref / 'eigenvalues.ht'
-        loadings_ht_path = res_pref / 'loadings.ht'
-        inferred_pop_ht_path = res_pref / 'inferred_pop.ht'
-        ancestry_sample_qc_ht_path = res_pref / 'ancestry_sample_qc.ht'
-
-        ancestry_pca.run(
-            dense_mt_path=dense_mt_path,
-            sample_qc_ht_path=sample_qc_ht_path,
-            relateds_to_drop_ht_path=relateds_to_drop_ht_path,
-            tmp_prefix=res_pref / 'tmp',
-            out_scores_ht_path=scores_ht_path,
-            out_eigenvalues_ht_path=eigenvalues_ht_path,
-            out_loadings_ht_path=loadings_ht_path,
-            out_inferred_pop_ht_path=inferred_pop_ht_path,
-            out_sample_qc_ht_path=ancestry_sample_qc_ht_path,
-        )
-        ancestry_plots.run(
-            out_path_pattern=res_pref / 'plots' / '{scope}_pc{pci}_{pca_suffix}.{ext}',
-            sample_qc_ht_path=ancestry_sample_qc_ht_path,
-            scores_ht_path=scores_ht_path,
-            eigenvalues_ht_path=eigenvalues_ht_path,
-            loadings_ht_path=loadings_ht_path,
-            inferred_pop_ht_path=inferred_pop_ht_path,
-            relateds_to_drop_ht_path=relateds_to_drop_ht_path,
-        )
-
-        siteonly_vcf_path = res_pref / 'siteonly.vcf.bgz'
-        site_only_vcf.run(
-            vds_path=str(vds_path),
-            sample_qc_ht_path=str(sample_qc_ht_path),
-            relateds_to_drop_ht_path=str(relateds_to_drop_ht_path),
-            out_vcf_path=str(siteonly_vcf_path),
-            tmp_prefix=str(res_pref / 'tmp'),
-        )
-
-        assert exists(vds_path)
-        assert exists(res_pref / 'plots' / 'dataset_pc1_hgdp_1kg_sites.html')
-        assert exists(siteonly_vcf_path)
+# """
+# Test large-cohort workflow.
+# """
+#
+# import os
+# from os.path import exists
+# from pathlib import Path
+#
+# from pytest_mock import MockFixture
+#
+# from cpg_utils import Path as CPGPath
+# from cpg_utils import to_path
+# from cpg_utils.hail_batch import start_query_context
+# from cpg_workflows.filetypes import GvcfPath
+# from cpg_workflows.large_cohort import (
+#     ancestry_pca,
+#     ancestry_plots,
+#     combiner,
+#     dense_subset,
+#     relatedness,
+#     sample_qc,
+#     site_only_vcf,
+# )
+# from cpg_workflows.targets import Cohort
+#
+# from . import set_config
+# from .factories.config import HailConfig, PipelineConfig, StorageConfig, WorkflowConfig
+# from .factories.types import SequencingType
+#
+# ref_prefix = to_path(__file__).parent / 'data/large_cohort/reference'
+# gnomad_prefix = ref_prefix / 'gnomad/v0'
+# broad_prefix = ref_prefix / 'hg38/v0'
+#
+#
+# DEFAULT_CONFIG = Path(to_path(__file__).parent.parent / 'cpg_workflows' / 'defaults.toml')
+# LARGE_COHORT_CONFIG = Path(to_path(__file__).parent.parent / 'configs' / 'defaults' / 'large_cohort.toml')
+#
+#
+# def create_config(
+#     tmp_path: Path,
+#     seq_type: SequencingType,
+#     gnomad_prefix: CPGPath,
+#     broad_prefix: CPGPath,
+# ) -> PipelineConfig:
+#     return PipelineConfig(
+#         workflow=WorkflowConfig(
+#             dataset='large-cohort-test',
+#             access_level='test',
+#             sequencing_type=seq_type,
+#             check_intermediates=True,
+#         ),
+#         hail=HailConfig(query_backend='spark_local'),
+#         storage={
+#             'default': StorageConfig(
+#                 default=tmp_path,
+#                 web=tmp_path / 'web',
+#                 analysis=tmp_path / 'analysis',
+#                 tmp=tmp_path / 'test-tmp',
+#             ),
+#             'large-cohort-test': StorageConfig(
+#                 default=tmp_path,
+#                 web=tmp_path / 'web',
+#                 analysis=tmp_path / 'analysis',
+#                 tmp=tmp_path / 'test-tmp',
+#             ),
+#         },
+#         references={
+#             'genome_build': 'GRCh38',
+#             'ancestry': {
+#                 'sites_table': (gnomad_prefix / 'sample_qc-test' / 'pre_ld_pruning_qc_variants.ht'),
+#             },
+#             'gnomad': {
+#                 'tel_and_cent_ht': (
+#                     gnomad_prefix / 'telomeres_and_centromeres' / 'hg38.telomeresAndMergedCentromeres.ht'
+#                 ),
+#                 'lcr_intervals_ht': (gnomad_prefix / 'lcr_intervals' / 'LCRFromHengHg38.ht'),
+#                 'seg_dup_intervals_ht': (gnomad_prefix / 'seg_dup_intervals' / 'GRCh38_segdups.ht'),
+#                 'clinvar_ht': (gnomad_prefix / 'clinvar' / 'clinvar_20190923.ht'),
+#                 'hapmap_ht': (gnomad_prefix / 'hapmap' / 'hapmap_3.3.hg38.ht'),
+#                 'kgp_omni_ht': (gnomad_prefix / 'kgp' / '1000G_omni2.5.hg38.ht'),
+#                 'kgp_hc_ht': (gnomad_prefix / 'kgp' / '1000G_phase1.snps.high_confidence.hg38.ht'),
+#                 'mills_ht': (gnomad_prefix / 'mills' / 'Mills_and_1000G_gold_standard.indels.hg38.ht'),
+#             },
+#             'gatk_sv': {
+#                 'protein_coding_gtf': (
+#                     broad_prefix / 'sv-resources' / 'resources' / 'v1' / 'MANE.GRCh38.v0.95.select_ensembl_genomic.gtf'
+#                 ),
+#             },
+#             'broad': {
+#                 'genome_calling_interval_lists': (broad_prefix / 'wgs_calling_regions.hg38.interval_list'),
+#             },
+#         },
+#         large_cohort={
+#             'n_pcs': 3,
+#             'sample_qc_cutoffs': {
+#                 'min_n_snps': 2500,
+#             },
+#             'combiner': {'intervals': ['chr20:start-end', 'chrX:start-end', 'chrY:start-end']},
+#         },
+#     )
+#
+#
+# def _mock_cohort(dataset_id: str):
+#     cohort = Cohort()
+#     dataset = cohort.create_dataset(dataset_id)
+#     gvcf_root = to_path(__file__).parent / 'data' / 'large_cohort' / 'gvcf'
+#     found_gvcf_paths = list(gvcf_root.glob('*.g.vcf.gz'))
+#     assert len(found_gvcf_paths) > 0, gvcf_root
+#     for gvcf_path in found_gvcf_paths:
+#         sequencing_group_id = gvcf_path.name.split('.')[0]
+#         sequencing_group = dataset.add_sequencing_group(
+#             id=sequencing_group_id,
+#             external_id=sequencing_group_id.replace('CPG', 'EXT'),
+#         )
+#         sequencing_group.gvcf = GvcfPath(gvcf_path)
+#     return cohort
+#
+#
+# class TestAllLargeCohortMethods:
+#     def test_with_sample_data(self, mocker: MockFixture, tmp_path: Path):
+#         """
+#         Run entire workflow in a local mode.
+#         """
+#         conf = create_config(tmp_path, 'genome', gnomad_prefix, broad_prefix)
+#         set_config(
+#             conf,
+#             tmp_path / 'config.toml',
+#             merge_with=[DEFAULT_CONFIG, LARGE_COHORT_CONFIG],
+#         )
+#
+#         mocker.patch(
+#             'cpg_workflows.inputs.deprecated_create_cohort',
+#             lambda: _mock_cohort(conf.workflow.dataset),
+#         )
+#         # skip can_reuse, implicit skip of existence checks
+#         mocker.patch('cpg_workflows.large_cohort.combiner.can_reuse', lambda x: False)
+#         mocker.patch('cpg_workflows.large_cohort.relatedness.can_reuse', lambda x: False)
+#         mocker.patch('cpg_workflows.large_cohort.site_only_vcf.can_reuse', lambda x: False)
+#
+#         start_query_context()
+#
+#         res_pref = tmp_path
+#         vds_path = res_pref / 'v01.vds'
+#         combiner.run(out_vds_path=vds_path, tmp_prefix=res_pref / 'tmp')
+#
+#         sample_qc_ht_path = res_pref / 'sample_qc.ht'
+#         sample_qc.run(
+#             vds_path=str(vds_path),
+#             out_sample_qc_ht_path=str(sample_qc_ht_path),
+#             tmp_prefix=os.path.join(res_pref, 'tmp'),
+#         )
+#
+#         dense_mt_path = res_pref / 'dense.mt'
+#         dense_subset.run(
+#             vds_path=str(vds_path),
+#             out_dense_mt_path=str(dense_mt_path),
+#         )
+#
+#         relateds_to_drop_ht_path = res_pref / 'relateds_to_drop.ht'
+#         relatedness.run(
+#             dense_mt_path=dense_mt_path,
+#             sample_qc_ht_path=sample_qc_ht_path,
+#             out_relatedness_ht_path=res_pref / 'relatedness.ht',
+#             out_relateds_to_drop_ht_path=relateds_to_drop_ht_path,
+#             tmp_prefix=res_pref / 'tmp',
+#         )
+#
+#         scores_ht_path = res_pref / 'scores.ht'
+#         eigenvalues_ht_path = res_pref / 'eigenvalues.ht'
+#         loadings_ht_path = res_pref / 'loadings.ht'
+#         inferred_pop_ht_path = res_pref / 'inferred_pop.ht'
+#         ancestry_sample_qc_ht_path = res_pref / 'ancestry_sample_qc.ht'
+#
+#         ancestry_pca.run(
+#             dense_mt_path=dense_mt_path,
+#             sample_qc_ht_path=sample_qc_ht_path,
+#             relateds_to_drop_ht_path=relateds_to_drop_ht_path,
+#             tmp_prefix=res_pref / 'tmp',
+#             out_scores_ht_path=scores_ht_path,
+#             out_eigenvalues_ht_path=eigenvalues_ht_path,
+#             out_loadings_ht_path=loadings_ht_path,
+#             out_inferred_pop_ht_path=inferred_pop_ht_path,
+#             out_sample_qc_ht_path=ancestry_sample_qc_ht_path,
+#         )
+#         ancestry_plots.run(
+#             out_path_pattern=res_pref / 'plots' / '{scope}_pc{pci}_{pca_suffix}.{ext}',
+#             sample_qc_ht_path=ancestry_sample_qc_ht_path,
+#             scores_ht_path=scores_ht_path,
+#             eigenvalues_ht_path=eigenvalues_ht_path,
+#             loadings_ht_path=loadings_ht_path,
+#             inferred_pop_ht_path=inferred_pop_ht_path,
+#             relateds_to_drop_ht_path=relateds_to_drop_ht_path,
+#         )
+#
+#         siteonly_vcf_path = res_pref / 'siteonly.vcf.bgz'
+#         site_only_vcf.run(
+#             vds_path=str(vds_path),
+#             sample_qc_ht_path=str(sample_qc_ht_path),
+#             relateds_to_drop_ht_path=str(relateds_to_drop_ht_path),
+#             out_vcf_path=str(siteonly_vcf_path),
+#             tmp_prefix=str(res_pref / 'tmp'),
+#         )
+#
+#         assert exists(vds_path)
+#         assert exists(res_pref / 'plots' / 'dataset_pc1_hgdp_1kg_sites.html')
+#         assert exists(siteonly_vcf_path)

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -61,14 +61,16 @@ def _common(mocker, tmp_path):
 
     mocker.patch('metamist.apis.AnalysisApi.create_analysis', mock_create_analysis)
 
-    from cpg_workflows.targets import Cohort
+    from cpg_workflows.targets import MultiCohort
 
-    def mock_create_cohort() -> Cohort:
-        c = Cohort()
+    def mock_create_cohort() -> MultiCohort:
+        m = MultiCohort()
+        c = m.create_cohort('fewgenomes')
         ds = c.create_dataset('my_dataset')
-        ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-        ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
-        return c
+        m_ds = m.add_dataset(ds)
+        m_ds.add_sequencing_group_object(ds.add_sequencing_group('CPGAA', external_id='SAMPLE1'))
+        m_ds.add_sequencing_group_object(ds.add_sequencing_group('CPGBB', external_id='SAMPLE2'))
+        return m
 
     mocker.patch('cpg_workflows.inputs.deprecated_create_cohort', mock_create_cohort)
 

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -8,7 +8,7 @@ from cpg_utils import Path, to_path
 from cpg_workflows.targets import Cohort, MultiCohort, SequencingGroup
 from cpg_workflows.workflow import path_walk
 
-from test import set_config
+from . import set_config
 
 TOML = """
 [workflow]

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -5,10 +5,10 @@ Test building Workflow object.
 from unittest import mock
 
 from cpg_utils import Path, to_path
-from cpg_workflows.targets import Cohort, SequencingGroup
+from cpg_workflows.targets import Cohort, MultiCohort, SequencingGroup
 from cpg_workflows.workflow import path_walk
 
-from . import set_config
+from test import set_config
 
 TOML = """
 [workflow]
@@ -36,12 +36,16 @@ backend = 'local'
 """
 
 
-def mock_deprecated_create_cohort() -> Cohort:
-    c = Cohort()
+def mock_deprecated_create_cohort() -> MultiCohort:
+    m = MultiCohort()
+    c = m.create_cohort('fewgenomes')
     ds = c.create_dataset('my_dataset')
-    ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-    ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
-    return c
+    sg1 = ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
+    sg2 = ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
+    m_ds = m.add_dataset(ds)
+    m_ds.add_sequencing_group_object(sg1)
+    m_ds.add_sequencing_group_object(sg2)
+    return m
 
 
 @mock.patch('cpg_workflows.inputs.deprecated_create_cohort', mock_deprecated_create_cohort)


### PR DESCRIPTION
I was incorrect - the changes in #860 didn't fully close the DatasetStage issue. I caught the structure of the MultiCohort/Cohort, but missed the fact that the DatsetStages have their own internal queue_for_cohort method, which was iterating over each cohort to find dataset targets.

This change:
- SequencingGroupStages now iterate directly over the `multicohort.get_sequencing_groups()` output, the layers of iteration and logging about Datasets/Cohorts are dropped.
- DatasetStages now iterate directly over the `multicohort.get_datasets()` output during setup
- no longer permits a Cohort to be used when running the pipeline - MultiCohorts only. This change was already made in #860 (i.e. `deprecated_create_cohort` already returns a MultiCohort), and removing a Cohort as an option in get_workflow just solidifies that
- A whole range of tests were still creating Cohorts instead of MultiCohorts, so I've fixed those up
- This means that all the Stage Target `deprecated_queue_for_cohort` methods are inaccessible, and can safely be deleted, but I'm not doing that here