### PR TITLE
Update CohortStage output paths to be Cohort-specific

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.12
+current_version = 1.27.13
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.12
+  VERSION: 1.27.13
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -435,8 +435,8 @@ class FastCombineGCNVs(CohortStage):
         pointers to both the MultiCohort and the Cohort
         """
         return {
-            'combined_calls': self.prefix / cohort.name / 'gcnv_joint_call.vcf.bgz',
-            'combined_calls_index': self.prefix / cohort.name / 'gcnv_joint_call.vcf.bgz.tbi',
+            'combined_calls': self.get_stage_cohort_prefix(cohort) / 'gcnv_joint_call.vcf.bgz',
+            'combined_calls_index': self.get_stage_cohort_prefix(cohort) / 'gcnv_joint_call.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -259,13 +259,15 @@ class TrimOffSexChromosomes(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
 
         # returning an empty dictionary might cause the pipeline setup to break?
-        return_dict: dict[str, Path | str] = {'placeholder': str(self.get_stage_cohort_prefix(cohort) / 'placeholder.txt')}
+        return_dict: dict[str, Path | str] = {
+            'placeholder': str(self.get_stage_cohort_prefix(cohort) / 'placeholder.txt'),
+        }
 
         # load up the file of aneuploidies - I don't think the pipeline supports passing an input directly here
         # so... I'm making a similar path and manually string-replacing it
-        aneuploidy_file = str(
-            self.get_stage_cohort_prefix(cohort) / 'aneuploidies.txt'
-        ).replace(self.name, 'UpgradePedWithInferred')
+        aneuploidy_file = str(self.get_stage_cohort_prefix(cohort) / 'aneuploidies.txt').replace(
+            self.name, 'UpgradePedWithInferred',
+        )
 
         if (aneuploidy_path := to_path(aneuploidy_file)).exists():
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -266,7 +266,8 @@ class TrimOffSexChromosomes(CohortStage):
         # load up the file of aneuploidies - I don't think the pipeline supports passing an input directly here
         # so... I'm making a similar path and manually string-replacing it
         aneuploidy_file = str(self.get_stage_cohort_prefix(cohort) / 'aneuploidies.txt').replace(
-            self.name, 'UpgradePedWithInferred',
+            self.name,
+            'UpgradePedWithInferred',
         )
 
         if (aneuploidy_path := to_path(aneuploidy_file)).exists():

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.12',
+    version='1.27.13',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Since moving to MultiCohorts, gCNV hasn't had a lot of love. 

This updates the Stages so that each Cohort result is written to a Cohort-specific path.

Example failure here - https://batch.hail.populationgenomics.org.au/batches/493675

This occurs when we expect output to be generated per-cohort, but we use an output path that incorporates the multicohort hash, so it's generated once per run instead. In this failure mode a later stage reads the file, and it doesn't have the expected content. 

At the moment the gCNV pipeline contains a cross-cohort merge to generate a single callset for annotation, but... the whole pipeline doesn't work because of the above issue D: 

This has also reminded me Jasmine was on the board as a better VCF merge

---

I've had a re-think and made some changes:

- The prepare Cohort Intervals stage is now a MultiCohort stage. All SG IDs in the MC are on the same capture, so don't duplicate work
- The janky `sg.dataset.cohort.multicohort` way of accessing the MultiCohort is replaced with the `workflow.get_multicohort()` method call
- All Cohort stages prior to MultiCohort involvement store their outputs in `bucket/pipeline/cohort`
- After the merge all results are stored in `bucket/pipeline/MC_hash`