### PR TITLE
Add CN calculation to sniffles modifier

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.5
+current_version = 1.26.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.5
+  VERSION: 1.26.6
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -26,11 +26,6 @@ def translate_var_and_sex_to_cn(contig: str, var_type: str, genotype: str, sex: 
     Returns:
         int, the CN value (copy number)
     """
-    global CHRX
-    global CHRY
-    global CHRM
-    global DUP
-    global DEL
 
     # determine the baseline copy number
     # conditions where the copy number is 1

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -89,7 +89,6 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         # find the vcf for this SG
         query_result = query_for_sv_vcfs(dataset_name=sg.dataset.name)
 
-        sex = sg.pedigree.sex
         expected_outputs = self.expected_outputs(sg)
 
         # instead of handling, we should probably just exclude this and run again
@@ -114,7 +113,8 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             f'--vcf_out {mod_job.output} '
             f'--ext_id {sg.external_id} '
             f'--int_id {sg.id} '
-            f'--fa {fasta} ',
+            f'--fa {fasta} '
+            f'--sex {sg.pedigree.sex} '
         )
 
         # block-gzip and index that result

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -114,7 +114,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             f'--ext_id {sg.external_id} '
             f'--int_id {sg.id} '
             f'--fa {fasta} '
-            f'--sex {sg.pedigree.sex} '
+            f'--sex {sg.pedigree.sex} ',
         )
 
         # block-gzip and index that result

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -79,7 +79,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             'index': sgid_prefix / f'{sequencing_group.id}_reformatted_renamed_lr_svs.vcf.bgz.tbi',
         }
 
-    def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:
+    def queue_jobs(self, sg: SequencingGroup, inputs: StageInput) -> StageOutput:
         """
         a python job to change the VCF contents
         - use a python job to modify all VCF lines, in-line
@@ -87,48 +87,48 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         """
 
         # find the vcf for this SG
-        query_result = query_for_sv_vcfs(dataset_name=sequencing_group.dataset.name)
+        query_result = query_for_sv_vcfs(dataset_name=sg.dataset.name)
 
-        expected_outputs = self.expected_outputs(sequencing_group)
+        sex = sg.pedigree.sex
+        expected_outputs = self.expected_outputs(sg)
 
         # instead of handling, we should probably just exclude this and run again
-        if sequencing_group.id not in query_result:
-            raise ValueError(f'No SV VCFs recorded for {sequencing_group.id}')
+        if sg.id not in query_result:
+            raise ValueError(f'No SV VCFs recorded for {sg.id}')
 
-        lr_sv_vcf: str = query_result[sequencing_group.id]
+        lr_sv_vcf: str = query_result[sg.id]
         local_vcf = get_batch().read_input(lr_sv_vcf)
 
-        modifier_job = get_batch().new_bash_job(f'Convert {lr_sv_vcf} prior to annotation')
-        modifier_job.storage('10Gi')
-        modifier_job.image(config_retrieve(['workflow', 'driver_image']))
+        mod_job = get_batch().new_bash_job(f'Convert {lr_sv_vcf} prior to annotation')
+        mod_job.storage('10Gi')
+        mod_job.image(config_retrieve(['workflow', 'driver_image']))
 
         # mandatory argument
         ref_fasta = config_retrieve(['workflow', 'ref_fasta'])
-        fasta = get_batch().read_input_group(fa=ref_fasta, fai=f'{ref_fasta}.fai')
+        fasta = get_batch().read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
 
         # the console entrypoint for the sniffles modifier script has only existed since 1.25.13, requires >=1.25.13
-        modifier_job.command(
-            f'modify_sniffles '
+        mod_job.command(
+            'modify_sniffles '
             f'--vcf_in {local_vcf} '
-            f'--vcf_out {modifier_job.output} '
-            f'--ext_id {sequencing_group.external_id} '
-            f'--int_id {sequencing_group.id} '
-            f'--fa {fasta.fa} '
-            f'--fai {fasta.fai} ',
+            f'--vcf_out {mod_job.output} '
+            f'--ext_id {sg.external_id} '
+            f'--int_id {sg.id} '
+            f'--fa {fasta} ',
         )
 
         # block-gzip and index that result
-        tabix_job = get_batch().new_job(f'BGZipping and Indexing for {sequencing_group.id}', {'tool': 'bcftools'})
+        tabix_job = get_batch().new_job(f'BGZipping and Indexing for {sg.id}', {'tool': 'bcftools'})
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         tabix_job.image(image=image_path('bcftools'))
         tabix_job.storage('10Gi')
-        tabix_job.command(f'bcftools view {modifier_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')
+        tabix_job.command(f'bcftools view {mod_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')
         tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')
 
         # write from temp storage into GCP
         get_batch().write_output(tabix_job.vcf_out, str(expected_outputs['vcf']).removesuffix('.vcf.bgz'))
 
-        return self.make_outputs(target=sequencing_group, jobs=[modifier_job, tabix_job], data=expected_outputs)
+        return self.make_outputs(target=sg, jobs=[mod_job, tabix_job], data=expected_outputs)
 
 
 @stage(required_stages=ReFormatPacBioSVs)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.5',
+    version='1.26.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_lr_sv_mods.py
+++ b/test/test_lr_sv_mods.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cpg_workflows.scripts.long_read_sniffles_vcf_modifier import translate_var_and_sex_to_cn
 
 
@@ -19,6 +20,7 @@ from cpg_workflows.scripts.long_read_sniffles_vcf_modifier import translate_var_
 )
 def test_calculate_cn_male(contig, var_type, gt, expected):
     assert translate_var_and_sex_to_cn(contig, var_type, gt, 1) == expected
+
 
 @pytest.mark.parametrize(
     'contig,var_type,gt,expected',

--- a/test/test_lr_sv_mods.py
+++ b/test/test_lr_sv_mods.py
@@ -1,0 +1,39 @@
+import pytest
+from cpg_workflows.scripts.long_read_sniffles_vcf_modifier import translate_var_and_sex_to_cn
+
+
+@pytest.mark.parametrize(
+    'contig,var_type,gt,expected',
+    (
+        ('chr1', 'DUP', '0/0', 2),
+        ('chr1', 'DUP', '0/1', 3),
+        ('chr1', 'DUP', '1/1', 4),
+        ('chr1', 'OTHER', '0/1', 2),
+        ('chr1', 'OTHER', '1/1', 2),
+        ('chrX', 'DUP', '0/1', 2),
+        ('chrX', 'DUP', '0|0', 1),
+        ('chrY', 'DUP', '0/1', 2),
+        ('chrY', 'DUP', '0/0', 1),
+        ('chrM', 'DUP', '0/1', 2),
+    ),
+)
+def test_calculate_cn_male(contig, var_type, gt, expected):
+    assert translate_var_and_sex_to_cn(contig, var_type, gt, 1) == expected
+
+@pytest.mark.parametrize(
+    'contig,var_type,gt,expected',
+    (
+        ('chr1', 'DUP', '0/0', 2),
+        ('chr1', 'DUP', '0/1', 3),
+        ('chr1', 'DUP', '1/1', 4),
+        ('chr1', 'OTHER', '0/1', 2),
+        ('chr1', 'OTHER', '1/1', 2),
+        ('chrX', 'DUP', '0/1', 3),
+        ('chrX', 'DUP', '0|0', 2),
+        ('chrY', 'DUP', '0/1', 1),
+        ('chrY', 'DUP', '0/0', 0),
+        ('chrM', 'DUP', '0/1', 2),
+    ),
+)
+def test_calculate_cn_female(contig, var_type, gt, expected):
+    assert translate_var_and_sex_to_cn(contig, var_type, gt, 2) == expected


### PR DESCRIPTION
To get data in the right format for Seqr we need a 'CN' attribute in the VCFs, which Sniffles has not provided. This change updates the Sniffles VCF modifier script: 

- take the sex (int) of the individual
- for each variant use the sex and contig name to determine a baseline copy number
- count number of alt alleles at this variant, and adjust the CN up or down according to the variant type

Based on Seqr's display, CN only matters for DEL and DUP. All other types just take a placeholder value.

Slight change to the Stage

- no need to pass both Fasta and index separately
- pass the sex value for the SequencingGroup from the pedigree as an integer
- I changed some variable names to reduce the line count, but... that didn't work