### PR TITLE
Uncomment the sitonly expected output for SiteOnlyVCFs

### DIFF
--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
@@ -209,7 +209,7 @@ class SiteOnlyVCFs(MultiCohortStage):
         Generate site-only VCFs from the merged VCF.
         """
         return {
-            # 'siteonly': to_path(self.prefix / 'siteonly.vcf.gz'),
+            'siteonly': to_path(self.prefix / 'siteonly.vcf.gz'),
             'siteonly_part_pattern': str(self.prefix / 'siteonly_parts' / 'part{idx}.vcf.gz'),
         }
 


### PR DESCRIPTION
Small fix needed to this pipeline - this was commented out late into development, as I was considering dropping support for the `scatter_count = 1` option. 

This output isn't actually created or used except for when `scatter_count = 1`, which is not recommended. However it needs to be in the expected outputs for the VEP job to work. 

See the error mode:
https://batch.hail.populationgenomics.org.au/batches/518674/jobs/1

Test run on this branch with this fix, using `scatter_count = 3`
https://batch.hail.populationgenomics.org.au/batches/518683/jobs/1