### PR TITLE
Add extra whitespace to bcftools cmd in FilterWham stage

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1137,7 +1137,7 @@ class FilterWham(MultiCohortStage):
         job.image(image_path('bcftools')).cpu(1).memory('highmem').storage('20Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         job.command(
-            'bcftools view -e \'SVTYPE=="DEL" && COUNT(ALGORITHMS)==1 && ALGORITHMS=="wham"\''
+            'bcftools view -e \'SVTYPE=="DEL" && COUNT(ALGORITHMS)==1 && ALGORITHMS=="wham"\' '
             f'{in_vcf} | bgzip -c  > {job.output["vcf.bgz"]}',
         )
         job.command(f'tabix {job.output["vcf.bgz"]}')


### PR DESCRIPTION
Adds a space character after the bcftools view options and before the input vcf filepath.


bcftools command without whitespace:
```
> bcftools view -e \'SVTYPE=="DEL" && COUNT(ALGORITHMS)==1 && ALGORITHMS=="wham"\'${BATCH_TMPDIR}/inputs/xxxxx/updated_ids.vcf.gz ...

Failed to read from standard input: unknown file type
```
See https://batch.hail.populationgenomics.org.au/batches/493256/jobs/89

With added whitespace:
```
> bcftools view -e \'SVTYPE=="DEL" && COUNT(ALGORITHMS)==1 && ALGORITHMS=="wham"\' ${BATCH_TMPDIR}/inputs/xxxxx/updated_ids.vcf.gz ...

(success, hopefully)
```
