### PR TITLE
Config option to run stages for specific datasets in cohort

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.3
+current_version = 1.27.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.3
+  VERSION: 1.27.4
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -24,7 +24,7 @@ vep_version = '110'
 
 # Create Seqr ElasticSearch indices for these datasets. If not specified, will
 # create indices for all input datasets.
-#create_es_index_for_datasets = []
+# create_es_index_for_datasets = []
 
 write_vcf = ["udn-aus"]
 

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -19,6 +19,9 @@ vep_version = '110'
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 
+# Write dataset MTs for these datasets. Required fot the AnnotateDataset stage
+# write_mt_for_datasets = []
+
 # Create Seqr ElasticSearch indices for these datasets. If not specified, will
 # create indices for all input datasets.
 #create_es_index_for_datasets = []

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -423,7 +423,7 @@ class Metamist:
         """
         dataset = dataset or self.default_dataset
         metamist_proj = dataset or self.default_dataset
-        if get_config()['workflow']['access_level'] == 'test':
+        if get_config()['workflow']['access_level'] == 'test' and not metamist_proj.endswith('-test'):
             metamist_proj += '-test'
 
         analyses = query(

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -384,7 +384,6 @@ class Metamist:
         """
         Query the DB to find the last completed joint-calling analysis for the sequencing groups.
         """
-        dataset = dataset or self.default_dataset
         metamist_proj = self.get_metamist_proj(dataset)
 
         data = self.make_aapi_call(
@@ -418,7 +417,6 @@ class Metamist:
         and sequencing type, one Analysis object per sequencing group. Assumes the analysis
         is defined for a single sequencing group (that is, analysis_type=cram|gvcf|qc).
         """
-        dataset = dataset or self.default_dataset
         metamist_proj = self.get_metamist_proj(dataset)
 
         analyses = query(
@@ -463,7 +461,6 @@ class Metamist:
         """
         Tries to create an Analysis entry, returns its id if successful.
         """
-        dataset = dataset or self.default_dataset
         metamist_proj = self.get_metamist_proj(dataset)
 
         if isinstance(type_, AnalysisType):

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -338,7 +338,7 @@ class Metamist:
         and filtering options.
         """
         metamist_proj = dataset_name
-        if get_config()['workflow']['access_level'] == 'test':
+        if get_config()['workflow']['access_level'] == 'test' and not dataset_name.endswith('-test'):
             metamist_proj += '-test'
         logging.info(f'Getting sequencing groups for dataset {metamist_proj}')
 

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -337,9 +337,7 @@ class Metamist:
         Retrieve sequencing group entries for a dataset, in the context of access level
         and filtering options.
         """
-        metamist_proj = dataset_name
-        if get_config()['workflow']['access_level'] == 'test' and not dataset_name.endswith('-test'):
-            metamist_proj += '-test'
+        metamist_proj = self.get_metamist_proj(dataset_name)
         logging.info(f'Getting sequencing groups for dataset {metamist_proj}')
 
         skip_sgs = get_config()['workflow'].get('skip_sgs', [])
@@ -386,9 +384,8 @@ class Metamist:
         """
         Query the DB to find the last completed joint-calling analysis for the sequencing groups.
         """
-        metamist_proj = dataset or self.default_dataset
-        if get_config()['workflow']['access_level'] == 'test':
-            metamist_proj += '-test'
+        dataset = dataset or self.default_dataset
+        metamist_proj = self.get_metamist_proj(dataset)
 
         data = self.make_aapi_call(
             self.aapi.get_latest_complete_analysis_for_type,
@@ -422,9 +419,7 @@ class Metamist:
         is defined for a single sequencing group (that is, analysis_type=cram|gvcf|qc).
         """
         dataset = dataset or self.default_dataset
-        metamist_proj = dataset or self.default_dataset
-        if get_config()['workflow']['access_level'] == 'test' and not metamist_proj.endswith('-test'):
-            metamist_proj += '-test'
+        metamist_proj = self.get_metamist_proj(dataset)
 
         analyses = query(
             GET_ANALYSES_QUERY,
@@ -469,9 +464,7 @@ class Metamist:
         Tries to create an Analysis entry, returns its id if successful.
         """
         dataset = dataset or self.default_dataset
-        metamist_proj = dataset or self.default_dataset
-        if get_config()['workflow']['access_level'] == 'test':
-            metamist_proj += '-test'
+        metamist_proj = self.get_metamist_proj(dataset)
 
         if isinstance(type_, AnalysisType):
             type_ = type_.value
@@ -594,15 +587,22 @@ class Metamist:
         """
         Retrieve PED lines for a specified SM project, with external participant IDs.
         """
-        metamist_proj = dataset or self.default_dataset
-        if get_config()['workflow']['access_level'] == 'test':
-            metamist_proj += '-test'
-
+        metamist_proj = self.get_metamist_proj(dataset)
         entries = query(GET_PEDIGREE_QUERY, variables={'metamist_proj': metamist_proj})
 
         pedigree_entries = entries['project']['pedigree']
 
         return pedigree_entries
+
+    def get_metamist_proj(self, dataset: str | None = None) -> str:
+        """
+        Return the Metamist project name, appending '-test' if the access level is 'test'.
+        """
+        metamist_proj = dataset or self.default_dataset
+        if get_config()['workflow']['access_level'] == 'test' and not metamist_proj.endswith('-test'):
+            metamist_proj += '-test'
+
+        return metamist_proj
 
 
 @dataclass

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -91,7 +91,7 @@ class AnnotateDataset(DatasetStage):
         Annotate MT with genotype and consequence data for Seqr
         """
         # only create dataset MTs for datasets specified in the config
-        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'])
+        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=[])
         if dataset.name not in eligible_datasets:
             return None
 
@@ -190,7 +190,7 @@ class MtToEs(DatasetStage):
         Transforms the MT into a Seqr index, no DataProc
         """
         # only create the elasticsearch index for the datasets specified in the config
-        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'])
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=[])
         if dataset.name not in eligible_datasets:
             return None
 

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -90,6 +90,11 @@ class AnnotateDataset(DatasetStage):
         """
         Annotate MT with genotype and consequence data for Seqr
         """
+        # only create dataset MTs for datasets specified in the config
+        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'])
+        if dataset.name not in eligible_datasets:
+            return None
+
         assert dataset.cohort
         assert dataset.cohort.multicohort
         mt_path = inputs.as_path(target=dataset.cohort.multicohort, stage=AnnotateCohort, key='mt')
@@ -184,6 +189,10 @@ class MtToEs(DatasetStage):
         """
         Transforms the MT into a Seqr index, no DataProc
         """
+        # only create the elasticsearch index for the datasets specified in the config
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'])
+        if dataset.name not in eligible_datasets:
+            return None
 
         # try to generate a password here - we'll find out inside the script anyway, but
         # by that point we'd already have localised the MT, wasting time and money

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -93,6 +93,7 @@ class AnnotateDataset(DatasetStage):
         # only create dataset MTs for datasets specified in the config
         eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=[])
         if dataset.name not in eligible_datasets:
