### PR TITLE
Insert new ID, don't replace

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.7
+current_version = 1.26.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.7
+  VERSION: 1.26.8
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -94,7 +94,7 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, new_id: str | None
             # alter the sample line in the header
             if line.startswith('#'):
                 if 'FORMAT=<ID=ID' in line:
-                    f_out.write('##FORMAT=<ID=GCN,Number=1,Type=Integer,Description="Copy number of this variant">')
+                    f_out.write('##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number of this variant">\n')
 
                 if line.startswith('#CHR') and new_id:
                     l_split = line.rstrip().split('\t')

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -54,30 +54,15 @@ def cli_main():
     parser = ArgumentParser(description='CLI for the Sniffles VCF modification script')
     parser.add_argument('--vcf_in', help='Path to a localised VCF, this will be modified', required=True)
     parser.add_argument('--vcf_out', help='Path to an output location for the modified VCF', required=True)
+    parser.add_argument('--new_id', help='The Sample ID we want in the output VCF', default=None)
     parser.add_argument('--fa', help='Path to a FASTA sequence file for GRCh38', required=True)
-    parser.add_argument('--ext_id', help='Path to the Sample ID in the input VCF', default=None)
-    parser.add_argument('--int_id', help='Path to the Sample ID we want in the output VCF', default=None)
     parser.add_argument('--sex', help='0=Unknown,1=Male, 2=Female', default=0, type=int)
     args = parser.parse_args()
 
-    modify_sniffles_vcf(
-        file_in=args.vcf_in,
-        file_out=args.vcf_out,
-        fa=args.fa,
-        ext_id=args.ext_id,
-        int_id=args.int_id,
-        sex=args.sex,
-    )
+    modify_sniffles_vcf(file_in=args.vcf_in, file_out=args.vcf_out, fa=args.fa, new_id=args.new_id, sex=args.sex)
 
 
-def modify_sniffles_vcf(
-    file_in: str,
-    file_out: str,
-    fa: str,
-    ext_id: str | None = None,
-    int_id: str | None = None,
-    sex: int = 0,
-):
+def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, new_id: str | None = None, sex: int = 0):
     """
     Scrolls through the VCF and performs a few updates:
 
@@ -91,8 +76,7 @@ def modify_sniffles_vcf(
         file_in (str): localised, VCF directly from Sniffles
         file_out (str): local batch output path, same VCF with INFO/ALT alterations
         fa (str): path to a reference FastA file, requires an implicit fa.fai index
-        ext_id (str): external ID to replace (if found)
-        int_id (str): CPG ID, required inside the reformatted VCF
+        new_id (str): CPG ID, required inside the reformatted VCF
         sex (int): 0=Unknown, 1=Male, 2=Female
     """
 
@@ -112,11 +96,11 @@ def modify_sniffles_vcf(
                 if 'FORMAT=<ID=ID' in line:
                     f_out.write('##FORMAT=<ID=GCN,Number=1,Type=Integer,Description="Copy number of this variant">')
 
-                if line.startswith('#CHR') and (ext_id and int_id):
-                    print(line)
-                    line = line.replace(ext_id, int_id)
-                    print('Modified header line')
-                    print(line)
+                if line.startswith('#CHR') and new_id:
+                    l_split = line.rstrip().split('\t')
+                    l_split[9] = new_id
+                    f_out.write('\t'.join(l_split) + '\n')
+                    continue
 
                 f_out.write(line)
                 continue

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -112,8 +112,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             'modify_sniffles '
             f'--vcf_in {local_vcf} '
             f'--vcf_out {mod_job.output} '
-            f'--ext_id {sg.external_id} '
-            f'--int_id {sg.id} '
+            f'--new_id {sg.id} '
             f'--fa {fasta} '
             f'--sex {sex} ',
         )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.7',
+    version='1.26.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In the LR SV modification script I was doing a string replacement for old ID -> new ID

In one instance this didn't match, and that threw the whole pipeline off, as the ID wasn't updated.

This PR changes the exact string replacement to a blind replacement, which solves this issue. I've messaged separately on Slack with more details

Drops a few lines by condensing the method calls, but the only change in the script is `ext_id and int_id -> just new_id` inside the script, and inside the stage that calls the script.