### PR TITLE
Check for overlapping cohorts

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.4
+current_version = 1.26.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.4
+  VERSION: 1.26.5
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -3,6 +3,7 @@ All post-batching stages of the GATK-SV workflow
 """
 
 from functools import cache
+from itertools import combinations
 from typing import Any
 
 from google.api_core.exceptions import PermissionDenied
@@ -102,12 +103,49 @@ class MakeCohortCombinedPed(CohortStage):
         return self.make_outputs(target=cohort, data=output)
 
 
+def check_for_cohort_overlaps(multicohort: MultiCohort):
+    """
+    Check for overlapping cohorts in a MultiCohort.
+    GATK-SV does not tolerate overlapping cohorts, so we check for this here.
+    This is called once per MultiCohort, and raises an Exception if any overlaps are found
+
+    Args:
+        multicohort (MultiCohort): the MultiCohort to check
+    """
+    # placeholder for errors
+    errors: list[str] = []
+    sgs_per_cohort: dict[str, set[str]] = {}
+    # grab all SG IDs per cohort
+    for cohort in multicohort.get_cohorts():
+        # shouldn't be possible, but guard against to be sure
+        if cohort.name in sgs_per_cohort:
+            raise ValueError(f'Cohort {cohort.name} already exists in {sgs_per_cohort}')
+
+        # collect the SG IDs for this cohort
+        sgs_per_cohort[cohort.name] = set(cohort.get_sequencing_group_ids())
+
+    # pairwise iteration over cohort IDs
+    for id1, id2 in combinations(sgs_per_cohort, 2):
+        # if the IDs are the same, skip. Again, shouldn't be possible, but guard against to be sure
+        if id1 == id2:
+            continue
+        # if there are overlapping SGs, raise an error
+        if overlap := sgs_per_cohort[id1] & sgs_per_cohort[id2]:
+            errors.append(f'Overlapping cohorts {id1} and {id2} have overlapping SGs: {overlap}')
+    # upon findings any errors, raise an Exception and die
+    if errors:
+        raise ValueError('\n'.join(errors))
+
+
 @stage
 class MakeMultiCohortCombinedPed(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
         return {'multicohort_ped': self.prefix / 'ped_with_ref_panel.ped'}
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
+        # check that there are no overlapping cohorts
+        check_for_cohort_overlaps(multicohort)
+
         output = self.expected_outputs(multicohort)
         # write the pedigree, if it doesn't already exist
         if not to_path(output['multicohort_ped']).exists():

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.4',
+    version='1.26.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_gatk_sv_methods.py
+++ b/test/test_gatk_sv_methods.py
@@ -73,7 +73,8 @@ def test_check_for_cohort_overlaps_fails(tmp_path):
 
     # this could also be done with pytest.raises(ValueError) as exc_info, then check that obj's attributes
     with pytest.raises(
-        ValueError, match="Overlapping cohorts fewgenomes and fewgenomes2 have overlapping SGs: {'CPGBBB'}",
+        ValueError,
+        match="Overlapping cohorts fewgenomes and fewgenomes2 have overlapping SGs: {'CPGBBB'}",
     ):
         check_for_cohort_overlaps(m)
 


### PR DESCRIPTION
Closes #866

I borked up when creating the GATK-SV cohorts for Bioheart/TOB, and the process ran until nearly the end before failing. Due to a copy-paste error I created 2 custom cohorts with the same group of SG IDs. This failed when merging a VCF, as bcftools merge (or a GATK equivalent?) requires non-overlapping sample sets to create merged output VCFs.

When assembling a MultiCohort from separate cohorts, there's no check that the SG IDs in each don't overlap. The pipeline API shouldn't need that, as it might be useful in some workflows. It is fatal for GATK though, and the stage which fails is ~2 days after initially triggering the workflow, so an up-front check is needed.

This change inserts a new method at the start of the GATK-SV pipeline, checking that all the component cohorts have no overlaps between. If there are overlaps, the process will fail. If there are not, we continue to writing a MultiCohortPedigree - this file is written once per MultiCohort ID, so this check is only run once per MultiCohort