+            get_logger().info(f'Skipping AnnotateDataset mt subsetting for {dataset}')
             return None
 
         assert dataset.cohort
@@ -192,6 +193,7 @@ class MtToEs(DatasetStage):
         # only create the elasticsearch index for the datasets specified in the config
         eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=[])
         if dataset.name not in eligible_datasets:
+            get_logger().info(f'Skipping ES index creation for {dataset}')
             return None
 
         # try to generate a password here - we'll find out inside the script anyway, but

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.3',
+    version='1.27.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -24,6 +24,7 @@ check_intermediates = false
 check_expected_outputs = false
 path_scheme = "local"
 local_dir = "{directory}"
+write_mt_for_datasets = ["test-analysis-dataset"]
 
 [hail]
 billing_project = "test-analysis-dataset"

--- a/test/test_seqr_loader_dry.py
+++ b/test/test_seqr_loader_dry.py
@@ -25,6 +25,7 @@ check_expected_outputs = false
 path_scheme = "local"
 local_dir = "{directory}"
 write_mt_for_datasets = ["test-analysis-dataset"]
+create_es_index_for_datasets = ["test-analysis-dataset"]
 
 [hail]
 billing_project = "test-analysis-dataset"


### PR DESCRIPTION
Adds in two new workflow config options (re-adding the MtToEs option since it was removed at some point?) for the seqr_loader pipeline.

`workflow.write_mt_for_datasets` - populate this config entry with the list of datasets for which you want the `AnnotateDataset` stage to run for. Useful because each time a new joint callset is created, only certain datasets may have new data for seqr, so we don't always want to run this stage for every dataset in the callset.

`workflow.create_es_index_for_datasets` - same as above but for the `MtToEs` stage

---

Also updates the `cpg_workflows.metamist` module with a new method: `get_metamist_proj`. This method has been added to resolve an issue faced while testing. As the metamist entries for datasets and sequencing groups within a cohort were being fetched, the `"-test"` suffix was being added to the `test` dataset names, e.g. https://batch.hail.populationgenomics.org.au/batches/489269/jobs/1.

This change will ensure that the test datasets don't get a duplicate suffix, as well as reduce some repetition in the code.