### PR TITLE
Ancestry without DP

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.0
+current_version = 1.27.1
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.4
+current_version = 1.26.5
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.6
+current_version = 1.26.7
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.1
+current_version = 1.27.2
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.9
+current_version = 1.26.10
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.10
+current_version = 1.26.11
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.5
+current_version = 1.26.6
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.8
+current_version = 1.26.9
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.7
+current_version = 1.26.8
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.11
+current_version = 1.27.0
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.2
+current_version = 1.27.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.0
+  VERSION: 1.27.1
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.11
+  VERSION: 1.27.0
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.5
+  VERSION: 1.26.6
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.9
+  VERSION: 1.26.10
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.2
+  VERSION: 1.27.3
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.10
+  VERSION: 1.26.11
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.1
+  VERSION: 1.27.2
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.4
+  VERSION: 1.26.5
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.6
+  VERSION: 1.26.7
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.7
+  VERSION: 1.26.8
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.8
+  VERSION: 1.26.9
 
 jobs:
   docker:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'true'
+          submodules: "true"
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install
         run: pip install .[test]
@@ -29,4 +29,15 @@ jobs:
         timeout-minutes: 20
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
-          pytest test
+          coverage run -m pytest test
+
+          rc=$?
+          coverage xml
+
+          echo "rc=$rc" >> $GITHUB_OUTPUT
+
+      - name: "Upload coverage reports to Codecov"
+        uses: codecov/codecov-action@v4.5.0
+        with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hail Batch Workflows
 
