### PR TITLE
Add config option for custom stripy report path prefix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.27.17
+current_version = 1.27.18
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.27.17
+  VERSION: 1.27.18
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -157,6 +157,8 @@ STARD7,TBP,TBX1,TCF4,TNRC6A,VWA1,XYLT1,YEATS2,ZFHX3,ZIC2,ZIC3"""
 # custom_loci_path = "gs://cpg-reference/hg38/loci/seqr/seqr_stripy_custom_loci.bed"
 # Set to empty string if no custom loci are to be used.
 custom_loci_path = ""
+# Change the path the stripy report is saved to, useful when testing novel loci
+output_prefix = "stripy"
 
 # Add in specific multiQC report config options
 # See https://multiqc.info/docs/getting_started/config for more details

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -52,6 +52,8 @@ def _update_meta(output_path: str) -> dict[str, Any]:
     analysis_type='web',
     analysis_keys=[
         'stripy_html',
+        'stripy_json',
+        'stripy_log',
     ],
     update_analysis_meta=_update_meta,
 )

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -59,12 +59,15 @@ class Stripy(SequencingGroupStage):
     """
     Call stripy to run STR analysis on known pathogenic loci.
     """
+
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
         # When testing new loci, its useful to save the report to an alternate path
         output_prefix = config_retrieve(['stripy', 'output_prefix'], default='stripy')
         return {
             'stripy_html': sequencing_group.dataset.web_prefix() / output_prefix / f'{sequencing_group.id}.stripy.html',
-            'stripy_json': sequencing_group.dataset.analysis_prefix() / output_prefix / f'{sequencing_group.id}.stripy.json',
+            'stripy_json': sequencing_group.dataset.analysis_prefix()
+            / output_prefix
+            / f'{sequencing_group.id}.stripy.json',
             'stripy_log': sequencing_group.dataset.analysis_prefix()
             / output_prefix
             / f'{sequencing_group.id}.stripy.log.txt',

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -7,7 +7,7 @@ See https://gitlab.com/andreassh/stripy-pipeline
 from typing import Any
 
 from cpg_utils import Path
-from cpg_utils.config import get_config
+from cpg_utils.config import config_retrieve, get_config
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.jobs import stripy
@@ -59,13 +59,14 @@ class Stripy(SequencingGroupStage):
     """
     Call stripy to run STR analysis on known pathogenic loci.
     """
-
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
+        # When testing new loci, its useful to save the report to an alternate path
+        output_prefix = config_retrieve(['stripy', 'output_prefix'], default='stripy')
         return {
-            'stripy_html': sequencing_group.dataset.web_prefix() / 'stripy' / f'{sequencing_group.id}.stripy.html',
-            'stripy_json': sequencing_group.dataset.analysis_prefix() / 'stripy' / f'{sequencing_group.id}.stripy.json',
+            'stripy_html': sequencing_group.dataset.web_prefix() / output_prefix / f'{sequencing_group.id}.stripy.html',
+            'stripy_json': sequencing_group.dataset.analysis_prefix() / output_prefix / f'{sequencing_group.id}.stripy.json',
             'stripy_log': sequencing_group.dataset.analysis_prefix()
-            / 'stripy'
+            / output_prefix
             / f'{sequencing_group.id}.stripy.log.txt',
         }
 

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -52,8 +52,6 @@ def _update_meta(output_path: str) -> dict[str, Any]:
     analysis_type='web',
     analysis_keys=[
         'stripy_html',
-        'stripy_json',
-        'stripy_log',
     ],
     update_analysis_meta=_update_meta,
 )

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -42,23 +42,8 @@ def complete_analysis_job(
     assert isinstance(output, str)
     output_cloudpath = to_path(output)
 
-    print('Analysis meta update')
-    print(update_analysis_meta)
     if update_analysis_meta is not None:
-        print(f'Updating analysis meta for {output}')
-        meta_update = update_analysis_meta(output)
-        print(f'Analysis meta: {meta}')
-        print(f'Update: {meta_update}')
-        print(f'update_analysis_meta: {update_analysis_meta(output)}')
-        if meta_update is not None:
-            meta |= meta_update
-        else:
-            print(f'No meta update for {output}')
-        # meta | update_analysis_meta(output)
-    else:
-        print(f'No meta update for {output}')
-        print(f'Analysis meta: {meta}')
-        print(f'Update analysis meta: {update_analysis_meta}')
+        meta = meta | update_analysis_meta(output)
 
     # if SG IDs are listed in the meta, remove them
     # these are already captured in the sg_ids list

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -42,6 +42,8 @@ def complete_analysis_job(
     assert isinstance(output, str)
     output_cloudpath = to_path(output)
 
+    print('Analysis meta update')
+    print(update_analysis_meta)
     if update_analysis_meta is not None:
         print(f'Updating analysis meta for {output}')
         meta_update = update_analysis_meta(output)

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -50,6 +50,10 @@ def complete_analysis_job(
         else:
             print(f'No meta update for {output}')
         # meta | update_analysis_meta(output)
+    else:
+        print(f'No meta update for {output}')
+        print(f'Analysis meta: {meta}')
+        print(f'Update analysis meta: {update_analysis_meta}')
 
     # if SG IDs are listed in the meta, remove them
     # these are already captured in the sg_ids list

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -47,6 +47,9 @@ def complete_analysis_job(
     if update_analysis_meta is not None:
         print(f'Updating analysis meta for {output}')
         meta_update = update_analysis_meta(output)
+        print(f'Analysis meta: {meta}')
+        print(f'Update: {meta_update}')
+        print(f'update_analysis_meta: {update_analysis_meta(output)}')
         if meta_update is not None:
             meta |= meta_update
         else:

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -43,7 +43,13 @@ def complete_analysis_job(
     output_cloudpath = to_path(output)
 
     if update_analysis_meta is not None:
-        meta | update_analysis_meta(output)
+        print(f'Updating analysis meta for {output}')
+        meta_update = update_analysis_meta(output)
+        if meta_update is not None:
+            meta |= meta_update
+        else:
+            print(f'No meta update for {output}')
+        # meta | update_analysis_meta(output)
 
     # if SG IDs are listed in the meta, remove them
     # these are already captured in the sg_ids list

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.27.17',
+    version='1.27.18',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
As we trial adding new loci to the STRipy reports using the `stripy.custom_loci_path` bed file config option, it would be useful to have the option of saving the reports do a different path aside from the standard `main-web/dataset/stripy/CPGID.html`. This would prevent overwriting existing reports while allowing us to analyse the value of additional loci, ad hoc.

By changing this config option, the report would be saved to `main-web/dataset/<stripy.output_prefix>/CPGID.html`.

Also fixes a bug with the Metamist status reporter used to write analyses - the `_update_meta_dict` function was being passed through to the analysis creation, but the resulting updated meta dict was not being saved to the `meta` variable. This fixes that, so the `update_analysis_meta` function now works and can be passed through to stage decorators.