### PR TITLE
Annotate cohort sv prevent null end_locus row field

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -214,12 +214,13 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str |
 
     # flexibly draw annotations depending on whether the VCF has them - this is for compatibility with Long-Read & GATK
     # this can all be removed if/when Long-read is removed to a separate pipeline
-
-    # add end_locus, with flexity for END2
-    if 'END2' in mt.info:
-        mt = mt.annotate_rows(end_locus=hl.struct(contig=mt.info.CHR2, position=mt.info.END2))
-    else:
-        mt = mt.annotate_rows(end_locus=hl.struct(contig=mt.locus.contig, position=mt.info.END))
+    mt = mt.annotate_rows(
+        end_locus=hl.if_else(
+            hl.is_defined(mt.info.END2),
+            hl.struct(contig=mt.info.CHR2, position=mt.info.END2),
+            hl.struct(contig=mt.locus.contig, position=mt.info.END),
+        ),
+    )
 
     # GATK-SV consists of multiple algorithms, other pathways may not
     if 'ALGORITHMS' in mt.info:


### PR DESCRIPTION
Recently importing SV es-indexes in to seqr is breaking the variant searches, most likely because the `xstop` field is null for some hits. This PR changes the logic used to derive the `end_locus` field so that it won't be null and matches the logic that used to be in this job, before it was changed in [this commit](https://github.com/populationgenomics/production-pipelines/commit/fbbde24ab22e53a5eaf57919d4f0052f07a566f7).

Change python `if-else` to `hl.if_else` and `mt.info.END2` existence check to `hl.is_defined` - should prevent nulls flowing through into the annotated cohort, dataset, and eventual es-index.