### PR TITLE
Resolve inter-stage output dependency

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.14
+current_version = 1.27.15
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.14
+  VERSION: 1.27.15
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -592,7 +592,6 @@ class AnnotateCohortgCNV(MultiCohortStage):
     """
 
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
-        # convert temp path to str to avoid checking existence
         return {'mt': self.prefix / 'gcnv_annotated_cohort.mt'}
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
@@ -616,7 +615,7 @@ class AnnotateCohortgCNV(MultiCohortStage):
             ),
         )
 
-        return self.make_outputs(multicohort, data=outputs['mt'], jobs=j)
+        return self.make_outputs(multicohort, data=outputs, jobs=j)
 
 
 @stage(required_stages=AnnotateCohortgCNV, analysis_type='cnv', analysis_keys=['mt'])
@@ -722,4 +721,4 @@ class MtToEsCNV(DatasetStage):
         # run the export from the localised MT - this job writes no new data, just transforms and exports over network
         job.command(f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {index_name} --flag {flag_name}')
 
-        return self.make_outputs(dataset, data=outputs['index_name'], jobs=job)
+        return self.make_outputs(dataset, data=outputs, jobs=job)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.14',
+    version='1.27.15',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Very frustrating output transmission issue

A previous stage was finishing with 

```return self.make_outputs(multicohort, data=outputs['mt'], jobs=j)```

This means that only the single String `outputs['mt']`, not the whole output dict is available to the next stage. Error message:

```
ValueError: AnnotateCohortgCNV <- [AnnotateCNVVcfWithStrvctvre]: gs://cpg-vcgs-clinical-main/gcnv/8e1636ebdd99509f62c1cd1a53b7b8caf73ac3_809/AnnotateCohortgCNV/gcnv_annotated_cohort.mt is not a dictionary, can't get "mt"
```

I really don't know how gCNV results have been generated so far with this many sneaky pipeline errors