### PR TITLE
Datasets config option gatksv

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.4
+current_version = 1.27.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.4
+  VERSION: 1.27.5
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample.toml
+++ b/configs/defaults/gatk_sv_multisample.toml
@@ -3,6 +3,12 @@ name = 'gatk_sv'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 status_reporter = 'metamist'
 
+# Write dataset MTs for these datasets. Required for the AnnotateDatasetSv stage.
+# write_mt_for_datasets = []
+
+# Create Seqr ElasticSearch indices for these datasets. Required for the MtToEsSv stage.
+# create_es_index_for_datasets = []
+
 # switches to deactivate all Metrics workflows. We ran into some resourcing issues when our total
 # cohort size approached ~1600. Response when raised with GATK team:
 #

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -19,11 +19,10 @@ vep_version = '110'
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 
-# Write dataset MTs for these datasets. Required fot the AnnotateDataset stage
+# Write dataset MTs for these datasets. Required for the AnnotateDataset stage
 # write_mt_for_datasets = []
 
-# Create Seqr ElasticSearch indices for these datasets. If not specified, will
-# create indices for all input datasets.
+# Create Seqr ElasticSearch indices for these datasets. Required for the MtToEs stage.
 # create_es_index_for_datasets = []
 
 write_vcf = ["udn-aus"]

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1276,6 +1276,12 @@ class AnnotateDatasetSv(DatasetStage):
             dataset (Dataset): SGIDs specific to this dataset/project
             inputs ():
         """
+        # only create dataset MTs for datasets specified in the config
+        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=[])
+        if dataset.name not in eligible_datasets:
+            get_logger().info(f'Skipping AnnotateDatasetSv mt subsetting for {dataset}')
+            return None
+
         assert dataset.cohort
         assert dataset.cohort.multicohort
         mt_path = inputs.as_path(target=dataset.cohort.multicohort, stage=AnnotateCohortSv, key='mt')
@@ -1322,6 +1328,11 @@ class MtToEsSv(DatasetStage):
         """
         Uses the non-DataProc MT-to-ES conversion script
         """
+        # only create the elasticsearch index for the datasets specified in the config
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=[])
+        if dataset.name not in eligible_datasets:
+            get_logger().info(f'Skipping SV ES index creation for {dataset}')
+            return None
 
         # try to generate a password here - we'll find out inside the script anyway, but
         # by that point we'd already have localised the MT, wasting time and money

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.4',
+    version='1.27.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Replicates the changes made to the `AnnotateDataset` and `MtToEs` stages in the seqr_loader pipeline (see https://github.com/populationgenomics/production-pipelines/pull/916) and applies them to the analogous stages `AnnotateDatasetSv` and `MtToEsSv` in the gatk_sv_multisample pipeline. 