### PR TITLE
Fix missing population probability annotations in sample_qc_ht during Ancestry stage removal

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -177,7 +177,7 @@ def run(
         n_pcs=n_pcs,
         out_ht_path=out_inferred_pop_ht_path,
     )
-    sample_qc_ht.annotate(**pop_ht[sample_qc_ht.key])
+    sample_qc_ht = sample_qc_ht.annotate(**pop_ht[sample_qc_ht.key])
     sample_qc_ht.checkpoint(str(out_sample_qc_ht_path), overwrite=True)
     return scores_ht, eigenvalues_ht, loadings_ht, sample_qc_ht
 


### PR DESCRIPTION
During removal of Ancestry stage from dataproc I uncovered a bug where the `sample_qc_ht` variable is annotated with the inferred population probabilities. However, this doesn't actually happen because the variable is not reassigned after the annotation happens and so neither the checkpointed nor returned version will contain the new columns (`prob_<population>`).

As seen in the logging statements that print out the `sample_qc_ht` before and after annotation, you can see that table is unchanged, https://batch.hail.populationgenomics.org.au/batches/482959/jobs/2

**Fix**:
Assign the annotated table back to the variable name so that the annotated version is checkpointed and returned (instead of the un-annotated version)
Fix is deployed in this batch run, will investigate when it completes: https://batch.hail.populationgenomics.org.au/batches/483000/jobs/1