### PR TITLE
Upgrade Talos Job resources

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.5
+current_version = 1.27.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.5
+  VERSION: 1.27.6
 
 jobs:
   docker:

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -315,7 +315,7 @@ class GeneratePanelData(DatasetStage):
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         job = get_batch().new_job(f'Find HPO-matched Panels: {dataset.name}')
-        job.cpu(0.25).memory('lowmem').image(image_path('talos'))
+        job.cpu(1).image(image_path('talos'))
 
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))
@@ -346,7 +346,7 @@ class QueryPanelapp(DatasetStage):
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         job = get_batch().new_job(f'Query PanelApp: {dataset.name}')
-        job.cpu(0.25).memory('lowmem').image(image_path('talos'))
+        job.cpu(1).image(image_path('talos'))
 
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -371,7 +371,7 @@ class FindGeneSymbolMap(DatasetStage):
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         job = get_batch().new_job(f'Find Symbol-ENSG lookup: {dataset.name}')
-        job.cpu(0.25).memory('lowmem').image(image_path('talos'))
+        job.cpu(1).image(image_path('talos'))
 
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -278,7 +278,7 @@ class GeneratePED(DatasetStage):
         script to generate an extended pedigree format - additional columns for Ext. ID and HPO terms
         """
         job = get_batch().new_job('Generate PED from Metamist')
-        job.cpu(0.25).memory('lowmem').image(image_path('talos'))
+        job.cpu(1).image(image_path('talos'))
 
         # use the new config file
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig, 'config'))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.5',
+    version='1.27.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I was being incredibly stingy with resources in these two jobs. That was fine when I was doing a minimal bit of parsing, and now I'm pulling more objects and cross-comparing this is insufficient. 

This PR adds some more juice to some API-polling jobs. They're shortlived, minimal cost implications