### PR TITLE
Interval script max length arg

### DIFF
--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -28,7 +28,7 @@ job.command(
     f'--mt {args.mt} '
     f'--out {job.output} '
     f'--meres_file {meres_in} '
-    f'--intervals {args.intervals}'
+    f'--intervals {args.intervals} '
     f'--max_length {args.max_length}',
 )
 get_batch().write_output(job.output, args.out)

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -28,7 +28,7 @@ job.command(
     f'--mt {args.mt} '
     f'--out {job.output} '
     f'--meres_file {meres_in} '
-    f'--intervals {args.intervals}',
+    f'--intervals {args.intervals}'
     f'--max_length {args.max_length}',
 )
 get_batch().write_output(job.output, args.out)

--- a/cpg_workflows/scripts/generate_intervals_wrapper.py
+++ b/cpg_workflows/scripts/generate_intervals_wrapper.py
@@ -13,9 +13,10 @@ parser.add_argument('--mt', help='MatrixTable to generate intervals from')
 parser.add_argument('--out', help='Output intervals file - path to write the resulting BED in GCP')
 parser.add_argument('--meres', help='.interval_list file with intervals to exclude (Centro/Telomeres)')
 parser.add_argument('--intervals', help='Number of intervals to generate', type=int)
+parser.add_argument('--max_length', help='Max length of an interval', type=int, default=3000000)
 args = parser.parse_args()
 
-job = get_batch().new_bash_job(f'Generate {args.intervals} intervals from {args.mt}')
+job = get_batch().new_bash_job(f'Generate approx. {args.intervals} intervals from {args.mt}')
 authenticate_cloud_credentials_in_job(job)
 job.image(config_retrieve(['workflow', 'driver_image']))
 
@@ -28,6 +29,7 @@ job.command(
     f'--out {job.output} '
     f'--meres_file {meres_in} '
     f'--intervals {args.intervals}',
+    f'--max_length {args.max_length}',
 )
 get_batch().write_output(job.output, args.out)
 get_batch().run(wait=False)

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -100,6 +100,25 @@ def overlaps(a: tuple[int, int], b: tuple[int, int]) -> int:
     return 0
 
 
