### PR TITLE
Remove sgids from job attrs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.10
+current_version = 1.27.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.10
+  VERSION: 1.27.11
 
 jobs:
   docker:

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -206,7 +206,7 @@ class MultiCohort(Target):
         Attributes for Hail Batch job.
         """
         return {
-            'sequencing_groups': self.get_sequencing_group_ids(),
+            # 'sequencing_groups': self.get_sequencing_group_ids(),
             'datasets': [d.name for d in self.get_datasets()],
             'cohorts': [c.name for c in self.get_cohorts()],
         }
@@ -335,7 +335,7 @@ class Cohort(Target):
         Attributes for Hail Batch job.
         """
         return {
-            'sequencing_groups': self.get_sequencing_group_ids(),
+            # 'sequencing_groups': self.get_sequencing_group_ids(),
             'datasets': [d.name for d in self.get_datasets()],
         }
 
@@ -538,7 +538,7 @@ class Dataset(Target):
         """
         return {
             'dataset': self.name,
-            'sequencing_groups': self.get_sequencing_group_ids(),
+            # 'sequencing_groups': self.get_sequencing_group_ids(),
         }
 
     def get_job_prefix(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.10',
+    version='1.27.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #914

See https://centrepopgen.slack.com/archives/C030X7WGFCL/p1727226994302319

Hail jobs have a hard cap on data payload size. We are now exceeding this with SequencingGroups, as the `get_job_attrs` methods for MultiCohorts, Cohorts, Datasets, and SequencingGroups all push the full list of SG IDs into the job attributes.

I'm not aware of a situation where this data is used, and it is now a blocker in the pipeline processing clinical data.

This is not used to register files/analysis outputs, that list of SG IDs is generated by the same underlying method (`target.get_sequencing_group_ids()`), but is used directly instead of posting as job attributes.