+[![codecov](https://codecov.io/gh/populationgenomics/production-pipelines/graph/badge.svg?token=BKODL52HOU)](https://codecov.io/gh/populationgenomics/production-pipelines)
+
 This repository provides implementations of genomics workflows using Hail Batch, specifically:
 
 * WES/WGS Seqr Loader: FASTQ -> CRAM -> GVCF -> pVCF -> Matrix Table -> Elasticsearch index, with an ability to use parts of this pipeline as e.g. a single-sample germline variant calling workflow (FASTQ -> GVCF), joint-calling pipeline (GVCF -> pVCF), AS-VQSR pipeline, etc.

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -105,3 +105,6 @@ tel_and_cent_ht = "gs://cpg-common-main/references/gnomad/v0/telomeres_and_centr
 [references.hg38_telomeres_and_centromeres_intervals]
 # Derived from hg38.telomeresAndMergedCentromeres.bed used in gnomAD v3
 interval_list = "gs://cpg-common-main/references/hg38/v0/hg38.telomeresAndMergedCentromeres.interval_list"
+
+[Ancestry]
+cores = 8

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -153,10 +153,10 @@ def align(
     # if number of threads is not requested, using whole instance
     requested_nthreads = requested_nthreads or STANDARD.max_threads()
 
-    if get_config()['workflow']['sequencing_type'] == 'genome':
+    if sequencing_group.sequencing_type == 'genome':
         realignment_shards_num = 10
     else:
-        assert get_config()['workflow']['sequencing_type'] == 'exome'
+        assert sequencing_group.sequencing_type == 'exome'
         realignment_shards_num = 1
 
     sharded_fq = isinstance(alignment_input, FastqPairs) and len(alignment_input) > 1

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -76,8 +76,7 @@ class MissingAlignmentInputException(Exception):
 def _get_alignment_input(sequencing_group: SequencingGroup) -> AlignmentInput:
     """Given a sequencing group, will return an AlignmentInput object that
     represents the path to a relevant input (e.g. CRAM/BAM path)"""
-    sequencing_type = get_config()['workflow']['sequencing_type']
-    alignment_input = sequencing_group.alignment_input_by_seq_type.get(sequencing_type)
+    alignment_input = sequencing_group.alignment_input
     if realign_cram_ver := get_config()['workflow'].get('realign_from_cram_version'):
         if (
             path := (sequencing_group.dataset.prefix() / 'cram' / realign_cram_ver / f'{sequencing_group.id}.cram')

--- a/cpg_workflows/jobs/happy.py
+++ b/cpg_workflows/jobs/happy.py
@@ -57,7 +57,7 @@ def happy(
         """
 
     # Calling regions
-    seq_type = get_config()['workflow']['sequencing_type']
+    seq_type = sequencing_group.sequencing_type
     eval_intervals_path = reference_path(f'broad/{seq_type}_evaluation_interval_lists')
     if seq_type == 'genome':
         # sparse regions, bcftools would loop through them

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -53,10 +53,39 @@ def make_joint_genotyping_jobs(
     """
     Adds samples to the GenomicsDB and runs joint genotyping on them.
     Outputs a multi-sample VCF under `output_vcf_path`.
+
+    If the input intervals_path is not specified, use the get_intervals picard job to
+    generate scatter_count interval files and submit joint genotyping jobs for each.
+
+    If the input intervals_path is specified and is a bed file, read the intervals directly
+    into and submit joint genotyping jobs for each. Avoids the need for a picard job.
+    NOTE: the start positions of each interval from the bed file must be incremented by 1.
     """
     if len(gvcf_by_sgid) == 0:
         raise ValueError('Provided samples collection for joint calling should contain at least one active sample')
     scatter_count = scatter_count or joint_calling_scatter_count(len(gvcf_by_sgid))
+
+    jobs: list[Job] = []
+    intervals: list[str] | list[hb.ResourceFile] = []
+    if intervals_path and intervals_path.suffix == '.bed':
+        # If intervals_path is a bed file, read the intervals directly
+        intervals_j = None
+        intervals = get_intervals_from_bed(intervals_path)
+        assert scatter_count == len(intervals)
+    else:
+        # If intervals_path is not specified, use the get_intervals picard job
+        intervals_j, intervals = get_intervals(
+            b=b,
+            source_intervals_path=intervals_path,
+            exclude_intervals_path=exclude_intervals_path,
+            scatter_count=scatter_count,
+            job_attrs=job_attrs,
+            output_prefix=tmp_bucket / f'intervals_{scatter_count}',
+        )
+    if intervals_j:
+        jobs.append(intervals_j)
+
+    logging.info('Submitting joint-calling jobs')
 
     all_output_paths = [out_vcf_path, out_siteonly_vcf_path]
     if out_siteonly_vcf_part_paths:
@@ -64,20 +93,6 @@ def make_joint_genotyping_jobs(
         all_output_paths.extend(out_siteonly_vcf_part_paths)
     if can_reuse(all_output_paths + [to_path(f'{p}.tbi') for p in all_output_paths]):
         return []
-
-    logging.info('Submitting joint-calling jobs')
-
-    jobs: list[Job] = []
-    intervals_j, intervals = get_intervals(
-        b=b,
-        source_intervals_path=intervals_path,
-        exclude_intervals_path=exclude_intervals_path,
-        scatter_count=scatter_count,
-        job_attrs=job_attrs,
-        output_prefix=tmp_bucket / f'intervals_{scatter_count}',
-    )
-    if intervals_j:
-        jobs.append(intervals_j)
 
     vcfs: list[hb.ResourceGroup] = []
     siteonly_vcfs: list[hb.ResourceGroup] = []
@@ -194,11 +209,14 @@ def genomicsdb(
     b: hb.Batch,
     sample_map_bucket_path: Path,
     output_path: Path,
-    interval: Resource | None = None,
+    interval: Resource | str | None = None,
     job_attrs: dict | None = None,
 ) -> Job | None:
     """
     Create GenomicDBs for an interval.
+
+    The input interval can either be an interval_list file, or a string in the format
+    'chrN:start-end'. Either can be passed to the GenomicsDBImport tool.
 
     Note that GenomicsDBImport and GenotypeGVCFs can interact directly with a DB
     sitting on a bucket, without having to make a copy. However, there some problems
@@ -305,14 +323,17 @@ def genomicsdb(
 def _add_joint_genotyper_job(
     b: hb.Batch,
     genomicsdb_path: Path,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     output_vcf_path: Path | None = None,
     tool: JointGenotyperTool = JointGenotyperTool.GnarlyGenotyper,
     job_attrs: dict | None = None,
 ) -> tuple[Job | None, hb.ResourceGroup]:
     """
     Runs GATK GnarlyGenotyper or GenotypeGVCFs on a combined_gvcf VCF bgzipped file,
-    pre-called with HaplotypeCaller.
+    pre-called with HaplotypeCaller, over a single interval.
+
+    The input interval can either be an interval_list file, or a string in the format
+    'chrN:start-end'. Either can be passed to the GATK joint genotyper tools.
 
     GenotypeGVCFs is a standard GATK joint-genotyping tool.
 
@@ -414,12 +435,15 @@ def _add_excess_het_filter(
     b: hb.Batch,
     input_vcf: hb.ResourceGroup,
     excess_het_threshold: float = 54.69,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     output_vcf_path: Path | None = None,
     job_attrs: dict | None = None,
 ) -> tuple[Job | None, hb.ResourceGroup]:
     """
-    Filter a large cohort callset on Excess Heterozygosity.
+    Filter a large cohort callset on Excess Heterozygosity, over a single interval.
+
+    The input interval can either be an interval_list file, or a string in the format
+    'chrN:start-end'. Either can be passed to GATK VariantFiltration.
 
     The filter applies only to large callsets (`not is_small_callset`)
 
@@ -522,3 +546,17 @@ def add_make_sitesonly_job(
     if output_vcf_path:
         b.write_output(j.output_vcf, str(output_vcf_path).replace('.vcf.gz', ''))
     return j, j.output_vcf
+
+
+def get_intervals_from_bed(intervals_path: Path) -> list[str]:
+    """
+    Read intervals from a bed file.
+    Increment the start position of each interval by 1 to match the 1-based
+    coordinate system used by GATK.
+    """
+    with intervals_path.open('r') as f:
+        intervals = []
+        for line in f:
+            chrom, start, end = line.strip().split('\t')
+            intervals.append(f'{chrom}:{int(start)+1}-{end}')
+    return intervals

--- a/cpg_workflows/jobs/vqsr.py
+++ b/cpg_workflows/jobs/vqsr.py
@@ -16,6 +16,7 @@ from hailtop.batch.job import Job
 from cpg_utils import Path, to_path
 from cpg_utils.config import get_config, image_path, reference_path
 from cpg_utils.hail_batch import command
+from cpg_workflows.jobs.joint_genotyping import get_intervals_from_bed
 from cpg_workflows.jobs.picard import get_intervals
 from cpg_workflows.jobs.vcf import gather_vcfs
 from cpg_workflows.resources import HIGHMEM, STANDARD, joint_calling_scatter_count
@@ -192,13 +193,20 @@ def make_vqsr_jobs(
         b.write_output(model_j.model_file, str(snp_model_path))
     snp_model = b.read_input(str(snp_model_path))
 
-    intervals_j, intervals = get_intervals(
-        b=b,
-        scatter_count=scatter_count,
-        source_intervals_path=intervals_path,
-        job_attrs=job_attrs,
-        output_prefix=tmp_prefix / f'intervals_{scatter_count}',
-    )
+    intervals: list[str] | list[hb.ResourceFile] = []
+    if intervals_path and intervals_path.suffix == '.bed':
+        # If intervals_path is a bed file, read the intervals directly
+        intervals_j = None
+        intervals = get_intervals_from_bed(intervals_path)
+        assert scatter_count == len(intervals)
+    else:
+        intervals_j, intervals = get_intervals(
+            b=b,
+            scatter_count=scatter_count,
+            source_intervals_path=intervals_path,
+            job_attrs=job_attrs,
+            output_prefix=tmp_prefix / f'intervals_{scatter_count}',
+        )
     if intervals_j:
         jobs.append(intervals_j)
 
@@ -510,7 +518,7 @@ def snps_recalibrator_scattered(
     dbsnp_resource_vcf: hb.ResourceGroup,
     disk_size: int,
     use_as_annotations: bool,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     max_gaussians: int = 6,
     is_small_callset: bool = False,
     job_attrs: dict | None = None,
@@ -687,7 +695,7 @@ def apply_recalibration_snps(
     disk_size: int,
     use_as_annotations: bool,
     filter_level: float,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     job_attrs: dict | None = None,
 ) -> Job:
     """
@@ -745,7 +753,7 @@ def apply_recalibration_indels(
     disk_size: int,
     use_as_annotations: bool,
     filter_level: float,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     output_vcf_path: Path | None = None,
     job_attrs: dict | None = None,
 ) -> Job:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -59,7 +59,9 @@ def add_background(
                 logging.info(f'Checkpointing background_mt to {background_mt_checkpoint_path}')
                 background_mt = background_mt.checkpoint(str(background_mt_checkpoint_path), overwrite=True)
                 logging.info('Finished checkpointing densified_background_mt')
-                # annotate background mt with metadata info derived from SampleQC stage
+
+            # annotate background mt with metadata info derived from SampleQC stage
+            # TODO little confused - is this an indentation issue? We only apply metadata to a VDS?
             metadata_tables = []
             for path in dataset_dict['metadata_table']:
                 sample_qc_background = hl.read_table(path)

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -4,8 +4,7 @@ import logging
 import hail as hl
 
 from cpg_utils import Path
-from cpg_utils.config import get_config
-from cpg_utils.hail_batch import genome_build
+from cpg_utils.config import config_retrieve, genome_build, get_config
 from cpg_workflows.inputs import get_multicohort
 from cpg_workflows.targets import SequencingGroup
 from cpg_workflows.utils import can_reuse, exists
@@ -70,6 +69,17 @@ def run(out_vds_path: Path, tmp_prefix: Path, *sequencing_group_ids) -> hl.vds.V
         sequencing_groups = [s for s in sequencing_groups if s in sequencing_group_ids]
 
     sequencing_groups = _check_gvcfs(sequencing_groups)
+    seq_types = set(s.sequencing_type for s in sequencing_groups)
+    if len(seq_types) > 1:
+        by_seq_type = collections.defaultdict(list)
+        for s in sequencing_groups:
+            by_seq_type[s.sequencing_type].append(s.id)
+
+        raise ValueError(
+            f'Found multiple sequencing types for large cohort combiner: {by_seq_type}',
+        )
+    # else just use the first
+    sequencing_type = seq_types.pop()
 
     params = get_config().get('large_cohort', {}).get('combiner', {})
 
@@ -80,9 +90,9 @@ def run(out_vds_path: Path, tmp_prefix: Path, *sequencing_group_ids) -> hl.vds.V
             )
         else:
             params['intervals'] = hl.import_locus_intervals(params['intervals'])
-    elif get_config()['workflow']['sequencing_type'] == 'exome':
+    elif sequencing_type == 'exome':
         params.setdefault('use_exome_default_intervals', True)
-    elif get_config()['workflow']['sequencing_type'] == 'genome':
+    elif sequencing_type == 'genome':
         params.setdefault('use_genome_default_intervals', True)
     else:
         raise ValueError(

--- a/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
@@ -164,7 +164,7 @@ def main(qc_in: str, dense_in: str, qc_out: str, dense_out: str, background_data
     # start a Hail Query (on-batch) Runtime
     init_batch()
 
-    dense_mt = hl.read_matrix_table(dense_in).select_entries('GT', 'GQ', 'DP', 'AD')
+    dense_mt = hl.read_matrix_table(dense_in).select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
     sample_qc_ht = hl.read_table(qc_in)
 
     dense_mt, sample_qc_ht = add_background(dense_mt, sample_qc_ht, background_datasets, tmp_path)

--- a/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
@@ -41,11 +41,11 @@ def prepare_background_mt(data_path: str, dataset: str, qc_variants_ht: hl.Table
         raise ValueError('Background dataset path must be either .mt or .vds')
 
 
-def prepare_metadata_table(table_list: list[str], sample_qc_ht: hl.Table) -> hl.Table:
+def prepare_metadata_table(background_sample_qc_paths: list[str], sample_qc_ht: hl.Table) -> hl.Table:
     """
 
     Args:
-        table_list ():
+        background_sample_qc_paths ():
         sample_qc_ht (hl.Table):
 
     Returns:
@@ -54,7 +54,7 @@ def prepare_metadata_table(table_list: list[str], sample_qc_ht: hl.Table) -> hl.
     # annotate background mt with metadata info derived from SampleQC stage
     allow_missing_columns = config_retrieve(['large_cohort', 'pca_background', 'allow_missing_columns'], False)
     metadata_tables = []
-    for path in table_list:
+    for path in background_sample_qc_paths:
         metadata_tables.append(hl.read_table(path))
 
     metadata_table = hl.Table.union(*metadata_tables, unify=allow_missing_columns)

--- a/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
@@ -105,7 +105,8 @@ def add_background(dense_mt: hl.MatrixTable, sample_qc_ht: hl.Table, tmp_path: s
             )
             logging.info(f'Finished filtering background, kept samples that are {populations_to_filter}')
         if background_relateds_to_drop := config_retrieve(
-            ['large_cohort', 'pca_background', dataset, 'background_relateds_to_drop'], False
+            ['large_cohort', 'pca_background', dataset, 'background_relateds_to_drop'],
+            False,
         ):
             logging.info(
                 f'Removing related samples from background dataset {dataset}.\n'

--- a/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
@@ -8,6 +8,7 @@ from os.path import join
 
 import hail as hl
 
+from cpg_utils import to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
 
@@ -25,12 +26,12 @@ def prepare_background_mt(data_path: str, dataset: str, qc_variants_ht: hl.Table
     """
     background_mt_checkpoint_path = join(tmp_path, f'{dataset}_densified_background.mt')
 
-    if data_path.endswith('.mt'):
+    if to_path(data_path).suffix == '.mt':
         background_mt = hl.read_matrix_table(data_path)
         background_mt = hl.split_multi(background_mt, filter_changed_loci=True)
         background_mt = background_mt.semi_join_rows(qc_variants_ht)
         return background_mt.densify().checkpoint(background_mt_checkpoint_path, overwrite=True)
-    elif data_path.endswith('.vds'):
+    elif to_path(data_path).suffix == '.vds':
         background_vds = hl.vds.read_vds(data_path)
         background_vds = hl.vds.split_multi(background_vds, filter_changed_loci=True)
         background_vds = hl.vds.filter_variants(background_vds, qc_variants_ht)

--- a/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
@@ -122,7 +122,9 @@ def add_background(dense_mt: hl.MatrixTable, sample_qc_ht: hl.Table, tmp_path: s
         # save metadata info before merging dense and background datasets
         sample_qc_ht = sample_qc_ht.union(background_mt.cols(), unify=allow_missing_columns)
 
-        background_mt = background_mt.select_entries('GT', 'GQ', 'DP', 'AD').naive_coalesce(5000)
+        background_mt = (
+            background_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD').naive_coalesce(5000)
+        )
         # combine dense dataset with background population dataset
         dense_mt = dense_mt.union_cols(background_mt)
 

--- a/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_add_background.py
@@ -1,0 +1,178 @@
+"""
+This Stage does some Hail Query work to add background and Metadata to the QC tables
+"""
+
+import logging
+from argparse import ArgumentParser
+from os.path import join
+
+import hail as hl
+
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import init_batch
+
+
+def prepare_background_mt(data_path: str, qc_variants_ht: hl.Table, tmp_path) -> hl.MatrixTable:
+    """
+
+    Args:
+        data_path ():
+        qc_variants_ht ():
+        tmp_path ():
+
+    Returns:
+        A densified MT, checkpointed
+    """
+    background_mt_checkpoint_path = join(tmp_path, 'densified_background.mt')
+
+    if data_path.endswith('.mt'):
+        background_mt = hl.read_matrix_table(data_path)
+        background_mt = hl.split_multi(background_mt, filter_changed_loci=True)
+        background_mt = background_mt.semi_join_rows(qc_variants_ht)
+        return background_mt.densify().checkpoint(background_mt_checkpoint_path, overwrite=True)
+    elif data_path.endswith('.vds'):
+        background_mt_checkpoint_path = join(tmp_path, 'densified_background.mt')
+        background_vds = hl.vds.read_vds(data_path)
+        background_vds = hl.vds.split_multi(background_vds, filter_changed_loci=True)
+        background_vds = hl.vds.filter_variants(background_vds, qc_variants_ht)
+        background_mt = hl.vds.to_dense_mt(background_vds)
+        logging.info(f'Checkpointing background_mt to {background_mt_checkpoint_path}')
+        return background_mt.checkpoint(background_mt_checkpoint_path, overwrite=True)
+    else:
+        raise ValueError('Background dataset path must be either .mt or .vds')
+
+
+def prepare_metadata_table(table_list: list[str], sample_qc_ht: hl.Table) -> hl.Table:
+    """
+
+    Args:
+        table_list ():
+        sample_qc_ht (hl.Table):
+
+    Returns:
+        the union of all Metadata tables, with columns reordered WRT the SampleQC Hail Table
+    """
+    # annotate background mt with metadata info derived from SampleQC stage
+    allow_missing_columns = config_retrieve(['large_cohort', 'pca_background', 'allow_missing_columns'], False)
+    metadata_tables = []
+    for path in table_list:
+        metadata_tables.append(hl.read_table(path))
+
+    metadata_table = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
+
+    # reorder columns
+    reference_fields = sample_qc_ht.sample_qc.dtype.fields
+    ordered_sample_qc = {field: metadata_table.sample_qc[field] for field in reference_fields}
+    return metadata_table.annotate(sample_qc=hl.struct(**ordered_sample_qc))
+
+
+def add_background(dense_mt: hl.MatrixTable, sample_qc_ht: hl.Table, tmp_path: str) -> tuple[hl.MatrixTable, hl.Table]:
+    """
+    Add background dataset samples to the dense MT and sample QC HT.
+
+    Args:
+        dense_mt ():
+        sample_qc_ht ():
+        tmp_path (): where to generate temp data, if required
+
+    Returns:
+        Annotated versions of the Sample QC HT, and Dense MT
+    """
+    pca_bg_config = config_retrieve(['large_cohort', 'pca_background'])
+
+    # whole table read in from config path
+    qc_variants_ht = hl.read_table(config_retrieve(['references', 'ancestry', 'sites_table']))
+
+    allow_missing_columns = pca_bg_config.get('allow_missing_columns', False)
+
+    # loop over each dataset. If this is empty, we don't run this stage
+    # happy to hard pull from config and fail if absent
+    for dataset in pca_bg_config['datasets']:
+
+        dataset_dict = pca_bg_config[dataset]
+        logging.info(f'Adding background dataset {dataset_dict["dataset_path"]}')
+
+        # prepare the background MT, from either a Mt or VDS
+        background_mt = prepare_background_mt(dataset_dict['dataset_path'], qc_variants_ht, tmp_path=tmp_path)
+        metadata_table = prepare_metadata_table(dataset_dict['metadata_table'], sample_qc_ht)
+
+        background_mt = background_mt.annotate_cols(**metadata_table[background_mt.col_key])
+
+        if populations_to_filter := pca_bg_config.get('superpopulation_to_filter', False):
+            logging.info(f'Filtering background samples by {populations_to_filter}')
+            background_mt = background_mt.filter_cols(
+                hl.literal(populations_to_filter).contains(background_mt.superpopulation),
+            )
+            logging.info(f'Finished filtering background, kept samples that are {populations_to_filter}')
+        if background_relateds_to_drop := config_retrieve(
+            ['large_cohort', 'pca_background', dataset, 'background_relateds_to_drop'], False
+        ):
+            logging.info(
+                f'Removing related samples from background dataset {dataset}.\n'
+                f'Background relateds to drop: {background_relateds_to_drop}',
+            )
+            background_relateds_to_drop_ht = hl.read_table(background_relateds_to_drop)
+            background_mt = background_mt.filter_cols(
+                ~hl.is_defined(background_relateds_to_drop_ht[background_mt.col_key]),
+            )
+        else:
+            logging.info('No related samples to drop from background dataset')
+
+        # save metadata info before merging dense and background datasets
+        sample_qc_ht = sample_qc_ht.union(background_mt.cols(), unify=allow_missing_columns)
+
+        background_mt = background_mt.select_entries('GT', 'GQ', 'DP', 'AD').naive_coalesce(5000)
+        # combine dense dataset with background population dataset
+        dense_mt = dense_mt.union_cols(background_mt)
+
+    if drop_columns := pca_bg_config.get('drop_columns'):
+        sample_qc_ht = sample_qc_ht.drop(*drop_columns)
+
+    return dense_mt, sample_qc_ht
+
+
+def cli_main():
+    """
+    A command-line entrypoint for the ancestry add-background process
+    """
+
+    parser = ArgumentParser()
+    parser.add_argument('--qc_in', help='The QC Table to read in')
+    parser.add_argument('--dense_in', help='The Dense MT to read in')
+    parser.add_argument('--qc_out', help='The output path for the QC table')
+    parser.add_argument('--dense_out', help='The output path for the dense MT')
+    parser.add_argument('--tmp', help='Path to write temporary data to')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    main(qc_in=args.qc_in, dense_in=args.dense_in, qc_out=args.qc_out, dense_out=args.dense_out, tmp_path=args.tmp)
+
+
+def main(qc_in: str, dense_in: str, qc_out: str, dense_out: str, tmp_path: str):
+    """
+
+    Args:
+        qc_in (str):
+        dense_in (str):
+        qc_out (str):
+        dense_out (str):
+        tmp_path (str):
+    """
+
+    # start a Hail Query (on-batch) Runtime
+    init_batch()
+
+    dense_mt = hl.read_matrix_table(dense_in).select_entries('GT', 'GQ', 'DP', 'AD')
+    sample_qc_ht = hl.read_table(qc_in)
+
+    dense_mt, sample_qc_ht = add_background(dense_mt, sample_qc_ht, tmp_path)
+
+    logging.info(f'Writing dense_mt to {dense_out}')
+    dense_mt.write(dense_out)
+
+    logging.info(f'Writing sample_qc_ht to {qc_out}')
+    sample_qc_ht.write(qc_out, overwrite=True)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
@@ -1,0 +1,116 @@
+"""
+This Stage is a thin wrapper around the gnomad methods PCA call
+"""
+
+import logging
+import pickle
+from argparse import ArgumentParser
+
+import hail as hl
+
+from gnomad.sample_qc.ancestry import assign_population_pcs
+
+from cpg_utils.config import config_retrieve
+
+MAX_MISLABELLED_TRAINING_SAMPLES: int = 50
+
+
+def run_assign_population_pcs(pop_pca_scores_ht, min_prob, n_pcs: int):
+    examples_num = pop_pca_scores_ht.aggregate(hl.agg.count_where(hl.is_defined(pop_pca_scores_ht.training_pop)))
+    logging.info(f'Running RF using {examples_num} training examples')
+    pop_ht, pops_rf_model = assign_population_pcs(
+        pop_pca_scores_ht,
+        pc_cols=pop_pca_scores_ht.scores[:n_pcs],
+        known_col='training_pop',
+        min_prob=min_prob,
+    )
+    n_mislabeled_samples = pop_ht.aggregate(hl.agg.count_where(pop_ht.training_pop != pop_ht.pop))
+    return pop_ht, pops_rf_model, n_mislabeled_samples
+
+
+def cli_main():
+    """
+    A command-line entrypoint for the ancestry add-background process
+    """
+
+    parser = ArgumentParser()
+    parser.add_argument('--scores_ht', help='The PCA scores HT')
+    parser.add_argument('--sample_qc', help='The SampleQC HT')
+    parser.add_argument('--pop_ht_out', help='population table output path')
+    parser.add_argument('--pop_pickle_out', help='population model output path')
+    parser.add_argument('--pop_txt_out', help='population inference output path')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    main(scores_ht_path=args.scores_ht, sample_qc_in=args.sample_qc, pop_out=args.pop_out)
+
+
+def main(scores_ht_path: str, sample_qc_in: str, sample_qc_out: str, pop_out: str, pickle_out: str):
+    """
+
+    Args:
+        scores_ht_path ():
+        sample_qc_in ():
+        sample_qc_out ():
+        pop_out ():
+        pickle_out (str): where to write the model. pickled
+
+    Returns:
+
+    """
+    min_prob = config_retrieve(['large_cohort', 'min_pop_prob'])
+    n_pcs = config_retrieve(['large_cohort', 'n_pcs'], 16)
+
+    ncpu = config_retrieve(['Ancestry', 'cores'], 8)
+    hl.context.init_spark(master=f'local[{ncpu}]', quiet=True)
+    hl.default_reference('GRCh38')
+
+    scores_ht = hl.read_table(scores_ht_path)
+    sample_qc_ht = hl.read_table(sample_qc_in)
+
+    training_pop_ht = sample_qc_ht.filter(hl.is_defined(sample_qc_ht['training_pop']))
+
+    # no idea if continuing is a good idea in this case - failing instead
+    if training_pop_ht.count() < 2:
+        raise ValueError('Need at least 2 samples with known `population` label to run PCA')
+
+    logging.info(
+        'Using calculated PCA scores as well as training samples with known '
+        '`population` label to assign population labels to remaining samples',
+    )
+    scores_ht = scores_ht.annotate(training_pop=training_pop_ht[scores_ht.key].training_pop)
+
+    pop_ht, pops_rf_model, n_mislabeled_samples = run_assign_population_pcs(scores_ht, min_prob, n_pcs)
+    while n_mislabeled_samples > MAX_MISLABELLED_TRAINING_SAMPLES:
+        logging.info(
+            f'Found {n_mislabeled_samples} samples '
+            f'labeled differently from their known pop. '
+            f'Re-running without them.',
+        )
+
+        pop_ht = pop_ht[scores_ht.key]
+
+        # not sure if persist is viable here
+        pop_pca_scores_ht = scores_ht.annotate(
+            training_pop=hl.or_missing((pop_ht.training_pop == pop_ht.pop), scores_ht.training_pop),
+        ).persist()
+
+        pop_ht, pops_rf_model, n_mislabeled_samples = run_assign_population_pcs(pop_pca_scores_ht, min_prob, n_pcs)
+
+    # Writing a tab delimited file indicating inferred sample populations
+    pc_cnt = min(hl.min(10, hl.len(pop_ht.pca_scores)).collect())
+    pop_ht.transmute(**{f'PC{i + 1}': pop_ht.pca_scores[i] for i in range(pc_cnt)}).export(str(pop_tsv_file))
+
+    # Writing the RF model used for inferring sample populations
+    with open(pickle_out, 'wb', encoding='utf-8') as handle:
+        pickle.dump(pops_rf_model, handle)
+
+    pop_ht.annotate(is_training=hl.is_defined(training_pop_ht[pop_ht.key])).write(pop_out, overwrite=True)
+    # read this version back in
+    pop_ht = hl.read_table(pop_out)
+
+    sample_qc_ht.annotate(**pop_ht[sample_qc_ht.key]).write(sample_qc_out)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
@@ -36,7 +36,7 @@ def cli_main():
     parser.add_argument('--scores_ht', help='The PCA scores HT')
     parser.add_argument('--qc_in', help='The SampleQC HT to read')
     parser.add_argument('--qc_out', help='The updated SampleQC HT to write')
-    parser.add_argument('--ht_out', help='population table output path')
+    parser.add_argument('--pop_ht_out', help='population table output path')
     parser.add_argument('--pickle_out', help='population model output path')
     parser.add_argument('--txt_out', help='population inference output path')
     args = parser.parse_args()

--- a/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
@@ -108,7 +108,7 @@ def main(scores_ht_path: str, qc_in: str, qc_out: str, pop_ht_out: str, pickle_o
     pop_ht.transmute(**{f'PC{i + 1}': pop_ht.pca_scores[i] for i in range(pc_cnt)}).export(txt_out)
 
     # Writing the RF model used for inferring sample populations
-    with open(pickle_out, 'wb', encoding='utf-8') as handle:
+    with open(pickle_out, 'wb') as handle:
         pickle.dump(pops_rf_model, handle)
 
     pop_ht.annotate(is_training=hl.is_defined(training_pop_ht[pop_ht.key])).write(pop_ht_out)

--- a/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_infer_labels.py
@@ -8,9 +8,8 @@ from argparse import ArgumentParser
 
 import hail as hl
 
-from gnomad.sample_qc.ancestry import assign_population_pcs
-
 from cpg_utils.config import config_retrieve
+from gnomad.sample_qc.ancestry import assign_population_pcs
 
 MAX_MISLABELLED_TRAINING_SAMPLES: int = 50
 

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -1,0 +1,96 @@
+"""
+This Stage is a thin wrapper around the gnomad methods PCA call
+"""
+
+import logging
+from argparse import ArgumentParser
+
+import hail as hl
+import pandas as pd
+
+from gnomad.sample_qc.ancestry import run_pca_with_relateds
+
+from cpg_utils.config import config_retrieve
+
+MIN_N_PCS = 3  # for one PC1 vs PC2 plot
+MIN_N_SAMPLES = 10
+
+
+def cli_main():
+    """
+    A command-line entrypoint for the ancestry add-background process
+    """
+
+    parser = ArgumentParser()
+    parser.add_argument('--dense_mt', help='The Dense MT to read in')
+    parser.add_argument('--related', help='The HT from Relatedness ')
+    parser.add_argument('--scores_out', help='scores table output path')
+    parser.add_argument('--eigen_out', help='eigenvalues table output path')
+    parser.add_argument('--loadings_out', help='loadings table output path')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    main(
+        dense_mt=args.dense_mt,
+        related=args.related,
+        scores_out=args.scores_out,
+        eigen_out=args.eigen_out,
+        loadings_out=args.loadings_out,
+    )
+
+
+def main(dense_mt: str, related: str, scores_out: str, eigen_out: str, loadings_out: str):
+    """
+
+    Args:
+        dense_mt ():
+        related ():
+        scores_out (str): local path to write the scores table to
+        eigen_out (): local path to write the eigenvalues table to
+        loadings_out (): local path to write the loadings table to
+    """
+
+    ncpu = config_retrieve(['Ancestry', 'cores'], 8)
+    hl.context.init_spark(master=f'local[{ncpu}]', quiet=True)
+    hl.default_reference('GRCh38')
+
+    mt = hl.read_matrix_table(dense_mt)
+    sample_to_drop_ht = hl.read_table(related)
+
+    n_pcs = config_retrieve(['large_cohort', 'n_pcs'], 16)
+
+    if n_pcs < MIN_N_PCS:
+        raise ValueError(f'The number of PCs must be at least {MIN_N_PCS}, got {n_pcs}')
+
+    samples_to_use = mt.count_cols()
+    logging.info(f'Total sample number in the matrix table: {samples_to_use}')
+
+    samples_to_drop = sample_to_drop_ht.count()
+    logging.info(f'Determined {samples_to_drop} relateds to drop')
+    samples_to_use -= samples_to_drop
+    logging.info(
+        f'Removing the {samples_to_drop} relateds from the list of samples used '
+        f'for PCA, got remaining {samples_to_use} samples',
+    )
+
+    if samples_to_use < MIN_N_SAMPLES:
+        raise ValueError(
+            f'The number of samples after removing relateds if too low for the PCA '
+            f'analysis. Got {samples_to_use}, but need at least {MIN_N_SAMPLES}',
+        )
+
+    if n_pcs > samples_to_use:
+        logging.info(f'Adjusting the number of PCs not to exceed the number of samples:{n_pcs} -> {samples_to_use}')
+        n_pcs = samples_to_use
+
+    eigenvalues, scores_ht, loadings_ht = run_pca_with_relateds(mt, sample_to_drop_ht, n_pcs=n_pcs)
+    logging.info(f'scores_ht.s: {list(scores_ht.s.collect())}')
+    logging.info(f'eigenvalues: {eigenvalues}')
+    eigenvalues_ht = hl.Table.from_pandas(pd.DataFrame(eigenvalues, columns=['f0']))
+    scores_ht.write(scores_out)
+    eigenvalues_ht.write(eigen_out)
+    loadings_ht.write(loadings_out)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -51,7 +51,7 @@ def main(dense_mt: str, related: str, scores_out: str, eigen_out: str, loadings_
     """
 
     ncpu = config_retrieve(['Ancestry', 'cores'], 8)
-    hl.context.init_spark(master=f'local[{ncpu}]', quiet=True)
+    hl.context.init_spark(master=f'local[{ncpu}]')
     hl.default_reference('GRCh38')
     logging.info(f'Hail version: {hl.version()}')
 

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -93,4 +93,5 @@ def main(dense_mt: str, related: str, scores_out: str, eigen_out: str, loadings_
 
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     cli_main()

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -5,12 +5,12 @@ This Stage is a thin wrapper around the gnomad methods PCA call
 import logging
 from argparse import ArgumentParser
 
-import hail as hl
 import pandas as pd
 
-from gnomad.sample_qc.ancestry import run_pca_with_relateds
+import hail as hl
 
 from cpg_utils.config import config_retrieve
+from gnomad.sample_qc.ancestry import run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
 MIN_N_SAMPLES = 10

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -13,7 +13,7 @@ from cpg_utils.config import config_retrieve
 from gnomad.sample_qc.ancestry import run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
-MIN_N_SAMPLES = 10
+MIN_N_SAMPLES = 2
 
 
 def cli_main():

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -53,6 +53,7 @@ def main(dense_mt: str, related: str, scores_out: str, eigen_out: str, loadings_
     ncpu = config_retrieve(['Ancestry', 'cores'], 8)
     hl.context.init_spark(master=f'local[{ncpu}]', quiet=True)
     hl.default_reference('GRCh38')
+    logging.info(f'Hail version: {hl.version()}')
 
     mt = hl.read_matrix_table(dense_mt)
     sample_to_drop_ht = hl.read_table(related)

--- a/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
+++ b/cpg_workflows/large_cohort/scripts/ancestry_run_pca.py
@@ -13,7 +13,7 @@ from cpg_utils.config import config_retrieve
 from gnomad.sample_qc.ancestry import run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
-MIN_N_SAMPLES = 2
+MIN_N_SAMPLES = 10
 
 
 def cli_main():
@@ -83,6 +83,8 @@ def main(dense_mt: str, related: str, scores_out: str, eigen_out: str, loadings_
     if n_pcs > samples_to_use:
         logging.info(f'Adjusting the number of PCs not to exceed the number of samples:{n_pcs} -> {samples_to_use}')
         n_pcs = samples_to_use
+        n_pcs = 8
+        logging.info(f'Using {n_pcs} PCs for PCA')
 
     eigenvalues, scores_ht, loadings_ht = run_pca_with_relateds(mt, sample_to_drop_ht, n_pcs=n_pcs)
     logging.info(f'scores_ht.s: {list(scores_ht.s.collect())}')

--- a/cpg_workflows/large_cohort/scripts/densify_background_dataset.py
+++ b/cpg_workflows/large_cohort/scripts/densify_background_dataset.py
@@ -50,7 +50,12 @@ def cli_main():
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
-    main(background_vds=args.background_vds, qc_variants_table=args.qc_variants_table, tmp_path=args.tmp_path)
+    main(
+        background_vds=args.background_vds,
+        qc_variants_table=args.qc_variants_table,
+        dense_out=args.dense_out,
+        tmp_path=args.tmp_path,
+    )
 
 
 def main(background_vds: str, qc_variants_table: str, dense_out: str, tmp_path: str):

--- a/cpg_workflows/large_cohort/scripts/densify_background_dataset.py
+++ b/cpg_workflows/large_cohort/scripts/densify_background_dataset.py
@@ -1,0 +1,73 @@
+"""
+This Stage takes a background VDS dataset (e.g. thousand genomes, HGDP, or HGDP-1KG) and densifies it to a MatrixTable
+"""
+
+import logging
+from argparse import ArgumentParser
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
+
+
+def densify_background_dataset(data_path: str, qc_variants_ht: hl.Table) -> hl.MatrixTable:
+    """
+
+    Args:
+        data_path ():
+        qc_variants_ht ():
+        tmp_path ():
+
+    Returns:
+        A densified MT
+    """
+    if data_path.endswith('.mt'):
+        background_mt = hl.read_matrix_table(data_path)
+        background_mt = hl.split_multi(background_mt, filter_changed_loci=True)
+        background_mt = background_mt.semi_join_rows(qc_variants_ht)
+        background_mt = background_mt.densify()
+    elif data_path.endswith('.vds'):
+        background_vds = hl.vds.read_vds(data_path)
+        background_vds = hl.vds.split_multi(background_vds, filter_changed_loci=True)
+        background_vds = hl.vds.filter_variants(background_vds, qc_variants_ht)
+        background_mt = hl.vds.to_dense_mt(background_vds)
+    else:
+        raise ValueError('Background dataset path must be either .mt or .vds')
+
+    return background_mt
+
+
+def cli_main():
+    """
+    A command-line entrypoint for the densification of a background dataset
+    """
+
+    parser = ArgumentParser()
+    parser.add_argument('--background-vds', help='Path to the background VDS dataset')
+    parser.add_argument('--qc-variants-table', help='Path to the QC variants table')
+    parser.add_argument('--dense-out', help='Path to the output dense MT')
+    parser.add_argument('--tmp-path', help='Path to a temporary directory')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    main(background_vds=args.background_vds, qc_variants_table=args.qc_variants_table, tmp_path=args.tmp_path)
+
+
+def main(background_vds: str, qc_variants_table: str, dense_out: str, tmp_path: str):
+    """
+    Entrypoint for the densification of a background dataset
+    """
+
+    init_batch()
+
+    background_vds = hl.vds.read_vds(background_vds)
+    qc_variants_ht = hl.read_table(qc_variants_table)
+
+    dense_background_mt = densify_background_dataset(background_vds, qc_variants_ht)
+
+    logging.info(f'Writing dense background MT to {dense_out}')
+    dense_background_mt.write(dense_out)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/cpg_workflows/large_cohort/scripts/densify_background_dataset.py
+++ b/cpg_workflows/large_cohort/scripts/densify_background_dataset.py
@@ -51,24 +51,23 @@ def cli_main():
 
     logging.basicConfig(level=logging.INFO)
     main(
-        background_vds=args.background_vds,
+        background_vds_path=args.background_vds,
         qc_variants_table=args.qc_variants_table,
         dense_out=args.dense_out,
         tmp_path=args.tmp_path,
     )
 
 
-def main(background_vds: str, qc_variants_table: str, dense_out: str, tmp_path: str):
+def main(background_vds_path: str, qc_variants_table: str, dense_out: str, tmp_path: str):
     """
     Entrypoint for the densification of a background dataset
     """
 
     init_batch()
 
-    background_vds = hl.vds.read_vds(background_vds)
     qc_variants_ht = hl.read_table(qc_variants_table)
 
-    dense_background_mt = densify_background_dataset(background_vds, qc_variants_ht)
+    dense_background_mt = densify_background_dataset(background_vds_path, qc_variants_ht)
 
     logging.info(f'Writing dense background MT to {dense_out}')
     dense_background_mt.write(dense_out)

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -29,19 +29,21 @@ def annotate_cohort(
     logging.getLogger().setLevel(logging.INFO)
 
     # hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/permissions.20issues/near/398711114
+    # don't override the block size, as it explodes the number of partitions when processing TB+ datasets
+    # Each partition comes with some computational overhead, it's to be seen whether the standard block size
+    # is viable for QOB in large datasets... Requires a test
     mt = hl.import_vcf(
         vcf_path,
         reference_genome=genome_build(),
         skip_invalid_loci=True,
         force_bgz=True,
         array_elements_required=False,
-        block_size=10,
     )
     logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,
     # and hl.split_multi_hts can handle multiallelic VEP field.
-    vep_ht = hl.read_table(str(vep_ht_path))
+    vep_ht = hl.read_table(vep_ht_path)
     logging.info(
         f'Adding VEP annotations into the Matrix Table from {vep_ht_path}. VEP loaded as {vep_ht.n_partitions()} partitions',
     )
@@ -109,7 +111,7 @@ def annotate_cohort(
     liftover_path = reference_path('liftover_38_to_37')
     rg37 = hl.get_reference('GRCh37')
     rg38 = hl.get_reference('GRCh38')
-    rg38.add_liftover(str(liftover_path), rg37)
+    rg38.add_liftover(liftover_path, rg37)
     mt = mt.annotate_rows(rg37_locus=hl.liftover(mt.locus, 'GRCh37'))
 
     # only remove InbreedingCoeff if present (post-VQSR)
@@ -169,24 +171,27 @@ def annotate_cohort(
 
     logging.info('Done:')
     mt.describe()
-    mt.write(str(out_mt_path), overwrite=True)
+    mt.write(out_mt_path, overwrite=True)
     logging.info(f'Written final matrix table into {out_mt_path}')
 
 
-def subset_mt_to_samples(mt_path, sample_ids, out_mt_path, exclusion_file: str | None = None):
+def subset_mt_to_samples(mt_path: str, sample_ids: list[str], out_mt_path: str, exclusion_file: str | None = None):
     """
     Subset the MatrixTable to the provided list of samples and to variants present
     in those samples
-    @param mt_path: cohort-level matrix table from VCF.
-    @param sample_ids: samples to take from the matrix table.
-    @param out_mt_path: path to write the result.
-    @param exclusion_file: path to a file containing samples to remove from the
-            subset prior to attempting removal
+
+    Args:
+        mt_path (str): cohort-level matrix table from VCF.
+        sample_ids (list[str]): samples to take from the matrix table.
+        out_mt_path (str): path to write the result.
+        exclusion_file (str, optional): path to a file containing samples to remove from the
+                                        subset prior to extracting
     """
+    logging.basicConfig(level=logging.INFO)
 
-    mt = hl.read_matrix_table(str(mt_path))
+    mt = hl.read_matrix_table(mt_path)
 
-    sample_ids = set(sample_ids)
+    unique_sids: set[str] = set(sample_ids)
 
     # if an exclusion file was passed, remove the samples from the subset
     # this executes in a query command, by execution time the file should exist
@@ -194,33 +199,44 @@ def subset_mt_to_samples(mt_path, sample_ids, out_mt_path, exclusion_file: str |
         with hl.hadoop_open(exclusion_file) as f:
             exclusion_ids = set(f.read().splitlines())
         logging.info(f'Excluding {len(exclusion_ids)} samples from the subset')
-        sample_ids -= exclusion_ids
+        unique_sids -= exclusion_ids
 
     mt_sample_ids = set(mt.s.collect())
 
-    sample_ids_not_in_mt = sample_ids - mt_sample_ids
-    if sample_ids_not_in_mt:
+    if sample_ids_not_in_mt := unique_sids - mt_sample_ids:
         raise Exception(
-            f'Found {len(sample_ids_not_in_mt)}/{len(sample_ids)} samples '
-            f'in the subset set that do not matching IDs in the variant callset.\n'
+            f'Found {len(sample_ids_not_in_mt)}/{len(unique_sids)} IDs in the requested subset not in the callset.\n'
             f'IDs that aren\'t in the callset: {sample_ids_not_in_mt}\n'
             f'All callset sample IDs: {mt_sample_ids}',
         )
 
-    logging.info(f'Found {len(mt_sample_ids)} samples in mt, subsetting to {len(sample_ids)} samples.')
+    # work out the proportion of the original sample count that we'll keep
+    downsample = len(mt_sample_ids) // len(unique_sids)
+    # calculate the proportional number of partitions to generate
+    downsample_partitions = mt.n_partitions() // downsample
+
+    logging.info(f'Found {len(mt_sample_ids)} samples in mt, subsetting to {len(unique_sids)} samples.')
+    logging.info(f'Re-reading the MT with {downsample_partitions} partitions, reduced from {mt.n_partitions()}')
+    # re-read instead of a repartition/naive_coalesce
+    # naive coalesce could produce really unbalanced partitions, and repartitioning might be more expensive
+    # "it's basically free to read with different partitioning than you wrote with"
+    # https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query-0.2E2-support/topic/Reading.20many.20HTs/near/438846215
+    mt = hl.read_matrix_table(mt_path, _n_partitions=downsample_partitions)
 
     n_rows_before = mt.count_rows()
 
-    mt = mt.filter_cols(hl.literal(sample_ids).contains(mt.s))
+    mt = mt.filter_cols(hl.literal(unique_sids).contains(mt.s))
     mt = mt.filter_rows(hl.agg.any(mt.GT.is_non_ref()))
+    mt.write(out_mt_path, overwrite=True)
 
+    # read again to get the metadata
+    mt = hl.read_matrix_table(out_mt_path)
+    # log with row/col counts as a no-op as we read the fresh metadata
     logging.info(
-        f'Finished subsetting to {len(sample_ids)} samples. '
+        f'Finished subsetting to {len(unique_sids)} samples, written to {out_mt_path}. '
         f'Kept {mt.count_cols()}/{len(mt_sample_ids)} samples, '
         f'{mt.count_rows()}/{n_rows_before} rows',
     )
-    mt.write(str(out_mt_path), overwrite=True)
-    logging.info(f'Written {out_mt_path}')
 
 
 def vcf_from_mt_subset(mt_path: str, out_vcf_path: str):
@@ -234,17 +250,17 @@ def vcf_from_mt_subset(mt_path: str, out_vcf_path: str):
         out_vcf_path (str): path of the vcf.bgz to generate
     """
 
-    mt = hl.read_matrix_table(str(mt_path))
+    mt = hl.read_matrix_table(mt_path)
     logging.info(f'Dataset MT dimensions: {mt.count()}')
     hl.export_vcf(mt, out_vcf_path, tabix=True)
     logging.info(f'Written {out_vcf_path}')
 
 
-def annotate_dataset_mt(mt_path, out_mt_path):
+def annotate_dataset_mt(mt_path: str, out_mt_path: str):
     """
     Add dataset-level annotations.
     """
-    mt = hl.read_matrix_table(str(mt_path))
+    mt = hl.read_matrix_table(mt_path)
 
     # Convert the mt genotype entries into num_alt, gq, ab, dp, and sample_id.
     is_called = hl.is_defined(mt.GT)
@@ -263,9 +279,7 @@ def annotate_dataset_mt(mt_path, out_mt_path):
         'sample_id': mt.s,
     }
     logging.info('Annotating genotypes')
-    mt = mt.annotate_rows(
-        genotypes=hl.agg.collect(hl.struct(**genotype_fields)),
-    )
+    mt = mt.annotate_rows(genotypes=hl.agg.collect(hl.struct(**genotype_fields)))
 
     def _genotype_filter_samples(fn):
         # Filter on the genotypes.

--- a/cpg_workflows/query_modules/vep.py
+++ b/cpg_workflows/query_modules/vep.py
@@ -28,7 +28,7 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path, vep_version: str):
     """
     Parse results from VEP with annotations formatted in JSON,
     and write into a Hail Table.
-    receives a vep_version String to determine how data is decoded
+    receives a vep_version str to determine how data is decoded
     """
 
     # check against supported versions
@@ -40,10 +40,10 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path, vep_version: str):
         # Differences relative to the 105 schema:
         # - minimised, int32, new field at top level
         # - seq_region_name, str, new field at top level
-        # - am_class, String, new field in transcript_consequences
+        # - am_class, str, new field in transcript_consequences
         # - am_pathogenicity, Double/float, new field in transcript_consequences
         # - flags, List[str], new field in transcript_consequences
-        # - clin_sig_allele, String, new field in colocated_variants (wrongly absent in prev.?)
+        # - clin_sig_allele, str, new field in colocated_variants (wrongly absent in prev.?)
         # - frequencies, Dict[str, Dict[str, Float]], new struct in colocated_variants
         #   - this is being ignored, cannot be processed using fixed schema
         # - removal of all exac_* fields
@@ -142,6 +142,32 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path, vep_version: str):
                     lof_flags:str,
                     lof_filter:str,
                     lof_info:str,
+                    existing_inframe_oorfs:int32,
+                    existing_outofframe_oorfs:int32,
+                    existing_uorfs:int32,
+                    5utr_consequence:str,
+                    5utr_annotation:dict<
+                        str,
+                        struct{
+                            type:str,
+                            KozakContext:str,
+                            KozakStrength:str,
+                            DistanceToCDS:str,
+                            CapDistanceToStart:str,
+                            DistanceToStop:str,
+                            Evidence:str,
+                            AltStop:str,
+                            AltStopDistanceToCDS:str,
+                            FrameWithCDS:str,
+                            StartDistanceToCDS:str,
+                            newSTOPDistanceToCDS:str,
+                            alt_type:str,
+                            alt_type_length:str,
+                            ref_StartDistanceToCDS:str,
+                            ref_type:str,
+                            ref_type_length:str
+                        }
+                    >,
                     minimised:int32,
                     mirna:array<str>,
                     polyphen_prediction:str,

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -1,0 +1,33 @@
+"""
+Generate new intervals from a MatrixTable based on data distribution
+A wrapper for the generate_new_intervals.py script
+"""
+
+from argparse import ArgumentParser
+
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch
+
+parser = ArgumentParser()
+parser.add_argument('--mt', help='MatrixTable to generate intervals from')
+parser.add_argument('--out', help='Output intervals file - path to write the resulting BED in GCP')
+parser.add_argument('--meres', help='.interval_list file with intervals to exclude (Centro/Telomeres)')
+parser.add_argument('--intervals', help='Number of intervals to generate', type=int)
+args = parser.parse_args()
+
+job = get_batch().new_bash_job(f'Generate {args.intervals} intervals from {args.mt}')
+authenticate_cloud_credentials_in_job(job)
+job.image(config_retrieve(['workflow', 'driver_image']))
+
+# localise the centromere/telomere file in the batch
+meres_in = get_batch().read_input(args.meres)
+
+job.command(
+    'new_intervals_from_mt '
+    f'--mt {args.mt} '
+    f'--out {job.output} '
+    f'--meres_file {meres_in} '
+    f'--intervals {args.intervals}',
+)
+get_batch().write_output(job.output, args.out)
+get_batch().run(wait=False)

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -1,0 +1,186 @@
+"""
+Generate new intervals from a MatrixTable based on data distribution
+
+First we read the MT, and generate rough intervals based on the rows
+My understanding is that this is a based on the distribution of keys, so
+each partition will have roughly the same number of keys (i.e. variants)
+
+This initial group of intervals is split such that each interval fully sits
+on a contig. This is to avoid issues with cross-contig intervals.
+
+Then we polish the intervals by dodging centromeres and telomeres. This is
+done by reading in an interval_list file, which contains the centromere and
+telomere regions. We then check if the intervals overlap with these regions,
+and if so, we split the intervals around the centromere/telomere.
+
+For telomere overlaps, we shift the start or end position of the interval
+to outside the telomere region.
+
+For centromere overlaps, we split the intervals around the centromere, creating
+two new intervals.
+
+The input argument --intervals is the initial number of intervals created. Due to
+splitting this can then jump up a bit (in a small test this was +50). This may be
+negligible on larger splits, but for smaller interval counts can be huge.
+"""
+
+import logging
+from argparse import ArgumentParser
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
+
+
+def get_naive_intervals(mt: hl.MatrixTable, intervals: int) -> list[tuple[str, int, int]]:
+    """
+    Get naive new intervals from a MatrixTable
+
+    Args:
+        mt (hl.MatrixTable): Input MatrixTable
+        intervals (int): Number of intervals to generate
+
+    Returns:
+        list[tuple[str, int, int]]: List of intervals, in non-hail form
+    """
+    naive_interval_structs = mt._calculate_new_partitions(intervals)
+    logging.info(f'Generated {len(naive_interval_structs)} intervals')
+
+    # store both start and end positions separately
+    new_intervals = [
+        (
+            interval.start.locus.contig,
+            interval.start.locus.position,
+            interval.end.locus.contig,
+            interval.end.locus.position,
+        )
+        for interval in naive_interval_structs
+    ]
+
+    # check for cross-contig intervals, and split
+    final_intervals: list[tuple[str, int, int]] = []
+    parsed_chroms: set[str] = set()
+    for index, (contig1, start, contig2, end) in enumerate(new_intervals, start=1):
+        # shift start position to 1, regardless of the variant positions used when generating the intervals
+        if contig1 not in parsed_chroms:
+            parsed_chroms.add(contig1)
+            start = 1
+
+        if contig1 != contig2:
+            parsed_chroms.add(contig2)
+            # get the end of the first
+            first_end = hl.get_reference('GRCh38').lengths[contig1]
+            final_intervals.append((contig1, start, first_end))
+            final_intervals.append((contig2, 1, end))
+
+        else:
+            # if this is the final interval on this chromosome, shift the end position to the end of the chromosome
+            # true if this is the latest interval on this chromosome
+            if index == len(new_intervals) or new_intervals[index][0] != contig1:
+                final_intervals.append((contig1, start, hl.get_reference('GRCh38').lengths[contig1]))
+            else:
+                final_intervals.append((contig1, start, end))
+
+    logging.info(f'Naive intervals post splitting: {len(final_intervals)}')
+
+    return final_intervals
+
+
+def overlaps(a: tuple[int, int], b: tuple[int, int]) -> int:
+    """
+    Return the amount of overlap, in bp
+    between a and b.
+    If >0, the number of bp of overlap
+    If 0,  they are book-ended.
+    If <0, the distance in bp between them
+    """
+
+    if (overlap := min(a[1], b[1]) - max(a[0], b[0])) > 0:
+        return overlap
+    return 0
+
+
+def polish_intervals(naive_intervals: list[tuple[str, int, int]], meres_file: str) -> list[tuple[str, int, int]]:
+    """
+    Polish intervals by splitting/removing centromere and telomere regions
+    Args:
+        naive_intervals (list): naive intervals, each limited to a single contig
+        meres_file (str): path to file containing centromere and telomere regions
+
+    Returns:
+        a polished version of the intervals file, where no centromere or telomere regions are present
+    """
+    telomeres: dict[str, list[tuple[int, int]]] = {}
+    centromeres: dict[str, tuple[int, int]] = {}
+
+    logging.info(f'Reading centromere and telomere regions from {meres_file}')
+
+    with open(meres_file, encoding='utf-8') as f:
+        for line in f:
+            if line.startswith('@SQ') or line.startswith('@HD'):
+                continue
+
+            contig, start_str, end_str, strand, region_type = line.strip().split('\t')
+            if 'centromere' in region_type:
+                centromeres[contig] = (int(start_str), int(end_str))
+            else:
+                telomeres.setdefault(contig, []).append((int(start_str), int(end_str)))
+
+    new_intervals: list[tuple[str, int, int]] = []
+    logging.info('Polishing intervals')
+    for chrom, start, end in naive_intervals:
+        found_overlap = False
+        # does this overlap with a telomere?
+        for telo in telomeres.get(chrom, []):
+            # there's an overlap
+            if overlaps(telo, (start, end)):
+                # this is a 'start' telomere, shift the start coord
+                if telo[0] == 1:
+                    start = telo[1]
+                else:
+                    end = telo[0]
+        # does it overlap with a centromere? If so split around it
+        if centro_region := centromeres.get(chrom):
+            # check for an overlap
+            if overlaps(centro_region, (start, end)):
+                # check we have some interval left
+                if centro_region[0] > start:
+                    new_intervals.append((chrom, start, centro_region[0]))
+                if end > centro_region[1]:
+                    new_intervals.append((chrom, centro_region[1], end))
+                continue
+        new_intervals.append((chrom, start, end))
+
+    logging.info(f'Final intervals: {len(new_intervals)}')
+
+    return new_intervals
+
+
+def cli_main():
+    parser = ArgumentParser(description='Generate new intervals from a list of intervals')
+    parser.add_argument('--mt', help='Input MatrixTable')
+    parser.add_argument('--out', help='Output intervals file')
+    parser.add_argument('--intervals', help='Intervals to generate', type=int, default=100)
+    parser.add_argument('--meres_file', help='interval_list file of Centromere & telomere regions')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    main(args.mt, args.out, intervals=args.intervals, meres=args.meres_file)
+
+
+def main(mt: str, out: str, intervals: int, meres: str):
+    init_batch()
+    mt = hl.read_matrix_table(mt)
+
+    # generate rough intervals based on the rows in this MT
+    new_intervals = get_naive_intervals(mt, intervals)
+
+    # polish the intervals by dodging centromeres and telomeres
+    better_intervals = polish_intervals(new_intervals, meres)
+    with open(out, 'w') as f:
+        for contig, start, end in better_intervals:
+            f.write(f'{contig}\t{start}\t{end}\n')
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -3,27 +3,70 @@ from argparse import ArgumentParser
 
 from pyfaidx import Fasta
 
+DUP = 'DUP'
+DEL = 'DEL'
+CHRX = 'chrX'
+CHRY = 'chrY'
+CHRM = 'chrM'
+
+
+def translate_var_and_sex_to_cn(contig: str, var_type: str, genotype: str, sex: int) -> int:
+    """
+    Translate a variant and sex to a CN value
+    using CN==2 as a baseline, this is modified up or down based on the variant call
+    pull out the numbers from the genotype String
+    only need a CN for Deletion and Duplication
+
+    Args:
+        contig ():
+        var_type ():
+        genotype (): GT string, e.g. 0/1, 0|1, 1|0
+        sex (int): 0=Unknown, 1=Male, 2=Female
+
+    Returns:
+        int, the CN value (copy number)
+    """
+
+    # determine the baseline copy number
+    # conditions where the copy number is 1
+    if sex == 1 and contig in [CHRX, CHRY]:
+        copy_number = 1
+    elif sex == 2 and contig == CHRY:
+        copy_number = 0
+    else:
+        copy_number = 2
+
+    if (var_type not in (DUP, DEL)) or contig == CHRM:
+        return copy_number
+
+    # find the number of copies of the variant. Normalised variants, so only one alt
+    num_alt = genotype.count('1')
+
+    # reduce or increase the copy number based on the genotype, depending on the variant type
+    if var_type == DUP:
+        copy_number += num_alt
+    elif var_type == DEL:
+        copy_number -= num_alt
+    return copy_number
+
 
 def cli_main():
     parser = ArgumentParser(description='CLI for the Sniffles VCF modification script')
     parser.add_argument('--vcf_in', help='Path to a localised VCF, this will be modified', required=True)
     parser.add_argument('--vcf_out', help='Path to an output location for the modified VCF', required=True)
     parser.add_argument('--fa', help='Path to a FASTA sequence file for GRCh38', required=True)
-    parser.add_argument('--fai', help='Path to a FASTA.fai sequence index file for GRCh38', required=True)
     parser.add_argument('--ext_id', help='Path to the Sample ID in the input VCF', default=None)
     parser.add_argument('--int_id', help='Path to the Sample ID we want in the output VCF', default=None)
-    args, unknown = parser.parse_known_args()
-
-    if unknown:
-        raise ValueError(f'Unknown input flag(s) used: {unknown}')
+    parser.add_argument('--sex', help='0=Unknown,1=Male, 2=Female', default=0, type=int)
+    args = parser.parse_args()
 
     modify_sniffles_vcf(
         file_in=args.vcf_in,
         file_out=args.vcf_out,
         fa=args.fa,
-        fa_fai=args.fai,
         ext_id=args.ext_id,
         int_id=args.int_id,
+        sex=args.sex,
     )
 
 
@@ -31,9 +74,9 @@ def modify_sniffles_vcf(
     file_in: str,
     file_out: str,
     fa: str,
-    fa_fai: str,
     ext_id: str | None = None,
     int_id: str | None = None,
+    sex: int = 0,
 ):
     """
     Scrolls through the VCF and performs a few updates:
@@ -47,14 +90,14 @@ def modify_sniffles_vcf(
     Args:
         file_in (str): localised, VCF directly from Sniffles
         file_out (str): local batch output path, same VCF with INFO/ALT alterations
-        fa (str): path to a reference FastA file
-        fa_fai (str): path to the FA index
+        fa (str): path to a reference FastA file, requires an implicit fa.fai index
         ext_id (str): external ID to replace (if found)
         int_id (str): CPG ID, required inside the reformatted VCF
+        sex (int): 0=Unknown, 1=Male, 2=Female
     """
 
     # as_raw as a specifier here means that get_seq queries are just the sequence, no contig ID attached
-    fasta_client = Fasta(filename=fa, indexname=fa_fai, as_raw=True)
+    fasta_client = Fasta(filename=fa, as_raw=True)
 
     # read and write compressed. This is only a single sample VCF, but... it's good practice
     with gzip.open(file_in, 'rt') as f, gzip.open(file_out, 'wt') as f_out:
@@ -66,6 +109,9 @@ def modify_sniffles_vcf(
 
             # alter the sample line in the header
             if line.startswith('#'):
+                if 'FORMAT=<ID=ID' in line:
+                    f_out.write('##FORMAT=<ID=GCN,Number=1,Type=Integer,Description="Copy number of this variant">')
+
                 if line.startswith('#CHR') and (ext_id and int_id):
                     print(line)
                     line = line.replace(ext_id, int_id)
@@ -76,7 +122,7 @@ def modify_sniffles_vcf(
                 continue
 
             # for non-header lines, split on tabs
-            l_split = line.split('\t')
+            l_split = line.rstrip().split('\t')
 
             # set the reference allele to be the correct reference base
             chrom = l_split[0]
@@ -100,6 +146,18 @@ def modify_sniffles_vcf(
             # get the SVTYPE, always present
             sv_type = info_dict['SVTYPE']
 
+            # pull out the GT section of the FORMAT field
+            gt_string = dict(zip(l_split[8].split(':'), l_split[9].split(':')))['GT']
+
+            # determine the copy number, based on deviation from the baseline
+            copy_number = translate_var_and_sex_to_cn(contig=chrom, var_type=sv_type, genotype=gt_string, sex=sex)
+
+            # update the FORMAT schema field
+            l_split[8] = f'{l_split[8]}:CN'
+
+            # update the FORMAT content field
+            l_split[9] = f'{l_split[9]}:{copy_number}'
+
             # replace the alt with a symbolic String
             l_split[4] = f'<{sv_type}>'
 
@@ -117,7 +175,7 @@ def modify_sniffles_vcf(
             l_split[2] = f'{sv_type}_{chrom}_{position}_{end_position}'
 
             # rebuild the string and write as output
-            f_out.write('\t'.join(l_split))
+            f_out.write('\t'.join(l_split) + '\n')
 
 
 if __name__ == '__main__':

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -94,7 +94,7 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, new_id: str | None
             # alter the sample line in the header
             if line.startswith('#'):
                 if 'FORMAT=<ID=ID' in line:
-                    f_out.write('##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number of this variant">\n')
+                    f_out.write('##FORMAT=<ID=RD_CN,Number=1,Type=Integer,Description="Copy number of this variant">\n')
 
                 if line.startswith('#CHR') and new_id:
                     l_split = line.rstrip().split('\t')

--- a/cpg_workflows/stages/fastqc.py
+++ b/cpg_workflows/stages/fastqc.py
@@ -37,8 +37,7 @@ def _collect_fastq_outs(sequencing_group: SequencingGroup) -> list[OneFastqc]:
     """
     Collect input and output paths for FASTQC for all paths in alignment inputs.
     """
-    sequencing_type = get_config()['workflow']['sequencing_type']
-    if not (alignment_input := sequencing_group.alignment_input_by_seq_type.get(sequencing_type)):
+    if not (alignment_input := sequencing_group.alignment_input):
         # Only running FASTQC if sequencing inputs are available.
         return []
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -3,6 +3,7 @@ All post-batching stages of the GATK-SV workflow
 """
 
 from functools import cache
+from itertools import combinations
 from typing import Any
 
 from google.api_core.exceptions import PermissionDenied
@@ -102,12 +103,49 @@ class MakeCohortCombinedPed(CohortStage):
         return self.make_outputs(target=cohort, data=output)
 
 
+def check_for_cohort_overlaps(multicohort: MultiCohort):
+    """
+    Check for overlapping cohorts in a MultiCohort.
+    GATK-SV does not tolerate overlapping cohorts, so we check for this here.
+    This is called once per MultiCohort, and raises an Exception if any overlaps are found
+
+    Args:
+        multicohort (MultiCohort): the MultiCohort to check
+    """
+    # placeholder for errors
+    errors: list[str] = []
+    sgs_per_cohort: dict[str, set[str]] = {}
+    # grab all SG IDs per cohort
+    for cohort in multicohort.get_cohorts():
+        # shouldn't be possible, but guard against to be sure
+        if cohort.name in sgs_per_cohort:
+            raise ValueError(f'Cohort {cohort.name} already exists in {sgs_per_cohort}')
+
+        # collect the SG IDs for this cohort
+        sgs_per_cohort[cohort.name] = set(cohort.get_sequencing_group_ids())
+
+    # pairwise iteration over cohort IDs
+    for id1, id2 in combinations(sgs_per_cohort, 2):
+        # if the IDs are the same, skip. Again, shouldn't be possible, but guard against to be sure
+        if id1 == id2:
+            continue
+        # if there are overlapping SGs, raise an error
+        if overlap := sgs_per_cohort[id1] & sgs_per_cohort[id2]:
+            errors.append(f'Overlapping cohorts {id1} and {id2} have overlapping SGs: {overlap}')
+    # upon findings any errors, raise an Exception and die
+    if errors:
+        raise ValueError('\n'.join(errors))
+
+
 @stage
 class MakeMultiCohortCombinedPed(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
         return {'multicohort_ped': self.prefix / 'ped_with_ref_panel.ped'}
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
+        # check that there are no overlapping cohorts
+        check_for_cohort_overlaps(multicohort)
+
         output = self.expected_outputs(multicohort)
         # write the pedigree, if it doesn't already exist
         if not to_path(output['multicohort_ped']).exists():

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -36,8 +36,8 @@ def vds_version() -> str:
     if not (vds_version_str := get_config()['workflow'].get('vds_version')):
         return get_workflow().output_version
     vds_version_str = slugify(vds_version_str)
-    if not vds_version_str.startswith('v'):
-        vds_version_str = f'v{vds_version_str}'
+    # if not vds_version_str.startswith('v'):
+    #     vds_version_str = f'v{vds_version_str}'
     return vds_version_str
 
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -454,6 +454,13 @@ class AncestryPCA(CohortStage):
 @stage(required_stages=[AncestryPCA, SampleQC])
 class AncestryInfer(CohortStage):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
+            self.required_stages_classes.append(AncestryAddBackground)
+
+        logging.info(f'AncestryInfer required stages: {self.required_stages_classes}')
+
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
 
         ancestry_prefix = get_workflow().prefix / 'ancestry'

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -442,7 +442,7 @@ class Ancestry(CohortStage):
         return self.make_outputs(cohort, self.expected_outputs(cohort), [j])
 
 
-@stage(required_stages=[SampleQC, Ancestry, RelatednessFlag])
+@stage(required_stages=[SampleQC, AncestryInfer, RelatednessFlag])
 class AncestryPlots(CohortStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -52,13 +52,14 @@ def dense_subset_version() -> str:
 
 
 @cache
-def dense_background_vds_version() -> str:
+def dense_background_vds_version(dataset: str) -> str:
     """
     generate the dense_background version
     """
+    dataset = dataset.replace('-', '_')
     if not (
         dense_bg_vds_version_str := config_retrieve(
-            ['large_cohort', 'output_versions', 'dense_background'],
+            ['large_cohort', 'output_versions', f'{dataset}_dense_background'],
             default=None,
         )
     ):
@@ -295,16 +296,15 @@ class DenseBackground(CohortStage):
         # no datasets, no running
         if not (background_datasets := config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)):
             return self.make_outputs(target=cohort)
-        # construct input paths
-        # TODO: Allow for input background datasets to be '.mt' files
-        background_vds_version = dense_background_vds_version()
 
+        # construct input paths
         input_paths = {
             dataset: to_path(
                 config_retrieve(['storage', dataset, 'default']),
             )
             / 'vds'
-            / f'{background_vds_version}.vds'
+            # TODO: Allow for input background datasets to be '.mt' files
+            / f'{dense_background_vds_version(dataset)}.vds'
             for dataset in background_datasets
         }
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -279,9 +279,11 @@ class DenseBackground(CohortStage):
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        access_level = config_retrieve(['workflow', 'access_level'])
         background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: dict[str, Path] = {
-            dataset: Path(config_retrieve(['storage', dataset, 'default'])) for dataset in background_datasets
+            dataset: Path(config_retrieve(['storage', dataset.split(f'-{access_level}'), 'default']))
+            for dataset in background_datasets
         }
         return {
             bg_dataset: background_storage_paths[bg_dataset] / 'dense' / 'dense.mt'

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -334,7 +334,7 @@ class DenseBackground(CohortStage):
                 'densify_background_dataset '
                 f'--background-vds {str(input_paths[bg_dataset])} '
                 f'--qc-variants-table {qc_variants_ht}'
-                f'--dense-out {str(outputs[f"{bg_dataset}_dense_mt"])} '
+                f'--dense-out {str(outputs[bg_dataset])} '
                 f'--tmp {str(self.tmp_prefix)} ',
             )
             jobs.append(job)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -436,7 +436,7 @@ class AncestryPCA(CohortStage):
         return self.make_outputs(target=cohort, data=outputs, jobs=job)
 
 
-@stage(required_stages=[AncestryPCA, SampleQC, AncestryAddBackground])
+@stage(required_stages=[AncestryPCA, SampleQC])
 class AncestryInfer(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -187,9 +187,8 @@ class RelatednessPCRelate(CohortStage):
         t_shirt_size_value = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(cohort.get_sequencing_group_ids()),
-        ).split('Gi')[0]
-        required_storage_value = int(t_shirt_size_value) * 2
-        required_storage = f'{t_shirt_size_value*2}Gi'
+        )
+        required_storage = f'{t_shirt_size_value * 2}Gi'
 
         # create a job
         job = get_batch().new_job(f'Run Relatedness PCRelate stage: {cohort.name}')
@@ -242,9 +241,8 @@ class RelatednessFlag(CohortStage):
         t_shirt_size_value = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(cohort.get_sequencing_group_ids()),
-        ).split('Gi')[0]
-        required_storage_value = int(t_shirt_size_value) * 2
-        required_storage = f'{t_shirt_size_value*2}Gi'
+        )
+        required_storage = f'{t_shirt_size_value * 2}Gi'
 
         # create a job
         job = get_batch().new_job(f'Run Relatedness Sample Flagging stage: {cohort.name}')

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -381,7 +381,7 @@ class AncestryAddBackground(CohortStage):
         return self.make_outputs(target=cohort, jobs=job, data=outputs)
 
 
-@stage(required_stages=[SampleQC, RelatednessFlag, DenseSubset])
+@stage(required_stages=[SampleQC, RelatednessFlag, DenseSubset, AncestryAddBackground])
 class AncestryPCA(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         ancestry_prefix = get_workflow().prefix / 'ancestry'

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -290,11 +290,8 @@ class DenseBackground(CohortStage):
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
         # no datasets, no running
-        if not config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
+        if not (background_datasets := config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)):
             return self.make_outputs(target=cohort)
-
-        # inputs
-        background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: list[Path] = [
             Path(config_retrieve(['storage', dataset, 'default']) for dataset in background_datasets),
         ]

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -164,7 +164,10 @@ class DenseSubset(CohortStage):
 @stage(required_stages=DenseSubset, analysis_keys=['relatedness_ht'], analysis_type='custom')
 class RelatednessPCRelate(CohortStage):
     """
-    This is the first step of the Relatedness Stage, without Dataproc
+     This is the first step of the Relatedness Stage.
+
+    This stage calculates relatedness between samples using the PC-Relate method.
+    It uses a dense matrix table (MT) as input and produces a Hail table (HT) with relatedness metrics.
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
@@ -220,6 +223,9 @@ class RelatednessPCRelate(CohortStage):
     analysis_type='custom',
 )
 class RelatednessFlag(CohortStage):
+    """
+    The second step of Relatedness calculation. This stage flags related samples to drop.
+    """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
@@ -278,7 +284,10 @@ class RelatednessFlag(CohortStage):
 @stage()
 class DenseBackground(CohortStage):
     """
-    Will densify a background dataset such as 1KG, HGDP, or 1KG-HGDP
+    Will densify a background dataset such as 1KG, HGDP, or 1KG-HGDP.
+    This stage is run infrequently and only when the background dataset is updated.
+    The densified background dataset is saved to that dataset's bucket as 'dense.mt'.
+    Users can specify multiple background datasets to densify which will be saved to their respective buckets.
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
@@ -341,7 +350,7 @@ class DenseBackground(CohortStage):
 @stage(required_stages=[DenseSubset, SampleQC, DenseBackground])
 class AncestryAddBackground(CohortStage):
     """
-    optional stage, runs if we need to annotate with background datasets
+    Optional stage that adds a background dataset to the dense MT and sample QC HT.
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -473,7 +473,7 @@ class AncestryInfer(CohortStage):
             f'--scores_ht "${{BATCH_TMPDIR}}/{scores_name}" '
             f'--qc_in "${{BATCH_TMPDIR}}/{sample_qc_name}" '
             f'--qc_out {job.qc} '
-            f'--ht_out {job.ht} '
+            f'--pop_ht_out {job.ht} '
             f'--pickle_out {job.pickle} '
             f'--txt_out {job.txt} ',
         )

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -282,7 +282,7 @@ class DenseBackground(CohortStage):
         access_level = config_retrieve(['workflow', 'access_level'])
         background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: dict[str, Path] = {
-            dataset: Path(config_retrieve(['storage', dataset.split(f'-{access_level}'), 'default']))
+            dataset: Path(config_retrieve(['storage', dataset.split(f'-{access_level}')[:-1], 'default']))
             for dataset in background_datasets
         }
         return {

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -394,9 +394,9 @@ class AncestryPCA(CohortStage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
-            self.required_stages.append(AncestryAddBackground)
+            self.required_stages_classes.append(AncestryAddBackground)
 
-        logging.info(f'AncestryPCA required stages: {self.required_stages}')
+        logging.info(f'AncestryPCA required stages: {self.required_stages_classes}')
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         ancestry_prefix = get_workflow().prefix / 'ancestry'

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -1,7 +1,7 @@
 import logging
 from functools import cache
 
-from cpg_utils import Path
+from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
 from cpg_workflows.targets import Cohort

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -355,14 +355,14 @@ class AncestryAddBackground(CohortStage):
         # inputs
         dense_mt_path = inputs.as_path(cohort, DenseSubset)
         sample_qc_ht_path = inputs.as_path(cohort, SampleQC)
-        dense_background_mt_path_dict = dict(inputs.as_dict_by_target(DenseBackground)).items()
+        dense_background_mt_path_dict: dict = inputs.as_dict(cohort, DenseBackground)
 
         # expected outputs
         outputs = self.expected_outputs(cohort)
 
         # Construct the background dataset parameters
         background_datasets = ' '.join(
-            f'--background_dataset {name}={str(path)}' for name, path in dict(dense_background_mt_path_dict).items()
+            f'--background_dataset {name}={str(path)}' for name, path in dense_background_mt_path_dict
         )
 
         # job runs QOB, shouldn't need many resources itself

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -355,7 +355,7 @@ class AncestryAddBackground(CohortStage):
         # inputs
         dense_mt_path = inputs.as_path(cohort, DenseSubset)
         sample_qc_ht_path = inputs.as_path(cohort, SampleQC)
-        dense_background_mt_path_dict = inputs.as_path_dict_by_target(DenseBackground)
+        dense_background_mt_path_dict = inputs.as_dict_by_target(DenseBackground)
 
         # expected outputs
         outputs = self.expected_outputs(cohort)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -282,7 +282,7 @@ class DenseBackground(CohortStage):
         access_level = config_retrieve(['workflow', 'access_level'])
         background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: dict[str, Path] = {
-            dataset: Path(config_retrieve(['storage', dataset.split(f'-{access_level}')[:-1], 'default']))
+            dataset: Path(config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}'))[:-1], 'default']))
             for dataset in background_datasets
         }
         return {

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -279,11 +279,10 @@ class DenseBackground(CohortStage):
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        access_level = config_retrieve(['workflow', 'access_level'])
         background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: dict[str, Path] = {
             dataset: to_path(
-                config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}')[:-1]), 'default']),
+                config_retrieve(['storage', dataset, 'default']),
             )
             for dataset in background_datasets
         }
@@ -299,11 +298,10 @@ class DenseBackground(CohortStage):
         # construct input paths
         # TODO: Allow for input background datasets to be '.mt' files
         background_vds_version = dense_background_vds_version()
-        access_level = config_retrieve(['workflow', 'access_level'])
 
         input_paths = {
             dataset: to_path(
-                config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}')[:-1]), 'default']),
+                config_retrieve(['storage', dataset, 'default']),
             )
             / 'vds'
             / f'{background_vds_version}.vds'

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -391,8 +391,8 @@ class AncestryPCA(CohortStage):
     If not, will bypass adding background and run on the dense MT with the related samples removed.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
             self.required_stages.append(AncestryAddBackground)
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -381,7 +381,7 @@ class AncestryAddBackground(CohortStage):
         return self.make_outputs(target=cohort, jobs=job, data=outputs)
 
 
-@stage(required_stages=[SampleQC, RelatednessFlag, DenseSubset, AncestryAddBackground])
+@stage(required_stages=[SampleQC, RelatednessFlag, DenseSubset])
 class AncestryPCA(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         ancestry_prefix = get_workflow().prefix / 'ancestry'

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -282,7 +282,9 @@ class DenseBackground(CohortStage):
         access_level = config_retrieve(['workflow', 'access_level'])
         background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: dict[str, Path] = {
-            dataset: Path(config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}')[:-1]), 'default']))
+            dataset: to_path(
+                config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}')[:-1]), 'default']),
+            )
             for dataset in background_datasets
         }
         return {

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -280,7 +280,7 @@ class DenseBackground(CohortStage):
     """
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
+        background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], [])
         background_storage_paths: dict[str, Path] = {
             dataset: to_path(
                 config_retrieve(['storage', dataset, 'default']),

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -408,7 +408,7 @@ class AncestryPCA(CohortStage):
         # big job
         job = get_batch().new_bash_job('Run Ancestry PCA')
         job.image(config_retrieve(['workflow', 'driver_image']))
-        job.storage('50gi').memory('highmem').cpu(config_retrieve(['Ancestry', 'cores'], 8))
+        job.storage('50Gi').memory('highmem').cpu(config_retrieve(['Ancestry', 'cores'], 8))
 
         # localise the Dense MT
         dense_name = dense_mt_path.split('/')[-1]

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -355,14 +355,14 @@ class AncestryAddBackground(CohortStage):
         # inputs
         dense_mt_path = inputs.as_path(cohort, DenseSubset)
         sample_qc_ht_path = inputs.as_path(cohort, SampleQC)
-        dense_background_mt_path_dict = inputs.as_dict_by_target(DenseBackground)
+        dense_background_mt_path_dict = dict(inputs.as_dict_by_target(DenseBackground)).items()
 
         # expected outputs
         outputs = self.expected_outputs(cohort)
 
         # Construct the background dataset parameters
         background_datasets = ' '.join(
-            f'--background_dataset {name}={str(path)}' for name, path in dense_background_mt_path_dict.items()
+            f'--background_dataset {name}={str(path)}' for name, path in dict(dense_background_mt_path_dict).items()
         )
 
         # job runs QOB, shouldn't need many resources itself

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -5,7 +5,7 @@ from cpg_utils import Path
 from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
 from cpg_workflows.targets import Cohort
-from cpg_workflows.utils import ExpectedResultT, slugify, tshirt_mt_sizing
+from cpg_workflows.utils import slugify, tshirt_mt_sizing
 from cpg_workflows.workflow import CohortStage, StageInput, StageOutput, get_workflow, stage
 
 from .genotype import Genotype

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -312,7 +312,6 @@ class DenseBackground(CohortStage):
 
         # localise QC variants table
         qc_variants_ht = config_retrieve(['references', 'ancestry', 'sites_table'])
-        job.command(f'gcloud --no-user-output-enabled storage cp -r {qc_variants_ht} $BATCH_TMPDIR')
 
         # jobs
         jobs = []

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -356,13 +356,14 @@ class AncestryAddBackground(CohortStage):
         dense_mt_path = inputs.as_path(cohort, DenseSubset)
         sample_qc_ht_path = inputs.as_path(cohort, SampleQC)
         dense_background_mt_path_dict: dict = inputs.as_dict(cohort, DenseBackground)
+        logging.info(f'Background datasets: {dense_background_mt_path_dict}')
 
         # expected outputs
         outputs = self.expected_outputs(cohort)
 
         # Construct the background dataset parameters
         background_datasets = ' '.join(
-            f'--background_dataset {name}={str(path)}' for name, path in dense_background_mt_path_dict
+            f'--background_dataset {name}={str(path)}' for name, path in dense_background_mt_path_dict.items()
         )
 
         # job runs QOB, shouldn't need many resources itself

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -385,6 +385,17 @@ class AncestryAddBackground(CohortStage):
 
 @stage(required_stages=[SampleQC, RelatednessFlag, DenseSubset])
 class AncestryPCA(CohortStage):
+    """
+    Run PCA on the dense MT to get the scores, eigenvalues, and loadings.
+    Will run on the dense MT with the background dataset added if large_cohort.pca_background.datasets is set.
+    If not, will bypass adding background and run on the dense MT with the related samples removed.
+    """
+
+    def __init__(self):
+        super().__init__()
+        if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
+            self.required_stages.append(AncestryAddBackground)
+
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         ancestry_prefix = get_workflow().prefix / 'ancestry'
         return {

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -457,7 +457,7 @@ class AncestryInfer(CohortStage):
         scores_table = str(inputs.as_path(cohort, AncestryPCA, 'scores'))
 
         # big job
-        job = get_batch().new_bash_job('Run Ancestry PCA')
+        job = get_batch().new_bash_job('Ancestry Infer Populations')
         job.image(config_retrieve(['workflow', 'driver_image']))
         job.storage('50Gi').memory('highmem').cpu(config_retrieve(['Ancestry', 'cores'], 8))
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -388,6 +388,7 @@ class AncestryPCA(CohortStage):
     """
     Run PCA on the dense MT to get the scores, eigenvalues, and loadings.
     Will run on the dense MT with the background dataset added if large_cohort.pca_background.datasets is set.
+        - Does this by directly appending to the class `Stage` requiresd_stages_classes.
     If not, will bypass adding background and run on the dense MT with the related samples removed.
     """
 
@@ -395,8 +396,6 @@ class AncestryPCA(CohortStage):
         super().__init__(*args, **kwargs)
         if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
             self.required_stages_classes.append(AncestryAddBackground)
-
-        logging.info(f'AncestryPCA required stages: {self.required_stages_classes}')
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         ancestry_prefix = get_workflow().prefix / 'ancestry'
@@ -458,8 +457,6 @@ class AncestryInfer(CohortStage):
         super().__init__(*args, **kwargs)
         if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
             self.required_stages_classes.append(AncestryAddBackground)
-
-        logging.info(f'AncestryInfer required stages: {self.required_stages_classes}')
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -282,7 +282,7 @@ class DenseBackground(CohortStage):
         access_level = config_retrieve(['workflow', 'access_level'])
         background_datasets: list[str] = config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)
         background_storage_paths: dict[str, Path] = {
-            dataset: Path(config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}'))[:-1], 'default']))
+            dataset: Path(config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}')[:-1]), 'default']))
             for dataset in background_datasets
         }
         return {

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -184,7 +184,8 @@ class RelatednessPCRelate(CohortStage):
         t_shirt_size_value = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(cohort.get_sequencing_group_ids()),
-        )
+        ).split('Gi')[0]
+        required_storage_value = int(t_shirt_size_value) * 2
         required_storage = f'{t_shirt_size_value*2}Gi'
 
         # create a job
@@ -235,8 +236,9 @@ class RelatednessFlag(CohortStage):
         t_shirt_size_value = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(cohort.get_sequencing_group_ids()),
-        )
-        required_storage = f'{t_shirt_size_value * 2}Gi'
+        ).split('Gi')[0]
+        required_storage_value = int(t_shirt_size_value) * 2
+        required_storage = f'{t_shirt_size_value*2}Gi'
 
         # create a job
         job = get_batch().new_job(f'Run Relatedness Sample Flagging stage: {cohort.name}')

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -460,7 +460,7 @@ class AncestryInfer(CohortStage):
         # big job
         job = get_batch().new_bash_job('Run Ancestry PCA')
         job.image(config_retrieve(['workflow', 'driver_image']))
-        job.storage('50gi').memory('highmem').cpu(config_retrieve(['Ancestry', 'cores'], 8))
+        job.storage('50Gi').memory('highmem').cpu(config_retrieve(['Ancestry', 'cores'], 8))
 
         sample_qc_name = sample_qc_ht_path.split('/')[-1]
         job.command(f'gcloud --no-user-output-enabled storage cp -r {sample_qc_ht_path} $BATCH_TMPDIR')

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -165,9 +165,8 @@ class RelatednessPCRelate(CohortStage):
         t_shirt_size_value = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(cohort.get_sequencing_group_ids()),
-        ).split('Gi')[0]
-        required_storage_value = int(t_shirt_size_value) * 2
-        required_storage = f'{required_storage_value}Gi'
+        )
+        required_storage = f'{t_shirt_size_value*2}Gi'
 
         # create a job
         job = get_batch().new_job(f'Run Relatedness PCRelate stage: {cohort.name}')
@@ -217,9 +216,8 @@ class RelatednessFlag(CohortStage):
         t_shirt_size_value = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(cohort.get_sequencing_group_ids()),
-        ).split('Gi')[0]
-        required_storage_value = int(t_shirt_size_value) * 2
-        required_storage = f'{required_storage_value}Gi'
+        )
+        required_storage = f'{t_shirt_size_value * 2}Gi'
 
         # create a job
         job = get_batch().new_job(f'Run Relatedness Sample Flagging stage: {cohort.name}')

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -396,6 +396,8 @@ class AncestryPCA(CohortStage):
         if config_retrieve(['large_cohort', 'pca_background', 'datasets'], False):
             self.required_stages.append(AncestryAddBackground)
 
+        logging.info(f'AncestryPCA required stages: {self.required_stages}')
+
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         ancestry_prefix = get_workflow().prefix / 'ancestry'
         return {

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -356,7 +356,6 @@ class AncestryAddBackground(CohortStage):
         dense_mt_path = inputs.as_path(cohort, DenseSubset)
         sample_qc_ht_path = inputs.as_path(cohort, SampleQC)
         dense_background_mt_path_dict: dict = inputs.as_dict(cohort, DenseBackground)
-        logging.info(f'Background datasets: {dense_background_mt_path_dict}')
 
         # expected outputs
         outputs = self.expected_outputs(cohort)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -5,7 +5,7 @@ from cpg_utils import Path
 from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
 from cpg_workflows.targets import Cohort
-from cpg_workflows.utils import slugify, tshirt_mt_sizing, ExpectedResultT
+from cpg_workflows.utils import ExpectedResultT, slugify, tshirt_mt_sizing
 from cpg_workflows.workflow import CohortStage, StageInput, StageOutput, get_workflow, stage
 
 from .genotype import Genotype
@@ -261,6 +261,7 @@ class AncestryAddBackground(CohortStage):
     """
     optional stage, runs if we need to annotate with background datasets
     """
+
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
             'bg_qc_ht': cohort.analysis_dataset.prefix() / get_workflow().name / sample_qc_version() / 'sample_qc.ht',
@@ -288,7 +289,7 @@ class AncestryAddBackground(CohortStage):
             f'--dense_in {str(dense_mt_path)} '
             f'--qc_out {str(outputs["bg_qc_ht"])} '
             f'--dense_out {str(outputs["bg_dense_mt"])} '
-            f'--tmp {str(self.tmp_prefix)} '
+            f'--tmp {str(self.tmp_prefix)} ',
         )
 
         return self.make_outputs(target=cohort, jobs=job, data=outputs)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -292,16 +292,12 @@ class DenseBackground(CohortStage):
         # no datasets, no running
         if not (background_datasets := config_retrieve(['large_cohort', 'pca_background', 'datasets'], False)):
             return self.make_outputs(target=cohort)
-        background_storage_paths: list[Path] = [
-            Path(config_retrieve(['storage', dataset, 'default']) for dataset in background_datasets),
-        ]
-
         # construct input paths
         # TODO: Allow for input background datasets to be '.mt' files
         background_vds_version = dense_background_vds_version()
         input_paths = {
-            bg_dataset: background_storage_paths[i] / 'vds' / f'{background_vds_version}.vds'
-            for i, bg_dataset in enumerate(background_datasets)
+            dataset: to_path(config_retrieve(['storage', dataset, 'default'])) / 'vds' / f'{background_vds_version}.vds'
+            for dataset in background_datasets
         }
 
         job = get_batch().new_job(f'Densify {", ".join(background_datasets)} background datasets')

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -313,10 +313,6 @@ class DenseBackground(CohortStage):
         job = get_batch().new_job(f'Densify {", ".join(background_datasets)} background datasets')
         job.storage('500Gi').image(config_retrieve(['workflow', 'driver_image']))
 
-        # localise the Dense MT
-        for bacgkround_vds in input_paths.values():
-            job.command(f'gcloud --no-user-output-enabled storage cp -r {bacgkround_vds} $BATCH_TMPDIR')
-
         # expected outputs
         outputs = self.expected_outputs(cohort)
 
@@ -333,7 +329,7 @@ class DenseBackground(CohortStage):
             job.command(
                 'densify_background_dataset '
                 f'--background-vds {str(input_paths[bg_dataset])} '
-                f'--qc-variants-table {qc_variants_ht}'
+                f'--qc-variants-table {qc_variants_ht} '
                 f'--dense-out {str(outputs[bg_dataset])} '
                 f'--tmp {str(self.tmp_prefix)} ',
             )

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -355,7 +355,7 @@ class AncestryAddBackground(CohortStage):
         # inputs
         dense_mt_path = inputs.as_path(cohort, DenseSubset)
         sample_qc_ht_path = inputs.as_path(cohort, SampleQC)
-        dense_background_mt_path_dict = inputs.as_path(cohort, DenseBackground)
+        dense_background_mt_path_dict = inputs.as_path_dict_by_target(DenseBackground)
 
         # expected outputs
         outputs = self.expected_outputs(cohort)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -299,8 +299,14 @@ class DenseBackground(CohortStage):
         # construct input paths
         # TODO: Allow for input background datasets to be '.mt' files
         background_vds_version = dense_background_vds_version()
+        access_level = config_retrieve(['workflow', 'access_level'])
+
         input_paths = {
-            dataset: to_path(config_retrieve(['storage', dataset, 'default'])) / 'vds' / f'{background_vds_version}.vds'
+            dataset: to_path(
+                config_retrieve(['storage', ('-').join(dataset.split(f'-{access_level}')[:-1]), 'default']),
+            )
+            / 'vds'
+            / f'{background_vds_version}.vds'
             for dataset in background_datasets
         }
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -264,8 +264,11 @@ class AncestryAddBackground(CohortStage):
 
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         return {
-            'bg_qc_ht': cohort.analysis_dataset.prefix() / get_workflow().name / sample_qc_version() / 'sample_qc.ht',
-            'bg_dense_mt': cohort.analysis_dataset.prefix() / get_workflow().name / sample_qc_version() / 'dense.mt',
+            'bg_qc_ht': cohort.analysis_dataset.prefix()
+            / get_workflow().name
+            / sample_qc_version()
+            / 'bg_sample_qc.ht',
+            'bg_dense_mt': cohort.analysis_dataset.prefix() / get_workflow().name / sample_qc_version() / 'bg_dense.mt',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -207,14 +207,14 @@ class MtToEs(DatasetStage):
         index_name = str(outputs['index_name'])
         flag_name = str(outputs['done_flag'])
 
-        job = get_batch().new_job(f'Generate {index_name} from {mt_path}')
+        job = get_batch().new_bash_job(f'Generate {index_name} from {mt_path}')
 
-        required_storage = tshirt_mt_sizing(
+        req_storage = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(dataset.get_sequencing_group_ids()),
         )
 
-        job.cpu(4).storage(f'{required_storage}Gi').memory('lowmem')
+        job.cpu(4).storage(f'{req_storage}Gi').memory('lowmem').image(config_retrieve(['workflow', 'driver_image']))
 
         # localise the MT
         job.command(f'gcloud --no-user-output-enabled storage cp -r {mt_path} $BATCH_TMPDIR')

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -214,7 +214,7 @@ class MtToEs(DatasetStage):
             cohort_size=len(dataset.get_sequencing_group_ids()),
         )
 
-        job.cpu(4).storage(required_storage).memory('lowmem')
+        job.cpu(4).storage(f'{required_storage}Gi').memory('lowmem')
 
         # localise the MT
         job.command(f'gcloud --no-user-output-enabled storage cp -r {mt_path} $BATCH_TMPDIR')

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -45,7 +45,10 @@ class BamToCram(SequencingGroupStage):
         Using the existing `bam_to_cram` function from the `jobs` module.
         """
         b = get_batch()
-        input_bam = b.read_input_group(bam=str(sequencing_group.alignment_input_by_seq_type.get('genome')))
+        assert (
+            sequencing_group.sequencing_type == 'genome'
+        ), f'Only genome sequencing type is supported for BAM to CRAM conversion, unavailable for {sequencing_group.id}'
+        input_bam = b.read_input_group(bam=str(sequencing_group.alignment_input))
         job, output_cram = bam_to_cram.bam_to_cram(
             b=get_batch(),
             input_bam=input_bam,

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -112,8 +112,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             'modify_sniffles '
             f'--vcf_in {local_vcf} '
             f'--vcf_out {mod_job.output} '
-            f'--ext_id {sg.external_id} '
-            f'--int_id {sg.id} '
+            f'--new_id {sg.id} '
             f'--fa {fasta} '
             f'--sex {sex} ',
         )

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -79,7 +79,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             'index': sgid_prefix / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz.tbi',
         }
 
-    def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:
+    def queue_jobs(self, sg: SequencingGroup, inputs: StageInput) -> StageOutput:
         """
         a python job to change the VCF contents
         - use a python job to modify all VCF lines, in-line
@@ -87,48 +87,48 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         """
 
         # find the vcf for this SG
-        query_result = query_for_sv_vcfs(dataset_name=sequencing_group.dataset.name)
+        query_result = query_for_sv_vcfs(dataset_name=sg.dataset.name)
 
-        expected_outputs = self.expected_outputs(sequencing_group)
+        expected_outputs = self.expected_outputs(sg)
 
         # instead of handling, we should probably just exclude this and run again
-        if sequencing_group.id not in query_result:
-            raise ValueError(f'No SV VCFs recorded for {sequencing_group.id}')
+        if sg.id not in query_result:
+            raise ValueError(f'No SV VCFs recorded for {sg.id}')
 
-        lr_sv_vcf: str = query_result[sequencing_group.id]
+        lr_sv_vcf: str = query_result[sg.id]
         local_vcf = get_batch().read_input(lr_sv_vcf)
 
-        modifier_job = get_batch().new_bash_job(f'Convert {lr_sv_vcf} prior to annotation')
-        modifier_job.storage('10Gi')
-        modifier_job.image(config_retrieve(['workflow', 'driver_image']))
+        mod_job = get_batch().new_bash_job(f'Convert {lr_sv_vcf} prior to annotation')
+        mod_job.storage('10Gi')
+        mod_job.image(config_retrieve(['workflow', 'driver_image']))
 
         # mandatory argument
         ref_fasta = config_retrieve(['workflow', 'ref_fasta'])
-        fasta = get_batch().read_input_group(fa=ref_fasta, fai=f'{ref_fasta}.fai')
+        fasta = get_batch().read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
 
         # the console entrypoint for the sniffles modifier script has only existed since 1.25.13, requires >=1.25.13
-        modifier_job.command(
-            f'modify_sniffles '
+        mod_job.command(
+            'modify_sniffles '
             f'--vcf_in {local_vcf} '
-            f'--vcf_out {modifier_job.output} '
-            f'--ext_id {sequencing_group.external_id} '
-            f'--int_id {sequencing_group.id} '
-            f'--fa {fasta.fa} '
-            f'--fai {fasta.fai} ',
+            f'--vcf_out {mod_job.output} '
+            f'--ext_id {sg.external_id} '
+            f'--int_id {sg.id} '
+            f'--fa {fasta} '
+            f'--sex {sg.pedigree.sex} ',
         )
 
         # block-gzip and index that result
-        tabix_job = get_batch().new_job(f'BGZipping and Indexing for {sequencing_group.id}', {'tool': 'bcftools'})
+        tabix_job = get_batch().new_job(f'BGZipping and Indexing for {sg.id}', {'tool': 'bcftools'})
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         tabix_job.image(image=image_path('bcftools'))
         tabix_job.storage('10Gi')
-        tabix_job.command(f'bcftools view {modifier_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')
+        tabix_job.command(f'bcftools view {mod_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')
         tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')
 
         # write from temp storage into GCP
         get_batch().write_output(tabix_job.vcf_out, str(expected_outputs['vcf']).removesuffix('.vcf.bgz'))
 
-        return self.make_outputs(target=sequencing_group, jobs=[modifier_job, tabix_job], data=expected_outputs)
+        return self.make_outputs(target=sg, jobs=[mod_job, tabix_job], data=expected_outputs)
 
 
 @stage(required_stages=ReFormatPacBioSVs)

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -107,6 +107,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         fasta = get_batch().read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
 
         # the console entrypoint for the sniffles modifier script has only existed since 1.25.13, requires >=1.25.13
+        sex = sg.pedigree.sex.value if sg.pedigree.sex else 0
         mod_job.command(
             'modify_sniffles '
             f'--vcf_in {local_vcf} '
@@ -114,7 +115,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             f'--ext_id {sg.external_id} '
             f'--int_id {sg.id} '
             f'--fa {fasta} '
-            f'--sex {sg.pedigree.sex} ',
+            f'--sex {sex} ',
         )
 
         # block-gzip and index that result

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -409,14 +409,14 @@ class RunHailFiltering(DatasetStage):
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
 
-        # MTs can vary from <10GB for a small exome, to 170GB for a larger one
-        # Genomes are more like 500GB
+        # MTs can vary from <10GB for a small exome, to 170GB for a larger one, Genomes ~500GB
         required_storage = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(dataset.get_sequencing_group_ids()),
         )
         required_cpu: int = config_retrieve(['hail', 'cores', 'small_variants'], 8)
-        job.cpu(required_cpu).storage(required_storage).memory('highmem')
+        # doubling storage due to the repartitioning
+        job.cpu(required_cpu).storage(f'{required_storage*2}Gi').memory('highmem')
 
         panelapp_json = get_batch().read_input(
             str(inputs.as_path(target=dataset, stage=QueryPanelapp, key='panel_data')),

--- a/cpg_workflows/stages/trim_align.py
+++ b/cpg_workflows/stages/trim_align.py
@@ -27,8 +27,7 @@ def get_trim_inputs(sequencing_group: SequencingGroup) -> FastqPairs | None:
     """
     Get the input FASTQ file pairs for trimming
     """
-    sequencing_type = get_config()['workflow']['sequencing_type']
-    alignment_input = sequencing_group.alignment_input_by_seq_type.get(sequencing_type)
+    alignment_input = sequencing_group.alignment_input
     if (
         not alignment_input
         or (get_config()['workflow'].get('check_inputs', True) and not alignment_input.exists())

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -46,13 +46,7 @@ class Target:
         whether the analysis on the target needs to be rerun.
         """
         s = ' '.join(
-            sorted(
-                [
-                    ' '.join(sorted(str(alignment_input) for alignment_input in s.alignment_input_by_seq_type.values()))
-                    for s in self.get_sequencing_groups()
-                    if s.alignment_input_by_seq_type
-                ],
-            ),
+            sorted(' '.join(str(s.alignment_input)) for s in self.get_sequencing_groups() if s.alignment_input),
         )
         h = hashlib.sha256(s.encode()).hexdigest()[:38]
         return f'{h}_{len(self.get_sequencing_group_ids())}'
@@ -481,12 +475,16 @@ class Dataset(Target):
     def add_sequencing_group(
         self,
         id: str,  # pylint: disable=redefined-builtin
+        *,
+        sequencing_type: str,
+        sequencing_technology: str,
+        sequencing_platform: str,
         external_id: str | None = None,
         participant_id: str | None = None,
         meta: dict | None = None,
         sex: Optional['Sex'] = None,
         pedigree: Optional['PedigreeInfo'] = None,
-        alignment_input_by_seq_type: dict[str, AlignmentInput] | None = None,
+        alignment_input: AlignmentInput | None = None,
     ) -> 'SequencingGroup':
         """
         Create a new sequencing group and add it to the dataset.
@@ -502,11 +500,14 @@ class Dataset(Target):
             id=id,
             dataset=self,
             external_id=external_id,
+            sequencing_type=sequencing_type,
+            sequencing_technology=sequencing_technology,
+            sequencing_platform=sequencing_platform,
             participant_id=participant_id,
             meta=meta,
             sex=sex,
             pedigree=pedigree,
-            alignment_input_by_seq_type=alignment_input_by_seq_type,
+            alignment_input=alignment_input,
             forced=forced,
         )
         self._sequencing_group_by_id[id] = s
@@ -603,19 +604,27 @@ class SequencingGroup(Target):
         self,
         id: str,  # pylint: disable=redefined-builtin
         dataset: 'Dataset',  # type: ignore  # noqa: F821
+        *,
+        sequencing_type: str,
+        sequencing_technology: str,
+        sequencing_platform: str,
         external_id: str | None = None,
         participant_id: str | None = None,
         meta: dict | None = None,
         sex: Sex | None = None,
         pedigree: Optional['PedigreeInfo'] = None,
-        alignment_input_by_seq_type: dict[str, AlignmentInput] | None = None,
-        assays: dict[str, tuple[Assay, ...]] | None = None,
+        alignment_input: AlignmentInput | None = None,
+        assays: tuple[Assay, ...] | None = None,
         forced: bool = False,
     ):
         super().__init__()
         self.id = id
         self.name = id
         self._external_id = external_id
+        self.sequencing_type = sequencing_type
+        self.sequencing_technology = sequencing_technology
+        self.sequencing_platform = sequencing_platform
+
         self.dataset = dataset
         self._participant_id = participant_id
         self.meta: dict = meta or dict()
@@ -626,8 +635,8 @@ class SequencingGroup(Target):
         )
         if sex:
             self.pedigree.sex = sex
-        self.alignment_input_by_seq_type: dict[str, AlignmentInput] = alignment_input_by_seq_type or dict()
-        self.assays: dict[str, tuple[Assay, ...]] = assays or {}
+        self.alignment_input: AlignmentInput | None = alignment_input
+        self.assays: tuple[Assay, ...] | None = assays
         self.forced = forced
         self.active = True
         # Only set if the file exists / found in Metamist:
@@ -637,12 +646,13 @@ class SequencingGroup(Target):
     def __repr__(self):
         values = {
             'participant': self._participant_id if self._participant_id else '',
+            'sequencing_type': self.sequencing_type,
+            'sequencing_technology': self.sequencing_technology,
+            'sequencing_platform': self.sequencing_platform,
             'forced': str(self.forced),
             'active': str(self.active),
             'meta': str(self.meta),
-            'alignment_inputs': ','.join(
-                [f'{seq_t}: {al_inp}' for seq_t, al_inp in self.alignment_input_by_seq_type.items()],
-            ),
+            'alignment_inputs': self.alignment_input,
             'pedigree': self.pedigree,
         }
         retval = f'SequencingGroup({self.dataset.name}/{self.id}'
@@ -652,15 +662,16 @@ class SequencingGroup(Target):
 
     def __str__(self):
         ai_tag = ''
-        for seq_type, alignment_input in self.alignment_input_by_seq_type.items():
-            ai_tag += f'|SEQ={seq_type}:'
-            if isinstance(alignment_input, CramPath):
+        if self.alignment_input:
+            ai_tag += f'|SEQ={self.sequencing_type}:'
+            if isinstance(self.alignment_input, CramPath):
                 ai_tag += 'CRAM'
-            elif isinstance(alignment_input, BamPath):
+            elif isinstance(self.alignment_input, BamPath):
                 ai_tag += 'BAM'
+            elif isinstance(self.alignment_input, FastqPairs):
+                ai_tag += f'{len(self.alignment_input)}FQS'
             else:
-                assert isinstance(alignment_input, FastqPairs)
-                ai_tag += f'{len(alignment_input)}FQS'
+                raise ValueError(f'Unrecognised alignment input type {type(self.alignment_input)}')
 
         ext_id = f'|{self._external_id}' if self._external_id else ''
         return f'SequencingGroup({self.dataset.name}/{self.id}{ext_id}{ai_tag})'

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -302,7 +302,7 @@ def rich_sequencing_group_id_seds(
     return cmd
 
 
-def tshirt_mt_sizing(sequencing_type: str, cohort_size: int) -> str:
+def tshirt_mt_sizing(sequencing_type: str, cohort_size: int) -> int:
     """
     Some way of taking the details we have (#SGs, sequencing type)
     and producing an estimate (with padding) of the MT size on disc
@@ -321,8 +321,8 @@ def tshirt_mt_sizing(sequencing_type: str, cohort_size: int) -> str:
         return preset
 
     if (sequencing_type == 'genome' and cohort_size < 100) or (sequencing_type == 'exome' and cohort_size < 1000):
-        return '50Gi'
-    return '500Gi'
+        return 50
+    return 500
 
 
 ExpectedResultT = Union[Path, dict[str, Path], dict[str, str], str, None]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,3 +203,22 @@ cpg = [
     "hail_scripts",
     "metamist",
 ]
+
+[tool.coverage.run]
+omit = [
+    "gnomad_methods/*",
+    "seqr-loading-pipelines/*",
+    "cpg_workflows/stages/*",
+    "cpg_workflows/jobs/*",
+    "cpg_workflows/large_cohort/*",
+    "cpg_workflows/scripts/*",
+    "cpg_workflows/query_modules/*",
+    "cpg_workflows/dataproc_scripts/*",
+    "cpg_workflows/python_scripts/*",
+    "scripts/*",
+    "cpg_workflows/stages/*",
+    "test/*",
+    "main.py",
+    "pca_dataproc_runner.py",
+    "setup.py",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest
 pytest_mock
 mypy
 tenacity
+coverage

--- a/scripts/fix_sq_headers.py
+++ b/scripts/fix_sq_headers.py
@@ -207,12 +207,14 @@ def do_metamist_update(dataset, activeseqgroup, oldanalysis, oldpath, newpath, r
     metavar='NAME',
     help='KNOWN_REFS name of the replacement headers',
 )
+@click.option('--update-db', is_flag=True, help='Update metamist Analysis records to point to new CRAMs')
 @click.option('--dry-run', is_flag=True, help='Display information only without making changes')
 def main(
     source: tuple[str],
     new_reference_path: str,
     expected_refset: str,
     new_refset: str,
+    update_db: bool,
     dry_run: bool,
 ):
     """
@@ -304,7 +306,7 @@ def main(
         analysis = analysis_by_path[str(path)]
         if seqgroupcount := len(analysis['sequencingGroups']) != 1:
             print(f'Analysis id={analysis["id"]} for {path} is in {seqgroupcount} sequencing groups')
-        elif not dry_run:
+        elif update_db and not dry_run:
             db_j = b.new_python_job(f'Update metamist for {newpath}')
             db_j.image(config['workflow']['driver_image'])
 

--- a/scripts/fix_sq_headers.py
+++ b/scripts/fix_sq_headers.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
 
+"""
+Copy CRAM files while replacing existing @SQ headers with new ones as specified,
+add new analysis records to metamist pointing to the new CRAM files, and
+inactivate the existing analysis records for these sequencing groups.
+
+Typical usage:
+
+analysis-runner ... scripts/fix_sq_headers --ref gs://.../reference.dict
+    --expected 'Homo_sapiens_assembly38[unmasked]'
+    --intended 'Homo_sapiens_assembly38_masked'
+    [gs://... directory or file paths to limit processing]...
+"""
+
 import hashlib
 import os
 import subprocess as sb
@@ -16,40 +29,46 @@ from metamist import models
 from metamist.apis import AnalysisApi
 from metamist.graphql import gql, query
 
-FIND_CRAMS = gql(
+FIND_ANALYSES = gql(
     """
-query CramQuery($project: String!) {
+query AnalysesQuery($project: String!) {
   project(name: $project) {
-    sequencingGroups {
+    analyses(type: {eq: "cram"}, active: {eq: true}) {
       id
-      analyses(type: {eq: "cram"}) {
-        id
-        meta
-        output
-        active
-        type
+      meta
+      output
+      sequencingGroups {
+        sample {
+          id
+        }
       }
+      status
+      type
     }
   }
 }
 """,
 )
 
-
-def query_metamist(dataset: str):
-    cram_list = []
-
-    for seqgroup in query(FIND_CRAMS, {'project': dataset})['project']['sequencingGroups']:
-        for analysis in seqgroup['analyses']:
-            fname = analysis['output']
-            if fname is not None and fname.endswith('.cram'):
-                cram_list.append(fname)
-            else:
-                sgid = seqgroup['id']
-                anid = analysis['id']
-                print(f'Sequencing group {sgid} analysis {anid} is not CRAM: {fname}')
-
-    return cram_list
+FIND_SAMPLES = gql(
+    """
+query SamplesQuery($project: String!) {
+  project(name: $project) {
+    samples {
+      id
+      sequencingGroups {
+        id
+        analyses(type: {eq: "cram"}, active: {eq: true}) {
+          id
+          output
+          status
+        }
+      }
+    }
+  }
+}
+""",
+)
 
 
 # Precomputed hashes (as per classify_SQ()) for common reference sets
@@ -138,22 +157,32 @@ def do_reheader(dry_run, refset, newref, newrefset, incram, outcram, outcrai):
     }
 
 
-def do_metamist_update(dataset, sequencing_type, seqgroup, oldpath, newpath, result):
+def do_metamist_update(dataset, activeseqgroup, oldanalysis, oldpath, newpath, result):
     aapi = AnalysisApi()
 
-    analysis = models.Analysis(
-        type='cram',
-        status=models.AnalysisStatus('completed'),
+    newmeta = oldanalysis['meta']
+    newmeta['size'] = result['cram_size']
+    newmeta['source'] += f' (reheadered from {oldpath})'
+
+    newanalysis = models.Analysis(
+        type=oldanalysis['type'],
+        status=models.AnalysisStatus(oldanalysis['status'].lower()),
         output=str(newpath),
-        sequencing_group_ids=[seqgroup],
-        meta={
-            'sequencing_type': sequencing_type,
-            'size': result['cram_size'],
-            'source': f'Reheadered from {oldpath}',
-        },
+        sequencing_group_ids=[activeseqgroup['id']],
+        meta=newmeta,
     )
-    aid = aapi.create_analysis(dataset, analysis)
+    aid = aapi.create_analysis(dataset, newanalysis)
     print(f'Created Analysis(id={aid}, output={newpath}) in {dataset}')
+
+    for analysis in activeseqgroup['analyses']:
+        activeid = analysis['id']
+        analysisupdate = models.AnalysisUpdateModel(
+            active=False,
+            status=models.AnalysisStatus(analysis['status'].lower()),
+        )
+        if not aapi.update_analysis(activeid, analysisupdate):
+            raise ValueError(f'Updating analysis id={activeid} failed')
+        print(f'Inactivated Analysis(id={activeid}, output={analysis["output"]} in {dataset}')
 
 
 @click.command()
@@ -187,7 +216,7 @@ def main(
     dry_run: bool,
 ):
     """
-    This script uses the usual config entries (workflow.dataset, .access_level, .sequencing_type
+    This script uses the usual config entries (workflow.dataset, .access_level, .driver_image
     and images.samtools) and the following options to select CRAM files to have their @SQ
     headers rewritten.
     """
@@ -197,16 +226,30 @@ def main(
     if config['workflow']['access_level'] == 'test' and not dataset.endswith('-test'):
         dataset = f'{dataset}-test'
 
+    project_analyses = query(FIND_ANALYSES, {'project': dataset})['project']['analyses']
+    analysis_by_path = {analysis['output']: analysis for analysis in project_analyses}
+
     if len(source) > 0:
         print(f'Scanning {" ".join(source)} for *.cram files')
-        cram_list = [fn for srcdir in source for fn in to_path(srcdir).iterdir() if fn.suffix == '.cram']
+        cram_list = []
+        for src in source:
+            if src.endswith('.cram'):
+                if src in analysis_by_path:
+                    cram_list.append(src)
+                else:
+                    print(f'No analysis record found for {src}')
+            else:
+                for fn in to_path(src).iterdir():
+                    if fn.suffix == '.cram':
+                        if fn in analysis_by_path:
+                            cram_list.append(fn)
+                        else:
+                            print(f'No analysis record found for {fn}')
     else:
-        print(f'Finding CRAMs for {dataset} in database')
-        cram_list = query_metamist(dataset)
+        print(f'Using all CRAMs for {dataset} in database')
+        cram_list = analysis_by_path.keys()
 
     print(f'Total CRAM file entries found: {len(cram_list)}')
-
-    sequencing_type = config['workflow']['sequencing_type']
 
     reheader_list = []
     for fname in cram_list:
@@ -224,6 +267,9 @@ def main(
         sys.exit('No CRAMs to be reheadered!')
 
     print(f'CRAM files to be reheadered: {len(reheader_list)}')
+
+    project_samples = query(FIND_SAMPLES, {'project': dataset})['project']['samples']
+    sample_by_id = {sample['id']: sample for sample in project_samples}
 
     b = get_batch(f'Reheader {dataset} to {new_reference_path}')
     new_reference = b.read_input(new_reference_path)
@@ -255,19 +301,28 @@ def main(
 
         print(f'Added reheader job for {path}')
 
-        if not dry_run:
+        analysis = analysis_by_path[str(path)]
+        if seqgroupcount := len(analysis['sequencingGroups']) != 1:
+            print(f'Analysis id={analysis["id"]} for {path} is in {seqgroupcount} sequencing groups')
+        elif not dry_run:
             db_j = b.new_python_job(f'Update metamist for {newpath}')
             db_j.image(config['workflow']['driver_image'])
+
+            sample = sample_by_id[analysis['sequencingGroups'][0]['sample']['id']]
+            seqgroup = sample['sequencingGroups'][0]
 
             db_j.call(
                 do_metamist_update,
                 dataset,
-                sequencing_type,
-                path.stem,
+                seqgroup,
+                analysis,
                 str(path),
                 str(newpath),
                 j_result,
             )
+
+            oldids = ', '.join(str(a['id']) for a in seqgroup['analyses'])
+            print(f'Added metamist job to create new analysis and inactivate id={oldids}')
 
     b.run(wait=False)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.10',
+    version='1.26.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,10 @@ setup(
             'relatedness_pcrelate = cpg_workflows.large_cohort.scripts.relatedness_pcrelate:cli_main',
             # the Flagging step of LargeCohort - Relatedness
             'relatedness_flag = cpg_workflows.large_cohort.scripts.relatedness_flag:cli_main',
+            # the Background Stage of Ancestry - LargeCohort
+            'ancestry_add_background = cpg_workflows.large_cohort.scripts.ancestry_add_background:cli_main',
+            # the Background Stage of Ancestry - PCA
+            'ancestry_pca = cpg_workflows.large_cohort.scripts.ancestry_run_pca:cli_main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.5',
+    version='1.26.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.7',
+    version='1.26.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.9',
+    version='1.26.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
@@ -66,6 +66,8 @@ setup(
             'modify_sniffles = cpg_workflows.scripts.long_read_sniffles_vcf_modifier:cli_main',
             # for use in translating a MatrixTable to an ES index, first localising the MT
             'mt_to_es = cpg_workflows.scripts.mt_to_es_without_dataproc:main',
+            # Generate new intervals from a MatrixTable
+            'new_intervals_from_mt = cpg_workflows.scripts.generate_new_intervals:cli_main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
             # the Flagging step of LargeCohort - Relatedness
             'relatedness_flag = cpg_workflows.large_cohort.scripts.relatedness_flag:cli_main',
             # the Densification of a background population dataset
-            'densify_background_dataset = cpg_worfklwos.large_cohort.scripts.densify_background_dataset:cli_main',
+            'densify_background_dataset = cpg_workflows.large_cohort.scripts.densify_background_dataset:cli_main',
             # the Background Stage of Ancestry - LargeCohort
             'ancestry_add_background = cpg_workflows.large_cohort.scripts.ancestry_add_background:cli_main',
             # the Background Stage of Ancestry - PCA

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.1',
+    version='1.27.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setup(
             'relatedness_pcrelate = cpg_workflows.large_cohort.scripts.relatedness_pcrelate:cli_main',
             # the Flagging step of LargeCohort - Relatedness
             'relatedness_flag = cpg_workflows.large_cohort.scripts.relatedness_flag:cli_main',
+            # the Densification of a background population dataset
+            'densify_background_dataset = cpg_worfklwos.large_cohort.scripts.densify_background_dataset:cli_main',
             # the Background Stage of Ancestry - LargeCohort
             'ancestry_add_background = cpg_workflows.large_cohort.scripts.ancestry_add_background:cli_main',
             # the Background Stage of Ancestry - PCA

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'test': [
             'pytest',
             'pytest-mock',
+            'coverage',
         ],
     },
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.11',
+    version='1.27.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ setup(
             'ancestry_add_background = cpg_workflows.large_cohort.scripts.ancestry_add_background:cli_main',
             # the Background Stage of Ancestry - PCA
             'ancestry_pca = cpg_workflows.large_cohort.scripts.ancestry_run_pca:cli_main',
+            # the Background Stage of Ancestry - Infer Population Labels
+            'ancestry_infer_labels = cpg_workflows.large_cohort.scripts.ancestry_infer_labels:cli_main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.2',
+    version='1.27.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.4',
+    version='1.26.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.6',
+    version='1.26.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.0',
+    version='1.27.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.8',
+    version='1.26.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/factories/sequencing_group.py
+++ b/test/factories/sequencing_group.py
@@ -20,7 +20,12 @@ def create_sequencing_group(
     meta: dict | None = None,
     sex: Sex | None = None,
     pedigree: PedigreeInfo | None = None,
+    # 2024-07-25 mfranklin: I don't think _generally_ the sequencing group should be
+    #   limited to the SequencingType[genome, exome] list. Maybe for specific stages,
+    #   but not in general for the tests, but I'll leave it here.
     sequencing_type: SequencingType = 'genome',
+    sequencing_technology: str = 'short-read',
+    sequencing_platform: str = 'illumina',
     alignment_input: FastqPair | FastqPairs | CramPath | BamPath | None = None,
     gvcf: GvcfPath | Literal['auto'] | None = None,
     cram: CramPath | Literal['auto'] | None = None,
@@ -55,12 +60,10 @@ def create_sequencing_group(
             `None`.
 
         sequencing_type (SequencingType):
-            The type of sequencing performed used as the key in the property
-            `alignment_input_by_seq_type` on the new instance. Defaults to 'genome'.
+            The sequencing_type of the group of assays. Defaults to 'genome'.
 
         alignment_input (FastqPair | FastqPairs | CramPath | BamPath | None, optional):
-            The alignment input data. Defaults to `None`. If `None`, the property
-            `alignment_input_by_seq_type` on the new instance will be `None`.
+            The alignment input data. Defaults to `None`.
 
         gvcf (GvcfPath | Literal['auto'] | None, optional):
             Path to a gVCF file path for the sequencing group that will be used to save
@@ -97,12 +100,15 @@ def create_sequencing_group(
         id=id,
         external_id=external_id,
         participant_id=participant_id,
+        sequencing_type=sequencing_type,
+        sequencing_technology=sequencing_technology,
+        sequencing_platform=sequencing_platform,
         dataset=dataset,
         meta=meta,
         sex=sex,
         pedigree=pedigree,
         forced=forced,
-        alignment_input_by_seq_type=({sequencing_type: alignment_input} if alignment_input else None),
+        alignment_input=alignment_input,
     )
 
     if gvcf == 'auto':

--- a/test/jobs/somalier/test_check_pedigree.py
+++ b/test/jobs/somalier/test_check_pedigree.py
@@ -45,7 +45,13 @@ def setup_pedigree_test(tmp_path: Path, config: PipelineConfig | None = None):
     dataset_id = config.workflow.dataset
 
     dataset = create_dataset(name=dataset_id)
-    dataset.add_sequencing_group(id='CPGABCD', external_id='SAMPLE1')
+    dataset.add_sequencing_group(
+        id='CPGABCD',
+        external_id='SAMPLE1',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
     batch = create_local_batch(tmp_path)
 
     sg_id = dataset.get_sequencing_group_ids()[0]
@@ -196,7 +202,12 @@ class TestSomalierCheckPedigree:
 
         dataset_id = config.workflow.dataset
         dataset = create_dataset(name=dataset_id)
-        dataset.add_sequencing_group(id='CPGABCD')
+        dataset.add_sequencing_group(
+            id='CPGABCD',
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
+        )
 
         pedigree_jobs = pedigree(
             dataset=dataset,

--- a/test/jobs/somalier/test_relate.py
+++ b/test/jobs/somalier/test_relate.py
@@ -45,7 +45,13 @@ def setup_pedigree_test(tmp_path: Path, config: PipelineConfig | None = None):
     dataset_id = config.workflow.dataset
 
     dataset = create_dataset(name=dataset_id)
-    dataset.add_sequencing_group(id='CPGAAAAAA', external_id='SAMPLE1')
+    dataset.add_sequencing_group(
+        id='CPGAAAAAA',
+        external_id='SAMPLE1',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
     batch = create_local_batch(tmp_path)
 
     sg_id = dataset.get_sequencing_group_ids()[0]

--- a/test/stages/__init__.py
+++ b/test/stages/__init__.py
@@ -22,12 +22,24 @@ from cpg_workflows.workflow import (
 )
 
 
+def add_sg(ds, id, external_id: str):
+    sg = ds.add_sequencing_group(
+        id=id,
+        external_id=external_id,
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
+    return sg
+
+
 def mock_cohort() -> MultiCohort:
     m = MultiCohort()
     c = m.create_cohort('fewgenomes')
     ds = c.create_dataset('my_dataset')
-    sg1 = ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
     m_ds = m.add_dataset(ds)
+
+    sg1 = add_sg(ds, 'CPGAA', external_id='SAMPLE1')
     m_ds.add_sequencing_group_object(sg1)
     return m
 
@@ -37,18 +49,22 @@ def mock_multidataset_cohort() -> MultiCohort:
     c = m.create_cohort('fewgenomes')
 
     ds = c.create_dataset('my_dataset')
-    sg1 = ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-    sg2 = ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
     m_ds_1 = m.add_dataset(ds)
+
+    sg1 = add_sg(ds, 'CPGAA', external_id='SAMPLE1')
+    sg2 = add_sg(ds, 'CPGBB', external_id='SAMPLE2')
+
     m_ds_1.add_sequencing_group_object(sg1)
     m_ds_1.add_sequencing_group_object(sg2)
 
     ds2 = c.create_dataset('my_dataset2')
-    sg3 = ds2.add_sequencing_group('CPGCC', external_id='SAMPLE3')
-    sg4 = ds2.add_sequencing_group('CPGDD', external_id='SAMPLE4')
     m_ds_2 = m.add_dataset(ds2)
+
+    sg3 = add_sg(ds2, 'CPGCC', external_id='SAMPLE3')
+    sg4 = add_sg(ds2, 'CPGDD', external_id='SAMPLE4')
     m_ds_2.add_sequencing_group_object(sg3)
     m_ds_2.add_sequencing_group_object(sg4)
+
     return m
 
 
@@ -62,19 +78,25 @@ def mock_multicohort() -> MultiCohort:
     # Create a dataset in the multicohort (new)
     dm1 = mc.add_dataset(ds)
     # Add sequencing groups to the cohort.dataset AND multicohort.dataset
-    dm1.add_sequencing_group_object(ds.add_sequencing_group('CPGXXXX', external_id='SAMPLE1'))
-    dm1.add_sequencing_group_object(ds.add_sequencing_group('CPGAAAA', external_id='SAMPLE2'))
+    sg1 = add_sg(ds, 'CPGXXXX', external_id='SAMPLE1')
+    sg2 = add_sg(ds, 'CPGAAAA', external_id='SAMPLE2')
+    dm1.add_sequencing_group_object(sg1)
+    dm1.add_sequencing_group_object(sg2)
 
     ds2 = cohort_a.create_dataset('projectc')
     dm2 = mc.add_dataset(ds2)
-    dm2.add_sequencing_group_object(ds2.add_sequencing_group('CPGCCCC', external_id='SAMPLE3'))
-    dm2.add_sequencing_group_object(ds2.add_sequencing_group('CPGDDDD', external_id='SAMPLE4'))
+    sg3 = add_sg(ds2, 'CPGCCCC', external_id='SAMPLE3')
+    sg4 = add_sg(ds2, 'CPGDDDD', external_id='SAMPLE4')
+    dm2.add_sequencing_group_object(sg3)
+    dm2.add_sequencing_group_object(sg4)
 
     cohort_b = mc.create_cohort('CohortB')
     ds3 = cohort_b.create_dataset('projectb')
     dm3 = mc.add_dataset(ds3)
-    dm3.add_sequencing_group_object(ds3.add_sequencing_group('CPGEEEEEE', external_id='SAMPLE5'))
-    dm3.add_sequencing_group_object(ds3.add_sequencing_group('CPGFFFFFF', external_id='SAMPLE6'))
+    sg5 = add_sg(ds3, 'CPGEEEEEE', external_id='SAMPLE5')
+    sg6 = add_sg(ds3, 'CPGFFFFFF', external_id='SAMPLE6')
+    dm3.add_sequencing_group_object(sg5)
+    dm3.add_sequencing_group_object(sg6)
 
     return mc
 

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -77,9 +77,19 @@ def mock_deprecated_create_cohort() -> MultiCohort:
     c = m.create_cohort('fewgenomes')
     ds = c.create_dataset('my_dataset')
     m_ds = m.add_dataset(ds)
-    sg1 = ds.add_sequencing_group('CPGAAA', external_id='SAMPLE1')
+
+    def add_sg(id, external_id):
+        return ds.add_sequencing_group(
+            id=id,
+            external_id=external_id,
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
+        )
+
+    sg1 = add_sg('CPGAAA', external_id='SAMPLE1')
     m_ds.add_sequencing_group_object(sg1)
-    sg2 = ds.add_sequencing_group('CPGBBB', external_id='SAMPLE2')
+    sg2 = add_sg('CPGBBB', external_id='SAMPLE2')
     m_ds.add_sequencing_group_object(sg2)
     return m
 

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -79,6 +79,7 @@ def mock_get_sgs(*args, **kwargs) -> list[dict]:  # pylint: disable=unused-argum
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12340',
                 'participant': {
@@ -130,6 +131,7 @@ def mock_get_sgs(*args, **kwargs) -> list[dict]:  # pylint: disable=unused-argum
             'meta': {'sample_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12489',
                 'participant': {
@@ -319,9 +321,10 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     assert test_sg.meta == {'sg_meta': 'is_fun', 'participant_meta': 'is_here', 'phenotypes': {}}
 
     # Test Assay Population
-    assert test_sg.assays['sequencing'][0].sequencing_group_id == 'CPGLCL17'
-    assert test_sg.assays['sequencing'][0].id == '1'
-    assert test_sg.assays['sequencing'][0].meta['fluid_x_tube_id'] == '220405_FS28'
+    assert test_sg.assays
+    assert test_sg.assays[0].sequencing_group_id == 'CPGLCL17'
+    assert test_sg.assays[0].id == '1'
+    assert test_sg.assays[0].meta['fluid_x_tube_id'] == '220405_FS28'
 
     assert test_sg.participant_id == '8'
     # TODO/NOTE: The sex in the pedigree will overwrite the sex in the
@@ -360,6 +363,7 @@ def mock_get_sgs_with_missing_reads(*args, **kwargs) -> list[dict]:  # pylint: d
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12340',
                 'participant': {
@@ -411,6 +415,7 @@ def mock_get_sgs_with_missing_reads(*args, **kwargs) -> list[dict]:  # pylint: d
             'meta': {'sample_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12489',
                 'participant': {
@@ -486,9 +491,10 @@ def test_missing_reads(mocker: MockFixture, tmp_path):
     assert test_sg.meta == {'sg_meta': 'is_fun', 'participant_meta': 'is_here', 'phenotypes': {}}
 
     # Test Assay Population
-    assert test_sg.assays['sequencing'][0].sequencing_group_id == 'CPGLCL17'
-    assert test_sg.assays['sequencing'][0].id == '1'
-    assert test_sg.assays['sequencing'][0].meta['fluid_x_tube_id'] == '220405_FS28'
+    assert test_sg.assays
+    assert test_sg.assays[0].sequencing_group_id == 'CPGLCL17'
+    assert test_sg.assays[0].id == '1'
+    assert test_sg.assays[0].meta['fluid_x_tube_id'] == '220405_FS28'
 
     assert test_sg.participant_id == '8'
     assert test_sg.pedigree.sex == Sex.MALE
@@ -506,7 +512,7 @@ def test_missing_reads(mocker: MockFixture, tmp_path):
     # assert test_sg.alignment_input_by_seq_type['genome'][0].r1 == CloudPath(
     #     'gs://cpg-fewgenomes-main/HG3FMDSX3_2_220405_FS28_Homo-sapiens_AACGAGGCCG-ATCCAGGTAT_R_220208_BINKAN1_FEWGENOMES_M001_R1.fastq.gz'
     # )
-    assert test_sg2.alignment_input_by_seq_type == {}
+    assert test_sg2.alignment_input is None
 
 
 def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: disable=unused-argument
@@ -516,6 +522,7 @@ def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: dis
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12340',
                 'participant': {
@@ -567,6 +574,7 @@ def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: dis
             'meta': {'sample_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'genome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA12489',
                 'participant': {
@@ -600,6 +608,7 @@ def mock_get_sgs_with_mixed_reads(*args, **kwargs) -> list[dict]:  # pylint: dis
             'meta': {'sg_meta': 'is_fun'},
             'platform': 'illumina',
             'type': 'exome',
+            'technology': 'short-read',
             'sample': {
                 'externalId': 'NA1000',
                 'participant': {
@@ -687,7 +696,7 @@ def test_mixed_reads(mocker: MockFixture, tmp_path, caplog):
     #     'gs://cpg-fewgenomes-main/exomeexample_r1.fastq.gz'
     # )
 
-    assert test_none.alignment_input_by_seq_type == {}
+    assert test_none.alignment_input is None
     assert re.search(
         r'WARNING\s+root:inputs\.py:\d+\s+No reads found for sequencing group CPGbbb of type genome',
         caplog.text,
@@ -710,6 +719,7 @@ def test_unknown_data(mocker: MockFixture, tmp_path, caplog):
                 'meta': {'sg_meta': 'is_fun'},
                 'platform': 'illumina',
                 'type': 'genome',
+                'technology': 'short-read',
                 'sample': {
                     'externalId': 'NA12340',
                     'participant': {
@@ -744,6 +754,7 @@ def test_unknown_data(mocker: MockFixture, tmp_path, caplog):
                 'meta': {'sg_meta': 'is_fun'},
                 'platform': 'illumina',
                 'type': 'exome',
+                'technology': 'short-read',
                 'sample': {
                     'externalId': 'NA1000',
                     'participant': {

--- a/test/test_gatk_sv_methods.py
+++ b/test/test_gatk_sv_methods.py
@@ -8,11 +8,14 @@ import pytest
 from cpg_utils import to_path
 from cpg_workflows.jobs.sample_batching import batch_sgs
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_fasta, get_images, get_references, image_path
+from cpg_workflows.stages.gatk_sv.gatk_sv_multisample import check_for_cohort_overlaps
+from cpg_workflows.targets import Dataset, MultiCohort
 
 from . import set_config
 
 TOML = """
 [workflow]
+dataset = 'fewgenomes'
 sequencing_type = 'genome'
 ref_fasta = 'this/is/the/ref.fasta'
 
@@ -26,6 +29,54 @@ sv_reference = 'gatk_sv_content'
 [references.broad]
 broad_reference = 'broad_content'
 """
+
+
+def add_sg(dset: Dataset, id, external_id):
+    return dset.add_sequencing_group(
+        id=id,
+        external_id=external_id,
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+    )
+
+
+def test_check_for_cohort_overlaps(tmp_path):
+    """
+    check that the image return works correctly
+    """
+    set_config(TOML, tmp_path / 'config.toml')
+    m = MultiCohort()
+    c = m.create_cohort('fewgenomes')
+    ds = c.create_dataset('my_dataset')
+
+    add_sg(ds, 'CPGAAA', external_id='SAMPLE1')
+    add_sg(ds, 'CPGBBB', external_id='SAMPLE2')
+
+    check_for_cohort_overlaps(m)
+
+
+def test_check_for_cohort_overlaps_fails(tmp_path):
+    """
+    check that the image return works correctly
+    """
+    set_config(TOML, tmp_path / 'config.toml')
+    m = MultiCohort()
+    c = m.create_cohort('fewgenomes')
+    ds = c.create_dataset('my_dataset')
+    c2 = m.create_cohort('fewgenomes2')
+    ds2 = c2.create_dataset('my_dataset')
+
+    add_sg(ds, 'CPGAAA', external_id='SAMPLE1')
+    add_sg(ds, 'CPGBBB', external_id='SAMPLE2')
+    add_sg(ds2, 'CPGBBB', external_id='SAMPLE2')
+
+    # this could also be done with pytest.raises(ValueError) as exc_info, then check that obj's attributes
+    with pytest.raises(
+        ValueError,
+        match="Overlapping cohorts fewgenomes and fewgenomes2 have overlapping SGs: {'CPGBBB'}",
+    ):
+        check_for_cohort_overlaps(m)
 
 
 def test_get_images(tmp_path):

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -113,6 +113,9 @@ def _mock_cohort(dataset_id: str):
         sequencing_group = dataset.add_sequencing_group(
             id=sequencing_group_id,
             external_id=sequencing_group_id.replace('CPG', 'EXT'),
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
         )
         sequencing_group.gvcf = GvcfPath(gvcf_path)
         mc_dataset.add_sequencing_group_object(sequencing_group)

--- a/test/test_lr_sv_mods.py
+++ b/test/test_lr_sv_mods.py
@@ -1,0 +1,41 @@
+import pytest
+
+from cpg_workflows.scripts.long_read_sniffles_vcf_modifier import translate_var_and_sex_to_cn
+
+
+@pytest.mark.parametrize(
+    'contig,var_type,gt,expected',
+    (
+        ('chr1', 'DUP', '0/0', 2),
+        ('chr1', 'DUP', '0/1', 3),
+        ('chr1', 'DUP', '1/1', 4),
+        ('chr1', 'OTHER', '0/1', 2),
+        ('chr1', 'OTHER', '1/1', 2),
+        ('chrX', 'DUP', '0/1', 2),
+        ('chrX', 'DUP', '0|0', 1),
+        ('chrY', 'DUP', '0/1', 2),
+        ('chrY', 'DUP', '0/0', 1),
+        ('chrM', 'DUP', '0/1', 2),
+    ),
+)
+def test_calculate_cn_male(contig, var_type, gt, expected):
+    assert translate_var_and_sex_to_cn(contig, var_type, gt, 1) == expected
+
+
+@pytest.mark.parametrize(
+    'contig,var_type,gt,expected',
+    (
+        ('chr1', 'DUP', '0/0', 2),
+        ('chr1', 'DUP', '0/1', 3),
+        ('chr1', 'DUP', '1/1', 4),
+        ('chr1', 'OTHER', '0/1', 2),
+        ('chr1', 'OTHER', '1/1', 2),
+        ('chrX', 'DUP', '0/1', 3),
+        ('chrX', 'DUP', '0|0', 2),
+        ('chrY', 'DUP', '0/1', 1),
+        ('chrY', 'DUP', '0/0', 0),
+        ('chrM', 'DUP', '0/1', 2),
+    ),
+)
+def test_calculate_cn_female(contig, var_type, gt, expected):
+    assert translate_var_and_sex_to_cn(contig, var_type, gt, 2) == expected

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -133,27 +133,31 @@ def _mock_cohort():
     mc_dataset = multi_cohort.add_dataset(ds)
     sg1 = ds.add_sequencing_group(
         'CPGAA',
-        'SAMPLE1',
-        alignment_input_by_seq_type={'genome': BamPath('gs://test-input-dataset-upload/sample1.bam')},
+        external_id='SAMPLE1',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+        alignment_input=BamPath('gs://test-input-dataset-upload/sample1.bam'),
     )
     mc_dataset.add_sequencing_group_object(sg1)
     sg2 = ds.add_sequencing_group(
         'CPGBB',
-        'SAMPLE2',
-        alignment_input_by_seq_type={
-            'genome': FastqPairs(
-                [
-                    FastqPair(
-                        'gs://test-input-dataset-upload/sample2_L1_R1.fq.gz',
-                        'gs://test-input-dataset-upload/sample2_L1_R2.fq.gz',
-                    ),
-                    FastqPair(
-                        'gs://test-input-dataset-upload/sample2_L2_R1.fq.gz',
-                        'gs://test-input-dataset-upload/sample2_L2_R2.fq.gz',
-                    ),
-                ],
-            ),
-        },
+        external_id='SAMPLE2',
+        sequencing_type='genome',
+        sequencing_technology='short-read',
+        sequencing_platform='illumina',
+        alignment_input=FastqPairs(
+            [
+                FastqPair(
+                    'gs://test-input-dataset-upload/sample2_L1_R1.fq.gz',
+                    'gs://test-input-dataset-upload/sample2_L1_R2.fq.gz',
+                ),
+                FastqPair(
+                    'gs://test-input-dataset-upload/sample2_L2_R1.fq.gz',
+                    'gs://test-input-dataset-upload/sample2_L2_R2.fq.gz',
+                ),
+            ],
+        ),
     )
     mc_dataset.add_sequencing_group_object(sg2)
 

--- a/test/test_size.py
+++ b/test/test_size.py
@@ -1,0 +1,27 @@
+import hailtop.batch as hb
+
+
+def test_python_function(*values):
+    # making this smaller with 101 jobs means it passes
+    print(*values)
+    h = hash(values)
+    print(f'Hash is {h}')
+    # this return is important, otherwise it submits successfully
+    return h
+
+
+if __name__ == '__main__':
+    b = hb.Batch(
+        'Scale size recursion test',
+        backend=hb.ServiceBackend(
+            billing_project='michaelfranklin-trial',
+            remote_tmpdir='gs://cpg-michael-hail-dev/tmp',
+        ),
+        default_python_image='python-image-with-dill',
+    )
+    # 101 submits, 102 fails
+    for i in range(102):
+        j = b.new_python_job(f'Function call {i+1}')
+        j.call(test_python_function, i + 1)
+
+    submitted = b.run(wait=False)

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -68,8 +68,20 @@ def _common(mocker, tmp_path):
         c = m.create_cohort('fewgenomes')
         ds = c.create_dataset('my_dataset')
         m_ds = m.add_dataset(ds)
-        m_ds.add_sequencing_group_object(ds.add_sequencing_group('CPGAA', external_id='SAMPLE1'))
-        m_ds.add_sequencing_group_object(ds.add_sequencing_group('CPGBB', external_id='SAMPLE2'))
+
+        def add_sg(id, external_id):
+            return ds.add_sequencing_group(
+                id,
+                external_id=external_id,
+                sequencing_type='genome',
+                sequencing_technology='short-read',
+                sequencing_platform='illumina',
+            )
+
+        sg1 = add_sg('CPGAA', external_id='SAMPLE1')
+        sg2 = add_sg('CPGBB', external_id='SAMPLE2')
+        m_ds.add_sequencing_group_object(sg1)
+        m_ds.add_sequencing_group_object(sg2)
         return m
 
     mocker.patch('cpg_workflows.inputs.deprecated_create_cohort', mock_create_cohort)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -40,9 +40,19 @@ def mock_deprecated_create_cohort() -> MultiCohort:
     m = MultiCohort()
     c = m.create_cohort('fewgenomes')
     ds = c.create_dataset('my_dataset')
-    sg1 = ds.add_sequencing_group('CPGAA', external_id='SAMPLE1')
-    sg2 = ds.add_sequencing_group('CPGBB', external_id='SAMPLE2')
     m_ds = m.add_dataset(ds)
+
+    def add_sg(id, external_id):
+        return ds.add_sequencing_group(
+            id=id,
+            external_id=external_id,
+            sequencing_type='genome',
+            sequencing_technology='short-read',
+            sequencing_platform='illumina',
+        )
+
+    sg1 = add_sg('CPGAA', external_id='SAMPLE1')
+    sg2 = add_sg('CPGBB', external_id='SAMPLE2')
     m_ds.add_sequencing_group_object(sg1)
     m_ds.add_sequencing_group_object(sg2)
     return m


### PR DESCRIPTION
Stacked branch, splits Ancestry into 3 separate stages. I kinda ran out of stamina on this one so it's partially implemented...

1. Add Background - runs in QOB, no need for Dataproc here. This is just a join across many different tables. This stage is optional, instead of ancestry_pca deciding whether or not to run a method inside Dataproc based on config 
2. Run PCA - local Hail, removes samples that need to be removed, and generates 3 new tables which are copied to GCP
3. Infer Ancestry - local Hail, either uses the SampleQC table, or output of the AddBackground stage if it runs (depending on config)...

None of this is polished, the `Ancestry` stage still exists as originally implemented, and AncestryPlots still uses the standard Dataproc-generated outputs as input

For discussion - a comment in cpg_workflows/large_cohort/ancestry_pca.py
- It looks like we're adding some annotations only to a VDS object, and not if we generate a dense MT from a MT. Is that intentional? 