### PR TITLE
Fix the AF format row in sniffles vcf modifier script for snv vcfs

### DIFF
--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -117,6 +117,10 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, new_id: str | None
                     f_out.write('\t'.join(l_split) + '\n')
                     continue
 
+                if 'FORMAT=<ID=AF,Number=1' in line and not sv:
+                    # Correct the AF field to have 'Number=A' for SNPs/Indels, to allow for multiple AF values
+                    line = line.replace('Number=1', 'Number=A')
+
                 f_out.write(line)
                 continue
 


### PR DESCRIPTION
According to the [VCF 4.2 spec](https://samtools.github.io/hts-specs/VCFv4.2.pdf), if there is one AF value per alt allele in the row, then the `Number` field of the AF format header line needs to be `Number=A`. 

This is to fix the SNPs_Indels VCFs that were created with Clair3 <v1.0.9, [which had a bug](https://github.com/HKU-BAL/Clair3/releases/tag/v1.0.9).

See discussion: https://centrepopgen.slack.com/archives/C037XB40XFW/p1729811156519039