### PR TITLE
Generate new intervals from MT

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.9
+current_version = 1.26.10
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.9
+  VERSION: 1.26.10
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -3,21 +3,32 @@ Generate new intervals from a MatrixTable based on data distribution
 A wrapper for the generate_new_intervals.py script
 """
 
+from argparse import ArgumentParser
+
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch
 
-# some hard coded paths
-save_bed = 'gs://cpg-seqr-test/seqr_loader/new_intervals.bed'
-input_mt = 'gs://cpg-seqr-test/seqr_loader/1d93d4819ca2d100c5108e4b0973915b5eb4a9_3905/AnnotateCohort/cohort.mt'
 
-job = get_batch().new_bash_job('generate_intervals')
+parser = ArgumentParser()
+parser.add_argument('--mt', help='MatrixTable to generate intervals from')
+parser.add_argument('--out', help='Output intervals file - path to write the resulting BED in GCP')
+parser.add_argument('--meres', help='.interval_list file with intervals to exclude (Centro/Telomeres)')
+parser.add_argument('--intervals', help='Number of intervals to generate', type=int)
+args = parser.parse_args()
+
+job = get_batch().new_bash_job(f'Generate {args.intervals} intervals from {args.mt}')
 authenticate_cloud_credentials_in_job(job)
 job.image(config_retrieve(['workflow', 'driver_image']))
 
-# read this file in locally
-meres = 'gs://cpg-common-test/references/hg38/v0/hg38.telomeresAndMergedCentromeres.interval_list'
-meres_in = get_batch().read_input(meres)
+# localise the centromere/telomere file in the batch
+meres_in = get_batch().read_input(args.meres)
 
-job.command(f'new_intervals_from_mt --mt {input_mt} --out {job.output} --meres_file {meres_in} --intervals 1500')
-get_batch().write_output(job.output, save_bed)
+job.command(
+    'new_intervals_from_mt '
+    f'--mt {args.mt} '
+    f'--out {job.output} '
+    f'--meres_file {meres_in} '
+    f'--intervals {args.intervals}',
+)
+get_batch().write_output(job.output, args.out)
 get_batch().run(wait=False)

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -4,7 +4,7 @@ A wrapper for the generate_new_intervals.py script
 """
 
 from cpg_utils.config import config_retrieve
-from cpg_utils.hail_batch import get_batch, authenticate_cloud_credentials_in_job
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch
 
 # some hard coded paths
 save_bed = 'gs://cpg-seqr-test/seqr_loader/new_intervals.bed'

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -1,0 +1,23 @@
+"""
+Generate new intervals from a MatrixTable based on data distribution
+A wrapper for the generate_new_intervals.py script
+"""
+
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import get_batch, authenticate_cloud_credentials_in_job
+
+# some hard coded paths
+save_bed = 'gs://cpg-seqr-test/seqr_loader/new_intervals.bed'
+input_mt = 'gs://cpg-seqr-test/seqr_loader/1d93d4819ca2d100c5108e4b0973915b5eb4a9_3905/AnnotateCohort/cohort.mt'
+
+job = get_batch().new_bash_job('generate_intervals')
+authenticate_cloud_credentials_in_job(job)
+job.image(config_retrieve(['workflow', 'driver_image']))
+
+# read this file in locally
+meres = 'gs://cpg-common-test/references/hg38/v0/hg38.telomeresAndMergedCentromeres.interval_list'
+meres_in = get_batch().read_input(meres)
+
+job.command(f'new_intervals_from_mt --mt {input_mt} --out {job.output} --meres_file {meres_in} --intervals 1500')
+get_batch().write_output(job.output, save_bed)
+get_batch().run(wait=False)

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -8,7 +8,6 @@ from argparse import ArgumentParser
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch
 
