### PR TITLE
Correction to gCNV stage dependency

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.13
+current_version = 1.27.14
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.13
+  VERSION: 1.27.14
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -481,10 +481,10 @@ class MergeCohortsgCNV(MultiCohortStage):
             inputs (StageInput): link to FastCombineGCNVs outputs
 
         Returns:
-            the bcftools merge job to join the Cohorts into a MultiCohort VCF
+            the bcftools merge job to join the Cohort-VCFs into a MultiCohort VCF
         """
         outputs = self.expected_outputs(multicohort)
-        cohort_merges = inputs.as_dict_by_target(RecalculateClusteredQuality)
+        cohort_merges = inputs.as_dict_by_target(FastCombineGCNVs)
         cohort_vcfs = [str(cohort_merges[cohort.name]['combined_calls']) for cohort in multicohort.get_cohorts()]
 
         pipeline_image = get_images(['sv_pipeline_docker'])['sv_pipeline_docker']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.13',
+    version='1.27.14',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The gCNV pipeline can't start up due to the cross-cohort Merge stage trying to draw input from the wrong stage dependency

This was a copy-paste error from me, but I do find this framework very limiting - there's no way (AFAIK) do a static analysis that each Stage draws inputs from its dependent stages. It's not even possible to do that check with a Stage instance; required_stages is an attribute, but the actual pulling of input is only done when the jobs are being scheduled into a workflow. 