### PR TITLE
Prevent multiple overwrites to single file

### DIFF
--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -33,6 +33,7 @@ def upgrade_ped_file(local_ped: ResourceFile, new_output: str, aneuploidies: str
     j.image(config_retrieve(['workflow', 'driver_image']))
 
     # path to the python script
+    # todo this is jank, use as a standalone script
     script_path = upgrade_ped_with_inferred.__file__.removeprefix('/production-pipelines')
     j.command(f'tar -xf {ploidy_tar} -C .')  # creates the folder ploidy-calls
     j.command(f'python3 {script_path} {local_ped} {j.output} {j.aneuploidies} ploidy-calls')

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -33,7 +33,6 @@ def upgrade_ped_file(local_ped: ResourceFile, new_output: str, aneuploidies: str
     j.image(config_retrieve(['workflow', 'driver_image']))
 
     # path to the python script
-    # todo this is jank, use as a standalone script
     script_path = upgrade_ped_with_inferred.__file__.removeprefix('/production-pipelines')
     j.command(f'tar -xf {ploidy_tar} -C .')  # creates the folder ploidy-calls
     j.command(f'python3 {script_path} {local_ped} {j.output} {j.aneuploidies} ploidy-calls')

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -145,7 +145,9 @@ class UpgradePedWithInferred(CohortStage):
         outputs = self.expected_outputs(cohort)
         ploidy_inputs = get_batch().read_input(str(inputs.as_dict(cohort, DeterminePloidy)['calls']))
         tmp_ped_path = get_batch().read_input(
-            str(cohort.write_ped_file(self.get_stage_cohort_prefix(cohort, category='tmp') / 'pedigree.ped'))
+            str(
+                cohort.write_ped_file(self.get_stage_cohort_prefix(cohort, category='tmp') / 'pedigree.ped'),
+            ),
         )
         job = gcnv.upgrade_ped_file(
             local_ped=tmp_ped_path,


### PR DESCRIPTION
gCNV has recently been updated to use Cohorts/MultiCohorts properly. During this update I failed to catch a couple of cheeky CohortStages writing to `self.tmp` (the MultiCohort level tmp directory). This meant that each cohort (12) wrote to the same file, each deleting/overwriting the previous content. 

https://batch.hail.populationgenomics.org.au/batches/493947/jobs/1

There's only 12 cohorts here, so I'm surprised GCP threw a hissy fit when the file was deleted/replaced 11 times in quick succession. However, I'm glad it broke 😬 

The fix here is to use the per-cohort tmp directory when creating paths for each of these outputs.