### PR TITLE
SequencingGroup Sex attribute passed correctly

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.6
+current_version = 1.26.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.6
+  VERSION: 1.26.7
 
 jobs:
   docker:

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -114,7 +114,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             f'--ext_id {sg.external_id} '
             f'--int_id {sg.id} '
             f'--fa {fasta} '
-            f'--sex {sg.pedigree.sex} ',
+            f'--sex {sg.sex or 0} ',
         )
 
         # block-gzip and index that result

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -107,6 +107,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
         fasta = get_batch().read_input_group(**{'fa': ref_fasta, 'fa.fai': f'{ref_fasta}.fai'})['fa']
 
         # the console entrypoint for the sniffles modifier script has only existed since 1.25.13, requires >=1.25.13
+        sex = sg.pedigree.sex.value if sg.pedigree.sex else 0
         mod_job.command(
             'modify_sniffles '
             f'--vcf_in {local_vcf} '
@@ -114,7 +115,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             f'--ext_id {sg.external_id} '
             f'--int_id {sg.id} '
             f'--fa {fasta} '
-            f'--sex {sg.sex or 0} ',
+            f'--sex {sex} ',
         )
 
         # block-gzip and index that result

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.6',
+    version='1.26.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
My linter didn't like the idea of `sequencing_group.sex`:
<img width="675" alt="Screenshot 2024-08-09 at 10 30 38 AM" src="https://github.com/user-attachments/assets/fe235240-24a9-4d7a-8133-b5ece609c08c">

So I put in `sequencing_group.pedigree.sex`, which passed the String, not the enum Value:
```
modify_sniffles: error: argument --sex: invalid int value: 'FEMALE'
```

I don't really understand those events. `sex` is definitely a valid attribute on SG, and I thought it should have been an int. IDK. I've tried to fix this by passing `sg.pedigree.sex.value` to get the integer value of the enum, matching how this is done in `get_ped_dict`
