### PR TITLE
Improvement to gCNV output pathing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.15
+current_version = 1.27.16
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.15
+  VERSION: 1.27.16
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -397,9 +397,11 @@ class RecalculateClusteredQuality(SequencingGroupStage):
         # so we need to write the outputs to a cohort-specific location
         return {
             'genotyped_intervals_vcf': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.intervals.vcf.gz',
-            'genotyped_intervals_vcf_index': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'genotyped_intervals_vcf_index': self.get_stage_cohort_prefix(this_cohort)
+            / f'{seqgroup.id}.intervals.vcf.gz.tbi',
             'genotyped_segments_vcf': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.segments.vcf.gz',
-            'genotyped_segments_vcf_index': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'genotyped_segments_vcf_index': self.get_stage_cohort_prefix(this_cohort)
+            / f'{seqgroup.id}.segments.vcf.gz.tbi',
             'denoised_copy_ratios': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.ratios.tsv',
             'qc_status_file': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.qc_status.txt',
         }

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -381,14 +381,29 @@ class RecalculateClusteredQuality(SequencingGroupStage):
     This is done as another pass through PostprocessGermlineCNVCalls, with prior/clustered results
     """
 
-    def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
+    def expected_outputs(self, seqgroup: SequencingGroup) -> dict[str, Path]:
+
+        # identify the cohort that contains this SGID
+        this_cohort: Cohort | None = None
+        for c in get_multicohort().get_cohorts():
+            if seqgroup.id in c.get_sequencing_group_ids():
+                this_cohort = c
+                break
+
+        if this_cohort is None:
+            raise ValueError(f'Could not find cohort for {seqgroup}')
+
+        # this job runs per sample, on results with a cohort context
+        # so we need to prefix the outputs with the cohort name
+        path_prefix = seqgroup.dataset.prefix() / 'gcnv' / self.name / this_cohort.name
+
         return {
-            'genotyped_intervals_vcf': self.prefix / f'{sequencing_group.id}.intervals.vcf.gz',
-            'genotyped_intervals_vcf_index': self.prefix / f'{sequencing_group.id}.intervals.vcf.gz.tbi',
-            'genotyped_segments_vcf': self.prefix / f'{sequencing_group.id}.segments.vcf.gz',
-            'genotyped_segments_vcf_index': self.prefix / f'{sequencing_group.id}.segments.vcf.gz.tbi',
-            'denoised_copy_ratios': self.prefix / f'{sequencing_group.id}.ratios.tsv',
-            'qc_status_file': self.prefix / f'{sequencing_group.id}.qc_status.txt',
+            'genotyped_intervals_vcf': path_prefix / f'{seqgroup.id}.intervals.vcf.gz',
+            'genotyped_intervals_vcf_index': path_prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'genotyped_segments_vcf': path_prefix / f'{seqgroup.id}.segments.vcf.gz',
+            'genotyped_segments_vcf_index': path_prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'denoised_copy_ratios': path_prefix / f'{seqgroup.id}.ratios.tsv',
+            'qc_status_file': path_prefix / f'{seqgroup.id}.qc_status.txt',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -394,16 +394,14 @@ class RecalculateClusteredQuality(SequencingGroupStage):
             raise ValueError(f'Could not find cohort for {seqgroup}')
 
         # this job runs per sample, on results with a cohort context
-        # so we need to prefix the outputs with the cohort name
-        path_prefix = seqgroup.dataset.prefix() / 'gcnv' / self.name / this_cohort.name
-
+        # so we need to write the outputs to a cohort-specific location
         return {
-            'genotyped_intervals_vcf': path_prefix / f'{seqgroup.id}.intervals.vcf.gz',
-            'genotyped_intervals_vcf_index': path_prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
-            'genotyped_segments_vcf': path_prefix / f'{seqgroup.id}.segments.vcf.gz',
-            'genotyped_segments_vcf_index': path_prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
-            'denoised_copy_ratios': path_prefix / f'{seqgroup.id}.ratios.tsv',
-            'qc_status_file': path_prefix / f'{seqgroup.id}.qc_status.txt',
+            'genotyped_intervals_vcf': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.intervals.vcf.gz',
+            'genotyped_intervals_vcf_index': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'genotyped_segments_vcf': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.segments.vcf.gz',
+            'genotyped_segments_vcf_index': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'denoised_copy_ratios': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.ratios.tsv',
+            'qc_status_file': self.get_stage_cohort_prefix(this_cohort) / f'{seqgroup.id}.qc_status.txt',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.15',
+    version='1.27.16',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This step of the gCNV pipeline is SingleSample, but based on results from the Cohort it's called in. The output is currently being written to a path which contains the MultiCohort Hash, which means this whole process will repeat if I run with cohorts separately and then together - even though the result at this step of the pipeline would be identical.

This change adjusts the path so we write this into a cohort-level path in the bucket, instead of in the SG's project bucket with an unnecessary hash. 

Hopefully that's the end of the liftover required from Cohorts to MultiCohorts in this pipeline 😭 