### PR TITLE
gCNV Correction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.26.10
+current_version = 1.26.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.26.10
+  VERSION: 1.26.11
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.26.10',
+    version='1.26.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
`SGID.Dataset.Cohort` in the cpg_workflows API isn't necessarily the Cohort which contains this SGID. That's a quirk of using the connection between SGID, Dataset, Cohort, and MultiCohort to navigate between the layers in the hierarchy.

Since the restructuring PR https://github.com/populationgenomics/production-pipelines/pull/860, we've now got an appropriate way of iterating over the Cohorts in a MultiCohort, and finding which Cohort each Sequencing group belongs to. There isn't currently a shorthand method in the API for this, so I've added this little code block to iterate over the cohorts and find the correct one for each SG, then use that Cohort object to track down the appropriate previous Stage outputs. 

It's a bit hacky, but what about this pipeline isn't at least a little hacky...

We'd like to solve this better with API streamlining, but with a lot of the team absent over Winter we're holding off on substantive API changes.