### PR TITLE
T-Shirt MT sizing returns an int

### DIFF
--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -214,7 +214,7 @@ class MtToEs(DatasetStage):
             cohort_size=len(dataset.get_sequencing_group_ids()),
         )
 
-        job.cpu(4).storage(required_storage).memory('lowmem')
+        job.cpu(4).storage(f'{required_storage}Gi').memory('lowmem')
 
         # localise the MT
         job.command(f'gcloud --no-user-output-enabled storage cp -r {mt_path} $BATCH_TMPDIR')

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -409,14 +409,14 @@ class RunHailFiltering(DatasetStage):
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
         conf_in_batch = get_batch().read_input(runtime_config)
 
-        # MTs can vary from <10GB for a small exome, to 170GB for a larger one
-        # Genomes are more like 500GB
+        # MTs can vary from <10GB for a small exome, to 170GB for a larger one, Genomes ~500GB
         required_storage = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),
             cohort_size=len(dataset.get_sequencing_group_ids()),
         )
         required_cpu: int = config_retrieve(['hail', 'cores', 'small_variants'], 8)
-        job.cpu(required_cpu).storage(required_storage).memory('highmem')
+        # doubling storage due to the repartitioning
+        job.cpu(required_cpu).storage(f'{required_storage*2}Gi').memory('highmem')
 
         panelapp_json = get_batch().read_input(
             str(inputs.as_path(target=dataset, stage=QueryPanelapp, key='panel_data')),

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -302,7 +302,7 @@ def rich_sequencing_group_id_seds(
     return cmd
 
 
-def tshirt_mt_sizing(sequencing_type: str, cohort_size: int) -> str:
+def tshirt_mt_sizing(sequencing_type: str, cohort_size: int) -> int:
     """
     Some way of taking the details we have (#SGs, sequencing type)
     and producing an estimate (with padding) of the MT size on disc
@@ -321,8 +321,8 @@ def tshirt_mt_sizing(sequencing_type: str, cohort_size: int) -> str:
         return preset
 
     if (sequencing_type == 'genome' and cohort_size < 100) or (sequencing_type == 'exome' and cohort_size < 1000):
-        return '50Gi'
-    return '500Gi'
+        return 50
+    return 500
 
 
 ExpectedResultT = Union[Path, dict[str, Path], dict[str, str], str, None]


### PR DESCRIPTION
Instead of a String, MT sizing method returns an int, which is more easily modified (i.e. doubling)

This has implications for the relatedness/ancestry feature branches which already use the method with a String result