### PR TITLE
SV ES patch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.3
+current_version = 1.26.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.3
+  VERSION: 1.26.4
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -222,7 +222,7 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str |
                 hl.is_defined(mt.info.END2),
                 hl.struct(contig=mt.info.CHR2, position=mt.info.END2),
                 hl.struct(contig=mt.locus.contig, position=mt.info.END),
-            )
+            ),
         )
     else:
         mt = mt.annotate_rows(end_locus=hl.struct(contig=mt.locus.contig, position=mt.info.END))

--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -218,7 +218,7 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str |
     # add end_locus, with flexibility for END2
     if 'END2' in mt.info:
         mt = mt.annotate_rows(
-            hl.if_else(
+            end_locus=hl.if_else(
                 hl.is_defined(mt.info.END2),
                 hl.struct(contig=mt.info.CHR2, position=mt.info.END2),
                 hl.struct(contig=mt.locus.contig, position=mt.info.END),

--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -215,9 +215,15 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str |
     # flexibly draw annotations depending on whether the VCF has them - this is for compatibility with Long-Read & GATK
     # this can all be removed if/when Long-read is removed to a separate pipeline
 
-    # add end_locus, with flexity for END2
+    # add end_locus, with flexibility for END2
     if 'END2' in mt.info:
-        mt = mt.annotate_rows(end_locus=hl.struct(contig=mt.info.CHR2, position=mt.info.END2))
+        mt = mt.annotate_rows(
+            hl.if_else(
+                hl.is_defined(mt.info.END2),
+                hl.struct(contig=mt.info.CHR2, position=mt.info.END2),
+                hl.struct(contig=mt.locus.contig, position=mt.info.END),
+            )
+        )
     else:
         mt = mt.annotate_rows(end_locus=hl.struct(contig=mt.locus.contig, position=mt.info.END))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.3',
+    version='1.26.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
ES Indexes weren't playing well in Seqr - slight logic change meant that some end_locus attributes were appearing as None. This checks for both presence and validity in a way which doesn't break anything for SV, or Long-read SV