### PR TITLE
Use more efficient path checks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.14
+current_version = 1.27.15
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.14
+  VERSION: 1.27.15
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -13,7 +13,7 @@ from cpg_utils.config import config_retrieve, get_config, image_path, reference_
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.scripts import collect_dataset_tsvs
 from cpg_workflows.targets import SequencingGroup
-from cpg_workflows.utils import chunks, exists
+from cpg_workflows.utils import chunks, check_exists_path
 
 HPO_KEY: str = 'HPO Terms (present)'
 
@@ -98,7 +98,7 @@ def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_path
     for family, members in families.items():
 
         # skip if already done
-        if exists(out_paths[family]):
+        if check_exists_path(out_paths[family]):
             continue
 
         jobs.append(family_vcf_from_gvcf(members, str(out_paths[family])))
@@ -118,8 +118,9 @@ def extract_mini_ped_files(family_dict: dict[str, list[SequencingGroup]], out_pa
     for family_id, members in family_dict.items():
 
         ped_path = out_paths[family_id]
+
         # don't recreate if it exists
-        if not ped_path.exists():
+        if not check_exists_path(ped_path):
             # make the pedigree for this family
             df = pd.DataFrame([sg.pedigree.get_ped_dict() for sg in members])
             with ped_path.open('w') as ped_file:
@@ -138,7 +139,7 @@ def make_phenopackets(family_dict: dict[str, list[SequencingGroup]], out_path: d
 
     for family, members in family_dict.items():
 
-        if out_path[family].exists():
+        if check_exists_path(out_path[family]):
             continue
 
         # get all affected and unaffected

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -31,12 +31,7 @@ from cpg_utils.hail_batch import get_batch, reset_batch
 from .inputs import get_multicohort
 from .status import MetamistStatusReporter
 from .targets import Cohort, Dataset, MultiCohort, SequencingGroup, Target
-from .utils import (
-    ExpectedResultT,
-    exists,
-    slugify,
-    timestamp,
-)
+from .utils import ExpectedResultT, check_exists_path, slugify, timestamp
 
 StageDecorator = Callable[..., 'Stage']
 
@@ -713,7 +708,7 @@ class Stage(Generic[TargetT], ABC):
                 logging.info(f'{expected_out} is not reusable. No paths found.')
                 return False, None
 
-            if first_missing_path := next((p for p in paths if not exists(p)), None):
+            if first_missing_path := next((p for p in paths if not check_exists_path(p)), None):
                 logging.info(f'{expected_out} is not reusable, {first_missing_path} is missing')
                 return False, first_missing_path
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.14',
+    version='1.27.15',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Problem

Our pipeline regularly takes over an hour just to start up...

# Solution?

This issue has (at least) 2 components

1. Time taken doing existence checks in GCP
2. Time taken scheduling jobs

2 might just be an intractable Hail Batch problem, so shelve that for now...

1 - the solution for this already exists in the `cpg_workflows.utils` module. What we currently do is a cached per-path existence check. That saves us no time, as we only check each path once anyway.

The `check_exists_path` instead takes the path it's given, finds the parent directory, and does a cached check on the whole directory at once. That means that `<bucket>/CPGA.vcf` and `<bucket>/CPGB.vcf` are only a single cached glob call in GCP.

We already wrote this method, we just don't use it during pipeline startup...