### PR TITLE
Speed up the slowdown

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.29.1
+current_version = 1.29.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.29.1
+  VERSION: 1.29.2
 
 jobs:
   docker:

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -31,6 +31,7 @@ def run(
 ) -> None:
 
     import logging
+
     import hail as hl
 
     # set up a quick logger inside the job
@@ -42,10 +43,9 @@ def run(
         if specific_intervals:
             logging.info(f'Using specific intervals: {specific_intervals}')
 
-            intervals = hl.eval([
-                hl.parse_locus_interval(interval, reference_genome=genome_build)
-                for interval in specific_intervals
-            ])
+            intervals = hl.eval(
+                [hl.parse_locus_interval(interval, reference_genome=genome_build) for interval in specific_intervals],
+            )
 
         else:
             intervals = None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.29.1',
+    version='1.29.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -162,6 +162,8 @@ class TestAllLargeCohortMethods:
 
         res_pref = tmp_path
         vds_path = str(res_pref / 'v01.vds')
+
+        # we're passing a specific minority of intervals here, to test that the combiner works on a timely test case
         combiner.run(
             output_vds_path=vds_path,
             sequencing_type=conf['workflow']['sequencing_type'],
@@ -169,6 +171,7 @@ class TestAllLargeCohortMethods:
             genome_build=conf['references']['genome_build'],
             gvcf_paths=gvcf_paths,
             vds_paths=None,
+            specific_intervals=conf['large_cohort']['combiner']['intervals'],
         )
 
         sample_qc_ht_path = res_pref / 'sample_qc.ht'


### PR DESCRIPTION
The update to the combiner only tolerates exome or genome intervals when combining. The previous test case was limited to only a couple of small chromosomes, to keep timings in check. 

This reinstates the ability to pass custom intervals to the combiner, and passes them inside the test suite