-
 parser = ArgumentParser()
 parser.add_argument('--mt', help='MatrixTable to generate intervals from')
 parser.add_argument('--out', help='Output intervals file - path to write the resulting BED in GCP')

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -1,0 +1,174 @@
+"""
+Generate new intervals from a MatrixTable based on data distribution
+
+First we read the MT, and generate rough intervals based on the rows
+My understanding is that this is a based on the distribution of keys, so
+each partition will have roughly the same number of keys (i.e. variants)
+
+This initial group of intervals is split such that each interval fully sits
+on a contig. This is to avoid issues with cross-contig intervals.
+
+Then we polish the intervals by dodging centromeres and telomeres. This is
+done by reading in an interval_list file, which contains the centromere and
+telomere regions. We then check if the intervals overlap with these regions,
+and if so, we split the intervals around the centromere/telomere.
+
+For telomere overlaps, we shift the start or end position of the interval
+to outside the telomere region.
+
+For centromere overlaps, we split the intervals around the centromere, creating
+two new intervals.
+
+The input argument --intervals is the initial number of intervals created. Due to
+splitting this can then jump up a bit (in a small test this was +50). This may be
+negligible on larger splits, but for smaller interval counts can be huge.
+"""
+
+
+from argparse import ArgumentParser
+import logging
+
+import hail as hl
+
+
+def get_naive_intervals(mt: hl.MatrixTable, intervals: int) -> list[tuple[str, int, int]]:
+    """
+    Get naive new intervals from a MatrixTable
+
+    Args:
+        mt (hl.MatrixTable): Input MatrixTable
+        intervals (int): Number of intervals to generate
+
+    Returns:
+        list[tuple[str, int, int]]: List of intervals, in non-hail form
+    """
+    naive_interval_structs = mt._calculate_new_partitions(intervals)
+
+    # store both start and end positions separately
+    new_intervals = [
+        (
+            interval.start.locus.contig,
+            interval.start.locus.position,
+            interval.end.locus.contig,
+            interval.end.locus.position,
+        )
+        for interval in naive_interval_structs
+    ]
+
+    # check for cross-contig intervals, and split
+    final_intervals: list[tuple[str, int, int]] = []
+    for contig1, start, contig2, end in new_intervals:
+        if contig1 != contig2:
+            # get the end of the first
+            first_end = hl.get_reference('GRCh38').lengths[contig1]
+            final_intervals.append((contig1, start, first_end))
+            final_intervals.append((contig2, 0, end))
+        else:
+            final_intervals.append((contig1, start, end))
+
+    return final_intervals
+
+
+def overlaps(a: tuple[int, int], b: tuple[int, int]) -> int:
+    """
+    Return the amount of overlap, in bp
+    between a and b.
+    If >0, the number of bp of overlap
+    If 0,  they are book-ended.
+    If <0, the distance in bp between them
+    """
+
+    if (overlap := min(a[1], b[1]) - max(a[0], b[0])) > 0:
+        return overlap
+    return 0
+
+
+def polish_intervals(naive_intervals: list[tuple[str, int, int]], meres_file: str) -> list[tuple[str, int, int]]:
+    """
+    Polish intervals by splitting/removing centromere and telomere regions
+    Args:
+        naive_intervals (list): naive intervals, each limited to a single contig
+        meres_file (str): path to file containing centromere and telomere regions
+
+    Returns:
+        a polished version of the intervals file, where no centromere or telomere regions are present
+    """
+    telomeres: dict[str, list[tuple[int, int]]] = {}
+    centromeres: dict[str, tuple[int, int]] = {}
+
+    with open(meres_file, encoding='utf-8') as f:
+        for line in f:
+            if line.startswith('@SQ') or line.startswith('@HD'):
+                continue
+
+            contig, start_str, end_str, strand, region_type = line.strip().split('\t')
+            if 'centromere' in region_type:
+                centromeres[contig] = (int(start_str), int(end_str))
+            else:
+                telomeres.setdefault(contig, []).append((int(start_str), int(end_str)))
+
+    new_intervals: list[tuple[str, int, int]] = []
+    for chrom, start, end in naive_intervals:
+        found_overlap = False
+        # does this overlap with a telomere?
+        for telo in telomeres.get(chrom, []):
+            # there's an overlap
+            if overlaps(telo, (start, end)):
+                found_overlap = True
+                # this is a 'start' telomere, shift the start coord
+                if telo[0] == 1:
+                    new_intervals.append((chrom, telo[1], end))
+                # otherwise shift the end coord
+                else:
+                    new_intervals.append((chrom, start, telo[0]))
+                break
+        # does it overlap with a centromere?`If so split around it
+        if centro_region := centromeres.get(chrom):
+            # check for an overlap
+            if overlaps(centro_region, (start, end)):
+                found_overlap = True
+                # check we have some interval left
+                if centro_region[0] > start:
+                    new_intervals.append((chrom, start, centro_region[0]))
+                if end > centro_region[1]:
+                    new_intervals.append((chrom, centro_region[1], end))
+        if not found_overlap:
+            new_intervals.append((chrom, start, end))
+
+    return new_intervals
+
+
+def cli_main():
+    parser = ArgumentParser(description='Generate new intervals from a list of intervals')
+    parser.add_argument('--mt', help='Input MatrixTable')
+    parser.add_argument('--out', help='Output intervals file')
+    parser.add_argument('--intervals', help='Intervals to generate', type=int, default=100)
+    parser.add_argument('--meres_file', help='interval_list file of Centromere & telomere regions')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    main(args.mt, args.out, intervals=args.intervals, meres=args.meres_file)
+
+
+def main(mt: str, out: str, intervals: int, meres: str):
+    hl.init(default_reference='GRCh38')
+    mt = hl.read_matrix_table(mt)
+
+    # generate rough intervals based on the rows in this MT
+    new_intervals = get_naive_intervals(mt, intervals)
+
+    # useful in debugging...
+    # with open('naive_intervals.tsv', 'w') as f:
+    #     for contig, start, end in new_intervals:
+    #         f.write(f'{contig}\t{start}\t{end}\n')
+
+    # polish the intervals by dodging centromeres and telomeres
+    if meres:
+        better_intervals = polish_intervals(new_intervals, meres)
+        with open(out, 'w') as f:
+            for contig, start, end in better_intervals:
+                f.write(f'{contig}\t{start}\t{end}\n')
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -62,7 +62,7 @@ def get_naive_intervals(mt: hl.MatrixTable, intervals: int) -> list[tuple[str, i
             # get the end of the first
             first_end = hl.get_reference('GRCh38').lengths[contig1]
             final_intervals.append((contig1, start, first_end))
-            final_intervals.append((contig2, 0, end))
+            final_intervals.append((contig2, 1, end))
         else:
             final_intervals.append((contig1, start, end))
 

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -24,9 +24,8 @@ splitting this can then jump up a bit (in a small test this was +50). This may b
 negligible on larger splits, but for smaller interval counts can be huge.
 """
 
-
-from argparse import ArgumentParser
 import logging
+from argparse import ArgumentParser
 
 import hail as hl
 
@@ -74,10 +73,7 @@ def get_naive_intervals(mt: hl.MatrixTable, intervals: int) -> list[tuple[str, i
         else:
             # if this is the final interval on this chromosome, shift the end position to the end of the chromosome
             # true if this is the latest interval on this chromosome
-            if index == len(new_intervals):
-                final_intervals.append((contig1, start, hl.get_reference('GRCh38').lengths[contig1]))
-            # or the next interval is on a different chromosome
-            elif new_intervals[index][0] != contig1:
+            if index == len(new_intervals) or new_intervals[index][0] != contig1:
                 final_intervals.append((contig1, start, hl.get_reference('GRCh38').lengths[contig1]))
             else:
                 final_intervals.append((contig1, start, end))

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -31,6 +31,7 @@ import hail as hl
 
 from cpg_utils.hail_batch import init_batch
 
+
 def get_naive_intervals(mt: hl.MatrixTable, intervals: int) -> list[tuple[str, int, int]]:
     """
     Get naive new intervals from a MatrixTable

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -169,8 +169,7 @@ def cli_main():
 
 
 def main(mt: str, out: str, intervals: int, meres: str):
-    hl.init(default_reference='GRCh38')
-    # init_batch()
+    init_batch()
     mt = hl.read_matrix_table(mt)
 
     # generate rough intervals based on the rows in this MT

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ setup(
             'modify_sniffles = cpg_workflows.scripts.long_read_sniffles_vcf_modifier:cli_main',
             # for use in translating a MatrixTable to an ES index, first localising the MT
             'mt_to_es = cpg_workflows.scripts.mt_to_es_without_dataproc:main',
+            # Generate new intervals from a MatrixTable
+            'new_intervals_from_mt = cpg_workflows.scripts.generate_new_intervals:cli_main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.9',
+    version='1.26.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Generate new intervals from a naive MatrixTable interval inference, polished using a telo/centromeres region file.

This is a pretty simplistic approach:
- use hail to calculate `n` intervals in a MT
- if any of those intervals span two chromosomes, split 'em
- If this is the first interval on the contig, force the start position to 0. If it's the last, force the end position on == contig length.
- then clean each interval:
   - if it overlaps with a telomere, shrink the start/stop so that it doesn't
   - if it overlaps with a centromere, split it into two new non-overlapping intervals

I've only run this on a teeny dataset to test, but it completed in a few seconds and the results look usable. I've not checked if the resulting intervals are roughly balanced in terms of data content.

The Centro/Telomere splitting will also create some baby intervals, a secondary cleanup stage where intervals under a certain size threshold are merged with an adjacent interval could be a decent addition.