### PR TITLE
Add the --sv flag to the modify_sniffles command for SV VCFs

### DIFF
--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -114,7 +114,8 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             f'--vcf_out {mod_job.output} '
             f'--new_id {sg.id} '
             f'--fa {fasta} '
-            f'--sex {sex} ',
+            f'--sex {sex} '
+            f'--sv',
         )
 
         # block-gzip and index that result


### PR DESCRIPTION
SV VCFs were not being reformatted correctly because of the new --sv argument to modify_sniffles, which was added in #912 to accomodate both SNPs_Indels VCFs alongside the SV VCFs. 