### PR TITLE
Vqsr stage bed intervals

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.2
+current_version = 1.27.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.2
+  VERSION: 1.27.3
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.2',
+    version='1.27.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Follow up to https://github.com/populationgenomics/production-pipelines/pull/893 - the VQSR stage needs to cast the intervals.bed path from a string to pathlike for it to work with the jobs.