### PR TITLE
Variant recalibrator bed intervals

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.1
+current_version = 1.27.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.1
+  VERSION: 1.27.2
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/vqsr.py
+++ b/cpg_workflows/jobs/vqsr.py
@@ -16,6 +16,7 @@ from hailtop.batch.job import Job
 from cpg_utils import Path, to_path
 from cpg_utils.config import get_config, image_path, reference_path
 from cpg_utils.hail_batch import command
+from cpg_workflows.jobs.joint_genotyping import get_intervals_from_bed
 from cpg_workflows.jobs.picard import get_intervals
 from cpg_workflows.jobs.vcf import gather_vcfs
 from cpg_workflows.resources import HIGHMEM, STANDARD, joint_calling_scatter_count
@@ -192,13 +193,20 @@ def make_vqsr_jobs(
         b.write_output(model_j.model_file, str(snp_model_path))
     snp_model = b.read_input(str(snp_model_path))
 
-    intervals_j, intervals = get_intervals(
-        b=b,
-        scatter_count=scatter_count,
-        source_intervals_path=intervals_path,
-        job_attrs=job_attrs,
-        output_prefix=tmp_prefix / f'intervals_{scatter_count}',
-    )
+    intervals: list[str] | list[hb.ResourceFile] = []
+    if intervals_path and intervals_path.suffix == '.bed':
+        # If intervals_path is a bed file, read the intervals directly
+        intervals_j = None
+        intervals = get_intervals_from_bed(intervals_path)
+        assert scatter_count == len(intervals)
+    else:
+        intervals_j, intervals = get_intervals(
+            b=b,
+            scatter_count=scatter_count,
+            source_intervals_path=intervals_path,
+            job_attrs=job_attrs,
+            output_prefix=tmp_prefix / f'intervals_{scatter_count}',
+        )
     if intervals_j:
         jobs.append(intervals_j)
 
@@ -510,7 +518,7 @@ def snps_recalibrator_scattered(
     dbsnp_resource_vcf: hb.ResourceGroup,
     disk_size: int,
     use_as_annotations: bool,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     max_gaussians: int = 6,
     is_small_callset: bool = False,
     job_attrs: dict | None = None,
@@ -687,7 +695,7 @@ def apply_recalibration_snps(
     disk_size: int,
     use_as_annotations: bool,
     filter_level: float,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     job_attrs: dict | None = None,
 ) -> Job:
     """
@@ -745,7 +753,7 @@ def apply_recalibration_indels(
     disk_size: int,
     use_as_annotations: bool,
     filter_level: float,
-    interval: hb.Resource | None = None,
+    interval: hb.Resource | str | None = None,
     output_vcf_path: Path | None = None,
     job_attrs: dict | None = None,
 ) -> Job:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.1',
+    version='1.27.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Use the intervals from an intervals.bed file for the vqsr jobs the same way as was introduced for the joint genotyping jobs https://github.com/populationgenomics/production-pipelines/pull/892, making these stages compatible.

This is the last stage in the pipeline that uses scattered intervals that need to be passed around like this, so it should run to completion after this.