### PR TITLE
Add readgroup level stats config option for Picard metrics

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.3
+current_version = 1.27.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.3
+  VERSION: 1.27.4
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -67,6 +67,7 @@ indel_filter_level = 99.0
 [cramqc]
 assume_sorted = true
 num_pcs = 4
+readgroup_metrics = false
 
 [qc_thresholds.genome.min]
 "MEDIAN_COVERAGE" = 10

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -298,7 +298,7 @@ def picard_collect_metrics(
 
     assert cram_path.index_path
 
-    if config_retrieve(['workflow', 'cramqc', 'readgroup_metrics'], default=False):
+    if config_retrieve(['cramqc', 'readgroup_metrics'], default=False):
         readgroup_metrics = """ \\
             METRIC_ACCUMULATION_LEVEL=READ_GROUP """
     else:

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -6,7 +6,7 @@ import hailtop.batch as hb
 from hailtop.batch.job import Job
 
 from cpg_utils import Path
-from cpg_utils.config import get_config, image_path, reference_path
+from cpg_utils.config import config_retrieve, get_config, image_path, reference_path
 from cpg_utils.hail_batch import command, fasta_res_group
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.resources import (
@@ -297,6 +297,13 @@ def picard_collect_metrics(
     sorted_output = get_config()['cramqc']['assume_sorted']
 
     assert cram_path.index_path
+
+    if config_retrieve(['workflow', 'cramqc', 'readgroup_metrics'], default=False):
+        readgroup_metrics = """ \\
+            METRIC_ACCUMULATION_LEVEL=READ_GROUP """
+    else:
+        readgroup_metrics = ""
+
     cmd = f"""\
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}
     CRAI=$BATCH_TMPDIR/{cram_path.index_path.name}
@@ -319,7 +326,7 @@ def picard_collect_metrics(
       PROGRAM=CollectBaseDistributionByCycle \\
       PROGRAM=CollectQualityYieldMetrics \\
       METRIC_ACCUMULATION_LEVEL=null \\
-      METRIC_ACCUMULATION_LEVEL=SAMPLE
+      METRIC_ACCUMULATION_LEVEL=SAMPLE {readgroup_metrics}
 
     ls $BATCH_TMPDIR/
     cp $BATCH_TMPDIR/prefix.alignment_summary_metrics {j.out_alignment_summary_metrics}

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -299,10 +299,9 @@ def picard_collect_metrics(
     assert cram_path.index_path
 
     if config_retrieve(['cramqc', 'readgroup_metrics'], default=False):
-        readgroup_metrics = """ \\
-            METRIC_ACCUMULATION_LEVEL=READ_GROUP """
+        readgroup_metrics = "METRIC_ACCUMULATION_LEVEL=READ_GROUP"
     else:
-        readgroup_metrics = ""
+        readgroup_metrics = "METRIC_ACCUMULATION_LEVEL=SAMPLE"
 
     cmd = f"""\
     CRAM=$BATCH_TMPDIR/{cram_path.path.name}
@@ -326,7 +325,7 @@ def picard_collect_metrics(
       PROGRAM=CollectBaseDistributionByCycle \\
       PROGRAM=CollectQualityYieldMetrics \\
       METRIC_ACCUMULATION_LEVEL=null \\
-      METRIC_ACCUMULATION_LEVEL=SAMPLE {readgroup_metrics}
+      {readgroup_metrics}
 
     ls $BATCH_TMPDIR/
     cp $BATCH_TMPDIR/prefix.alignment_summary_metrics {j.out_alignment_summary_metrics}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.3',
+    version='1.27.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a config option for the Picard `CollectMultipleMetrics` job, to allow alignment summary metrics to be collected at a read group level, as opposed to at a sample level where all read groups are squished together.