+def split_interval(interval: tuple[str, int, int], max_interval_size: int) -> list[tuple[str, int, int]]:
+    """
+    Split an interval into approximately evenly sized smaller intervals of at most max_interval_size bp
+    """
+    chrom, start, end = interval
+    interval_size = end - start
+
+    num_splits = (interval_size + max_interval_size - 1) // max_interval_size
+    split_size = interval_size // num_splits
+
+    new_intervals = []
+    for i in range(num_splits):
+        new_start = start + i * split_size
+        new_end = new_start + split_size if i < num_splits - 1 else end
+        new_intervals.append((chrom, new_start, new_end))
+
+    return new_intervals
+
+
 def polish_intervals(
     naive_intervals: list[tuple[str, int, int]], 
     meres_file: str, 
@@ -158,10 +177,7 @@ def polish_intervals(
         # check the length of the interval
         if end - start > max_length:
             # split the interval
-            for new_start in range(start, end, max_length):
-                new_end = min(new_start + max_length, end)
-                new_intervals.append((chrom, new_start, new_end))
-            continue
+            new_intervals.extend(split_interval((chrom, start, end), max_length))
         new_intervals.append((chrom, start, end))
 
     logging.info(f'Final intervals: {len(new_intervals)}')

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -120,12 +120,12 @@ def split_interval(interval: tuple[str, int, int], max_interval_size: int) -> li
 
 
 def polish_intervals(
-    naive_intervals: list[tuple[str, int, int]], 
-    meres_file: str, 
+    naive_intervals: list[tuple[str, int, int]],
+    meres_file: str,
     max_length: int = 3000000,
 ) -> list[tuple[str, int, int]]:
     """
-    Polish intervals by splitting/removing centromere and telomere regions 
+    Polish intervals by splitting/removing centromere and telomere regions
     and setting a max interval length
     Args:
         naive_intervals (list): naive intervals, each limited to a single contig

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -100,9 +100,14 @@ def overlaps(a: tuple[int, int], b: tuple[int, int]) -> int:
     return 0
 
 
-def polish_intervals(naive_intervals: list[tuple[str, int, int]], meres_file: str) -> list[tuple[str, int, int]]:
+def polish_intervals(
+    naive_intervals: list[tuple[str, int, int]], 
+    meres_file: str, 
+    max_length: int = 3000000,
+) -> list[tuple[str, int, int]]:
     """
-    Polish intervals by splitting/removing centromere and telomere regions
+    Polish intervals by splitting/removing centromere and telomere regions 
+    and setting a max interval length
     Args:
         naive_intervals (list): naive intervals, each limited to a single contig
         meres_file (str): path to file containing centromere and telomere regions
@@ -149,6 +154,14 @@ def polish_intervals(naive_intervals: list[tuple[str, int, int]], meres_file: st
                 if end > centro_region[1]:
                     new_intervals.append((chrom, centro_region[1], end))
                 continue
+
+        # check the length of the interval
+        if end - start > max_length:
+            # split the interval
+            for new_start in range(start, end, max_length):
+                new_end = min(new_start + max_length, end)
+                new_intervals.append((chrom, new_start, new_end))
+            continue
         new_intervals.append((chrom, start, end))
 
     logging.info(f'Final intervals: {len(new_intervals)}')
@@ -161,22 +174,23 @@ def cli_main():
     parser.add_argument('--mt', help='Input MatrixTable')
     parser.add_argument('--out', help='Output intervals file')
     parser.add_argument('--intervals', help='Intervals to generate', type=int, default=100)
+    parser.add_argument('--max_length', help='Max length of an interval', type=int, default=3000000)
     parser.add_argument('--meres_file', help='interval_list file of Centromere & telomere regions')
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    main(args.mt, args.out, intervals=args.intervals, meres=args.meres_file)
+    main(args.mt, args.out, intervals=args.intervals, max_length=args.max_length, meres=args.meres_file)
 
 
-def main(mt: str, out: str, intervals: int, meres: str):
+def main(mt: str, out: str, intervals: int, max_length: int, meres: str):
     init_batch()
     mt = hl.read_matrix_table(mt)
 
     # generate rough intervals based on the rows in this MT
     new_intervals = get_naive_intervals(mt, intervals)
 
-    # polish the intervals by dodging centromeres and telomeres
-    better_intervals = polish_intervals(new_intervals, meres)
+    # polish the intervals by dodging centromeres and telomeres and capping the length
+    better_intervals = polish_intervals(new_intervals, meres, max_length)
     with open(out, 'w') as f:
         for contig, start, end in better_intervals:
             f.write(f'{contig}\t{start}\t{end}\n')

--- a/cpg_workflows/scripts/generate_new_intervals.py
+++ b/cpg_workflows/scripts/generate_new_intervals.py
@@ -178,6 +178,7 @@ def polish_intervals(
         if end - start > max_length:
             # split the interval
             new_intervals.extend(split_interval((chrom, start, end), max_length))
+            continue
         new_intervals.append((chrom, start, end))
 
     logging.info(f'Final intervals: {len(new_intervals)}')


### PR DESCRIPTION
Updates the intervals generating script used for JointGenotyping so that the max size of any given interval can be capped with the new argument `--max_length`. 

Intervals above the max size are split evenly after all other processing steps are completed - i.e. after the intervals are extracted from the mt, and the centromeres/telomeres are filtered.

This primarily impacts Chromosome Y, who's intervals are unusually large when extracted from the mt. These large intervals in chrY caused the JointGenotyping jobs to slow down drastically as they were covering regions > 10 Mbp per interval. 

With a max of 3 Mbp (3000000), setting the desired intervals to n=1500 outputs 1577 total intervals, each smaller than 300000 bp in size. Prior to this change, we generated 1544 intervals. So a small increase in the number of intervals in exchange for guaranteeing no regions are particularly oversized. 