### PR TITLE
Adapt to new Talos API queries

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.8
+current_version = 1.27.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.8
+  VERSION: 1.27.9
 
 jobs:
   docker:

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -15,6 +15,7 @@ panelapp = 'https://panelapp.agha.umccr.org/api/v1/panels'
 require_pheno_match = ['FLG', 'GJB2', 'F2', 'F5']
 # forbidden_genes = ['a', 'b']
 # forced_panels = [1, 2]
+within_x_months = 6
 
 [FindGeneSymbolMap]
 # much higher than this and we get into throttling issues

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -356,7 +356,7 @@ class QueryPanelapp(DatasetStage):
         expected_out = self.expected_outputs(dataset)
         job.command(f'export TALOS_CONFIG={conf_in_batch}')
         # insert a little stagger
-        job.command(f'sleep {randint(0, 30)}')
+        job.command(f'sleep {randint(0, 300)}')
         job.command(f'QueryPanelapp --panels {get_batch().read_input(str(hpo_panel_json))} --out_path {job.output}')
         get_batch().write_output(job.output, str(expected_out['panel_data']))
 

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -356,7 +356,7 @@ class QueryPanelapp(DatasetStage):
         expected_out = self.expected_outputs(dataset)
         job.command(f'export TALOS_CONFIG={conf_in_batch}')
         # insert a little stagger
-        job.command(f'sleep {randint(0, 300)}')
+        job.command(f'sleep {randint(20, 300)}')
         job.command(f'QueryPanelapp --panels {get_batch().read_input(str(hpo_panel_json))} --out_path {job.output}')
         get_batch().write_output(job.output, str(expected_out['panel_data']))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.8',
+    version='1.27.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Kinda linked to https://github.com/populationgenomics/automated-interpretation-pipeline/pull/439

The new PanelApp queries (searching for the gene data and the activity log) has doubled the number of queries. PanelApp was flaky enough as it was.

This upgrades the stagger when running the panelapp query job - each Dataset being processed gets a random stagger before trying to run. Instead of this stagger being between 0 - 30 secs (often single digits), the stagger is moved to somewhere between 20 secs and 5 minutes.

Logic here is that if even one dataset fails, the whole run needs a restart, so it's best to provide more wiggle room here, in the hope that it makes the run as a whole more resilient. When a run is between 15 mins and 4 hours (genome/exome/cohort dependent) this is still a tiny wait