### PR TITLE
Add option to use a custom bed file to define joint genotyping intervals

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.0
+current_version = 1.27.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.0
+  VERSION: 1.27.1
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -77,6 +77,7 @@ def make_joint_genotyping_jobs(
     jobs: list[Job] = []
     intervals: list[str] | list[hb.ResourceFile] = []
     if intervals_path and intervals_path.suffix == '.bed':
+        intervals_j = None
         intervals = get_intervals_from_bed(intervals_path)
     else:
         intervals_j, intervals = get_intervals(

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -65,15 +65,6 @@ def make_joint_genotyping_jobs(
         raise ValueError('Provided samples collection for joint calling should contain at least one active sample')
     scatter_count = scatter_count or joint_calling_scatter_count(len(gvcf_by_sgid))
 
-    all_output_paths = [out_vcf_path, out_siteonly_vcf_path]
-    if out_siteonly_vcf_part_paths:
-        assert len(out_siteonly_vcf_part_paths) == scatter_count
-        all_output_paths.extend(out_siteonly_vcf_part_paths)
-    if can_reuse(all_output_paths + [to_path(f'{p}.tbi') for p in all_output_paths]):
-        return []
-
-    logging.info('Submitting joint-calling jobs')
-
     jobs: list[Job] = []
     intervals: list[str] | list[hb.ResourceFile] = []
     if intervals_path and intervals_path.suffix == '.bed':
@@ -91,6 +82,15 @@ def make_joint_genotyping_jobs(
         )
     if intervals_j:
         jobs.append(intervals_j)
+
+    logging.info('Submitting joint-calling jobs')
+
+    all_output_paths = [out_vcf_path, out_siteonly_vcf_path]
+    if out_siteonly_vcf_part_paths:
+        assert len(out_siteonly_vcf_part_paths) == scatter_count
+        all_output_paths.extend(out_siteonly_vcf_part_paths)
+    if can_reuse(all_output_paths + [to_path(f'{p}.tbi') for p in all_output_paths]):
+        return []
 
     vcfs: list[hb.ResourceGroup] = []
     siteonly_vcfs: list[hb.ResourceGroup] = []

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -431,12 +431,15 @@ def _add_excess_het_filter(
     b: hb.Batch,
     input_vcf: hb.ResourceGroup,
     excess_het_threshold: float = 54.69,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     output_vcf_path: Path | None = None,
     job_attrs: dict | None = None,
 ) -> tuple[Job | None, hb.ResourceGroup]:
     """
-    Filter a large cohort callset on Excess Heterozygosity.
+    Filter a large cohort callset on Excess Heterozygosity, over a single interval.
+
+    The input interval can either be an interval_list file, or a string in the format
+    'chrN:start-end'. Either can be passed to GATK VariantFiltration.
 
     The filter applies only to large callsets (`not is_small_callset`)
 

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -79,6 +79,7 @@ def make_joint_genotyping_jobs(
     if intervals_path and intervals_path.suffix == '.bed':
         intervals_j = None
         intervals = get_intervals_from_bed(intervals_path)
+        scatter_count = len(intervals)
     else:
         intervals_j, intervals = get_intervals(
             b=b,

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -68,10 +68,12 @@ def make_joint_genotyping_jobs(
     jobs: list[Job] = []
     intervals: list[str] | list[hb.ResourceFile] = []
     if intervals_path and intervals_path.suffix == '.bed':
+        # If intervals_path is a bed file, read the intervals directly
         intervals_j = None
         intervals = get_intervals_from_bed(intervals_path)
-        scatter_count = len(intervals)
+        assert scatter_count == len(intervals)
     else:
+        # If intervals_path is not specified, use the get_intervals picard job
         intervals_j, intervals = get_intervals(
             b=b,
             source_intervals_path=intervals_path,

--- a/cpg_workflows/stages/joint_genotyping.py
+++ b/cpg_workflows/stages/joint_genotyping.py
@@ -5,7 +5,7 @@ Stage that performs joint genotyping of GVCFs using GATK.
 import logging
 
 from cpg_utils import to_path
-from cpg_utils.config import get_config
+from cpg_utils.config import config_retrieve, get_config
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.filetypes import GvcfPath
 from cpg_workflows.jobs import joint_genotyping
@@ -58,6 +58,14 @@ class JointGenotyping(MultiCohortStage):
             to_path(outputs['siteonly_part_pattern'].format(idx=idx)) for idx in range(scatter_count)
         ]
 
+        intervals_path = None
+        if config_retrieve(['workflow', 'intervals_path']):
+            intervals_path = to_path(config_retrieve(['workflow', 'intervals_path']))
+
+        exclude_intervals_path = None
+        if config_retrieve(['workflow', 'exclude_intervals_path']):
+            exclude_intervals_path = to_path(config_retrieve(['workflow', 'exclude_intervals_path']))
+
         jc_jobs = joint_genotyping.make_joint_genotyping_jobs(
             b=get_batch(),
             out_vcf_path=outputs['vcf'],
@@ -69,8 +77,8 @@ class JointGenotyping(MultiCohortStage):
                 if get_config()['workflow'].get('use_gnarly', False)
                 else joint_genotyping.JointGenotyperTool.GenotypeGVCFs
             ),
-            intervals_path=get_config()['workflow'].get('intervals_path'),
-            exclude_intervals_path=get_config()['workflow'].get('exclude_intervals_path'),
+            intervals_path=intervals_path,
+            exclude_intervals_path=exclude_intervals_path,
             job_attrs=self.get_job_attrs(),
             scatter_count=scatter_count,
             out_siteonly_vcf_part_paths=out_siteonly_vcf_part_paths,

--- a/cpg_workflows/stages/joint_genotyping.py
+++ b/cpg_workflows/stages/joint_genotyping.py
@@ -59,11 +59,11 @@ class JointGenotyping(MultiCohortStage):
         ]
 
         intervals_path = None
-        if config_retrieve(['workflow', 'intervals_path']):
+        if config_retrieve(['workflow', 'intervals_path'], default=None):
             intervals_path = to_path(config_retrieve(['workflow', 'intervals_path']))
 
         exclude_intervals_path = None
-        if config_retrieve(['workflow', 'exclude_intervals_path']):
+        if config_retrieve(['workflow', 'exclude_intervals_path'], default=None):
             exclude_intervals_path = to_path(config_retrieve(['workflow', 'exclude_intervals_path']))
 
         jc_jobs = joint_genotyping.make_joint_genotyping_jobs(

--- a/cpg_workflows/stages/joint_genotyping.py
+++ b/cpg_workflows/stages/joint_genotyping.py
@@ -53,6 +53,8 @@ class JointGenotyping(MultiCohortStage):
 
         # create expected outputs once
         outputs = self.expected_outputs(multicohort)
+
+        # If defining intervals with a custom bed file, make sure the scatter count matches the number of intervals
         scatter_count = joint_calling_scatter_count(len(gvcf_by_sgid))
         out_siteonly_vcf_part_paths = [
             to_path(outputs['siteonly_part_pattern'].format(idx=idx)) for idx in range(scatter_count)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.0',
+    version='1.27.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In the `JointGenotyping` stage jobs (`GenomicsDBImport`, `GenotypeGVCFs`, and `VariantFiltration`/`ExcessHetFilter`), the intervals over which we genotype are defined by `.interval_list` files which are created by splitting the Broad's `wgs_calling_regions.hg38.interval_list` into `scatter_count` fragments using Picard `IntervalListTools`.  

However, in the above jobs, the input intervals can also be defined using a string of the form `"chrN:{start}-{stop}"`. 

This PR introduces a method to extract the string start and stop values from a user provided .bed file containing a number of intervals. By using the script added in https://github.com/populationgenomics/production-pipelines/pull/883, we can create `~N` equally sized intervals from a cohort mt and then save these intervals as a bed file. This bed file can then be read by the `JointGenotyping` jobs, guaranteeing that all intervals are approximately equally sized (in terms of the number of variants in the region, not the number of basepairs), and also ensuring that no intervals are defined across both sides of a centromere or telomere. 

The cpg_workflows code does not need to change much to facilitate this new approach. If the user provides an intervals .bed file and specifies the scatter_count as the number of intervals in the bed file, then the intervals will be extracted and passed as strings. If the user does not specify the custom intervals bed file, then we will fall back to the old method of using the Broad calling list, split with the Picard `get_intervals` job.
The reason this change is so simple is because the GATK jobs can take the interval_list file as a Hail Batch `ResourceFile` in the `-L {interval}` argument, OR it can take a string with the chromosome+start and stop position. So, we can define each interval with the python type `hb.Resource | str`, and the jobs will work either way. 

One extra small note is that we need to increment the start position by 1 when reading from the bed file, to match what GATK expects from an interval list.

--- 

## Tests

[This job](https://batch.hail.populationgenomics.org.au/batches/478897/jobs/1) utilised the interval generation script from #883 to create an intervals bed file with 147 intervals. [This batch](https://batch.hail.populationgenomics.org.au/batches/478967) ran the JointGenotyping stage by extracting the 147 intervals from the bed file created in the previous step, and passing them as strings to the 147 GATK jobs. 

[This batch](https://batch.hail.populationgenomics.org.au/batches/478987) shows that the old method still works fine, where no input scatter count or bed file are provided, so the Picard job is used to create 50 interval_list files which are passed to each GATK job.

Noting that neither of these examples test the `VariantFiltration`/Excess Het Filter jobs, because they require a large number of samples. The functionality of the [VariantFiltration](https://gatk.broadinstitute.org/hc/en-us/articles/360037434691-VariantFiltration#--intervals) jobs with the intervals should be the same as it is for the `GenomicsDBImport` and `GenotypeGVCFs` jobs. 

---

Once this is merged, the genome seqr load can be started with (hopefully) drastically improved performance.