### PR TITLE
Support a massive number of Talos HTML files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.28.0
+current_version = 1.28.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.28.0
+  VERSION: 1.28.1
 
 jobs:
   docker:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         timeout-minutes: 20
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
-          coverage run -m pytest -m "not integration" test --junitxml=test-execution.xml
+          coverage run -m pytest test --junitxml=test-execution.xml
 
           rc=$?
           coverage xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         timeout-minutes: 20
         run: |
           PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
-          coverage run -m pytest test --junitxml=test-execution.xml
+          coverage run -m pytest -m "not integration" test --junitxml=test-execution.xml
 
           rc=$?
           coverage xml

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -58,10 +58,15 @@ spliceai = 0.5
 # for generating the VCF output - these are the fields pulled from the MT, in this order
 csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
 
+# config entries relating to size of VM provisioned for Hail
 [RunHailFiltering.cores]
-# size of VM provisioned for Hail
 sv = 2
 small_variants = 16
+
+# total allocated RAM, String
+[RunHailFiltering.memory]
+small_variants = 'highmem'
+#sv = 2
 
 [RunHailFiltering.storage]
 sv = 10

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -82,6 +82,7 @@ SEQR_KEYS: list[str] = ['seqr_project', 'seqr_instance', 'seqr_lookup']
 def get_date_string()-> str:
     """
     allows override of the date folder to continue/re-run previous analyses
+
     Returns:
         either an override in config, or the default (today, YYYY-MM-DD)
     """
@@ -93,7 +94,7 @@ def get_date_folder() -> str:
     """
     allows override of the date folder to continue/re-run previous analyses
     Returns:
-        either an override in config, or the default (today, YYYY-MM-DD)
+        either an override in config, or the default "reanalysis/(today, YYYY-MM-DD)"
     """
     return join('reanalysis', get_date_string())
 

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -444,8 +444,9 @@ class RunHailFiltering(DatasetStage):
             cohort_size=len(dataset.get_sequencing_group_ids()),
         )
         required_cpu: int = config_retrieve(['RunHailFiltering', 'cores', 'small_variants'], 8)
+        required_mem: str = config_retrieve(['RunHailFiltering', 'memory', 'small_variants'], 'highmem')
         # doubling storage due to the repartitioning
-        job.cpu(required_cpu).storage(f'{required_storage*2}Gi').memory('highmem')
+        job.cpu(required_cpu).storage(f'{required_storage*2}Gi').memory(required_mem)
 
         panelapp_json = get_batch().read_input(
             str(inputs.as_path(target=dataset, stage=QueryPanelapp, key='panel_data')),

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -79,7 +79,7 @@ SEQR_KEYS: list[str] = ['seqr_project', 'seqr_instance', 'seqr_lookup']
 
 
 @lru_cache(maxsize=1)
-def get_date_string()-> str:
+def get_date_string() -> str:
     """
     allows override of the date folder to continue/re-run previous analyses
 
@@ -692,8 +692,10 @@ class CreateTalosHTML(DatasetStage):
     def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
         return {
             'results_html': dataset.prefix(category='web') / get_date_folder() / 'summary_output.html',
-            'latest_html': dataset.prefix(category='web') / get_date_folder() / f'summary_latest_{get_date_string()}.html',
-            'folder': dataset.prefix(category='web') / get_date_folder()
+            'latest_html': dataset.prefix(category='web')
+            / get_date_folder()
+            / f'summary_latest_{get_date_string()}.html',
+            'folder': dataset.prefix(category='web') / get_date_folder(),
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
@@ -752,7 +754,9 @@ class MinimiseOutputForSeqr(DatasetStage):
     def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
         return {
             'seqr_file': dataset.prefix(category='analysis') / 'seqr_files' / f'{get_date_folder()}_seqr.json',
-            'seqr_pheno_file': dataset.prefix(category='analysis') / 'seqr_files' / f'{get_date_folder()}_seqr_pheno.json',
+            'seqr_pheno_file': dataset.prefix(category='analysis')
+            / 'seqr_files'
+            / f'{get_date_folder()}_seqr_pheno.json',
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 pythonpath = ['gnomad_methods', 'seqr-loading-pipelines']
 testpaths = ['test']
-
+markers = [
+    "integration: marks integration tests as slow (deselect with '-m \"not integration\"')",
+]
 
 [tool.ruff]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.28.0',
+    version='1.28.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -3,6 +3,7 @@ Test large-cohort workflow.
 """
 
 import os
+import pytest
 from os.path import exists
 from pathlib import Path
 
@@ -127,6 +128,8 @@ def _mock_cohort(dataset_id: str):
 
 
 class TestAllLargeCohortMethods:
+
+    @pytest.mark.integration
     def test_with_sample_data(self, mocker: MockFixture, tmp_path: Path):
         """
         Run entire workflow in a local mode.

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -3,10 +3,10 @@ Test large-cohort workflow.
 """
 
 import os
-import pytest
 from os.path import exists
 from pathlib import Path
 
+import pytest
 from pytest_mock import MockFixture
 
 import cpg_workflows


### PR DESCRIPTION
Related to https://github.com/populationgenomics/talos/pull/448

That version is being iterated on, but the gcloud syntax in the stage is required to try it out

This change includes:

- more granular control of the memory allocated for Hail tasks
- ability to override the date setting, so previous runs can be re-run/continued (will save hours/$s)
- report generation stage generates all files locally, then recursive copies everything into GCP using the gcloud client
  - trying to manually write 6000 HTML files took 2+ hours, despite being a small amount of total data