### PR TITLE
Strip extra .vcf.bgz extension from FilterWham stage outputs

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1141,7 +1141,10 @@ class FilterWham(MultiCohortStage):
             f'{in_vcf} | bgzip -c  > {job.output["vcf.bgz"]}',
         )
         job.command(f'tabix {job.output["vcf.bgz"]}')
-        get_batch().write_output(job.output, str(self.expected_outputs(multicohort)['wham_filtered_vcf']))
+        get_batch().write_output(
+            job.output,
+            str(self.expected_outputs(multicohort)['wham_filtered_vcf']).replace('.vcf.bgz', ''),
+        )
 
         expected_d = self.expected_outputs(multicohort)
         return self.make_outputs(multicohort, data=expected_d, jobs=job)


### PR DESCRIPTION
Removes the extra `.vcf.bgz` from the `FilterWham` output filtered vcf.

Outputs were created with extra extensions like this:
```
gs://cpg-dataset-main/gatk_sv/MultiCohortHash/FilterWham/filtered.vcf.gz.vcf.bgz
gs://cpg-dataset-main/gatk_sv/MultiCohortHash/FilterWham/filtered.vcf.gz.vcf.bgz.tbi
```

And as such were not picked up by the next stages
https://batch.hail.populationgenomics.org.au/batches/493256/jobs/92