### PR TITLE
Joint genotyping qc to multicohorts

### DIFF
--- a/cpg_workflows/stages/clinvarbitration.py
+++ b/cpg_workflows/stages/clinvarbitration.py
@@ -22,21 +22,21 @@ from cpg_utils.config import config_retrieve, image_path
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job
 from cpg_workflows import get_batch
 from cpg_workflows.jobs.simple_vep_annotation import split_and_annotate_vcf
-from cpg_workflows.workflow import Cohort, CohortStage, StageInput, StageOutput, stage
+from cpg_workflows.workflow import MultiCohort, MultiCohortStage, StageInput, StageOutput, stage
 
 DATE_STRING: str = datetime.now().strftime('%y-%m')
 
 
 @stage
-class CopyLatestClinvarFiles(CohortStage):
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+class CopyLatestClinvarFiles(MultiCohortStage):
+    def expected_outputs(self, mc: MultiCohort) -> dict[str, Path]:
         common_folder = join(config_retrieve(['storage', 'common', 'analysis']), 'clinvarbitration', DATE_STRING)
         return {
             'submission_file': to_path(join(common_folder, 'submission_summary.txt.gz')),
             'variant_file': to_path(join(common_folder, 'variant_summary.txt.gz')),
         }
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
+    def queue_jobs(self, mc: MultiCohort, inputs: StageInput) -> StageOutput:
         """
         run a wget copy of the relevant files into GCP
         """
@@ -50,17 +50,17 @@ class CopyLatestClinvarFiles(CohortStage):
         bash_job.command(f'wget -q {directory}{sub_file} -O {bash_job.subs}')
         bash_job.command(f'wget -q {directory}{var_file} -O {bash_job.vars}')
 
-        outputs = self.expected_outputs(cohort)
+        outputs = self.expected_outputs(mc)
 
         get_batch().write_output(bash_job.subs, str(outputs['submission_file']))
         get_batch().write_output(bash_job.vars, str(outputs['variant_file']))
 
-        return self.make_outputs(data=outputs, jobs=bash_job, target=cohort)
+        return self.make_outputs(data=outputs, jobs=bash_job, target=mc)
 
 
 @stage(required_stages=CopyLatestClinvarFiles, analysis_type='custom', analysis_keys=['clinvar_decisions'])
-class GenerateNewClinvarSummary(CohortStage):
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path | str]:
+class GenerateNewClinvarSummary(MultiCohortStage):
+    def expected_outputs(self, mc: MultiCohort) -> dict[str, Path | str]:
         """
         a couple of files and a HT as Paths
         """
@@ -70,7 +70,7 @@ class GenerateNewClinvarSummary(CohortStage):
             'snv_vcf': to_path(join(common_folder, 'pathogenic_snvs.vcf.bgz')),
         }
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
+    def queue_jobs(self, mc: MultiCohort, inputs: StageInput) -> StageOutput:
         # relatively RAM intensive, short running task
         clinvarbitrate = get_batch().new_job('Run ClinvArbitration Summary')
         clinvarbitrate.image(image_path('clinvarbitration')).memory('highmem').cpu('2')
@@ -80,7 +80,7 @@ class GenerateNewClinvarSummary(CohortStage):
         clinvarbitrate.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
 
         # get the expected outputs
-        outputs = self.expected_outputs(cohort)
+        outputs = self.expected_outputs(mc)
 
         if sites_to_blacklist := config_retrieve(['workflow', 'site_blacklist'], []):
             blacklist_sites = ' '.join(f'"{site}"' for site in sites_to_blacklist)
@@ -88,8 +88,8 @@ class GenerateNewClinvarSummary(CohortStage):
         else:
             blacklist_string = ''
 
-        var_file = get_batch().read_input(str(inputs.as_path(cohort, CopyLatestClinvarFiles, 'variant_file')))
-        sub_file = get_batch().read_input(str(inputs.as_path(cohort, CopyLatestClinvarFiles, 'submission_file')))
+        var_file = get_batch().read_input(str(inputs.as_path(mc, CopyLatestClinvarFiles, 'variant_file')))
+        sub_file = get_batch().read_input(str(inputs.as_path(mc, CopyLatestClinvarFiles, 'submission_file')))
 
         clinvarbitrate.command(
             f'resummary -v {var_file} -s {sub_file} -o {clinvarbitrate.output} --minimal {blacklist_string}',
@@ -99,37 +99,37 @@ class GenerateNewClinvarSummary(CohortStage):
         # selectively copy back some outputs
         get_batch().write_output(clinvarbitrate.output, str(outputs['snv_vcf']).removesuffix('.vcf.bgz'))
 
-        return self.make_outputs(target=cohort, data=outputs, jobs=clinvarbitrate)
+        return self.make_outputs(target=mc, data=outputs, jobs=clinvarbitrate)
 
 
 @stage(required_stages=GenerateNewClinvarSummary)
-class AnnotateClinvarDecisions(CohortStage):
+class AnnotateClinvarDecisions(MultiCohortStage):
     """
     take the vcf output from the clinvar stage, and apply VEP annotations
     """
 
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+    def expected_outputs(self, mc: MultiCohort) -> dict[str, Path]:
         common_folder = join(config_retrieve(['storage', 'common', 'analysis']), 'clinvarbitration', DATE_STRING)
         return {
             'vcf': to_path(join(common_folder, 'annotated_snv.vcf.bgz')),
             'index': to_path(join(common_folder, 'annotated_snv.vcf.bgz.tbi')),
         }
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
-        outputs = self.expected_outputs(cohort)
+    def queue_jobs(self, mc: MultiCohort, inputs: StageInput) -> StageOutput:
+        outputs = self.expected_outputs(mc)
 
         # delegate the splitting, annotation, and re-merging to this existing method
         _out_file, jobs = split_and_annotate_vcf(
-            vcf_in=str(inputs.as_path(cohort, GenerateNewClinvarSummary, 'snv_vcf')),
+            vcf_in=str(inputs.as_path(mc, GenerateNewClinvarSummary, 'snv_vcf')),
             out_vcf=str(outputs['vcf']),
         )
 
-        return self.make_outputs(target=cohort, jobs=jobs, data=outputs)
+        return self.make_outputs(target=mc, jobs=jobs, data=outputs)
 
 
 @stage(required_stages=AnnotateClinvarDecisions)
-class PM5TableGeneration(CohortStage):
-    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+class PM5TableGeneration(MultiCohortStage):
+    def expected_outputs(self, mc: MultiCohort) -> dict[str, Path]:
         """
         a single HT
         """
@@ -139,7 +139,7 @@ class PM5TableGeneration(CohortStage):
             'pm5_json': to_path(join(common_folder, 'clinvar_pm5.json')),
         }
 
-    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
+    def queue_jobs(self, mc: MultiCohort, inputs: StageInput) -> StageOutput:
 
         # declare a resouce group, but don't copy the whole thing back
         clinvarbitrate_pm5 = get_batch().new_job('Run ClinvArbitration PM5')
@@ -147,9 +147,9 @@ class PM5TableGeneration(CohortStage):
         authenticate_cloud_credentials_in_job(clinvarbitrate_pm5)
 
         # get the expected outputs
-        outputs = self.expected_outputs(cohort)
+        outputs = self.expected_outputs(mc)
 
-        vcf = str(inputs.as_path(cohort, AnnotateClinvarDecisions, 'vcf'))
+        vcf = str(inputs.as_path(mc, AnnotateClinvarDecisions, 'vcf'))
         annotated_vcf = get_batch().read_input_group(**{'vcf.gz': vcf, 'vcf.gz.tbi': vcf + '.tbi'})['vcf.gz']
 
         # using a declared resource group and only exporting part of it failed... not sure why
@@ -162,4 +162,4 @@ class PM5TableGeneration(CohortStage):
         # also copy back the JSON file
         get_batch().write_output(clinvarbitrate_pm5.output, str(outputs['pm5_json']))
 
-        return self.make_outputs(target=cohort, data=outputs, jobs=clinvarbitrate_pm5)
+        return self.make_outputs(target=mc, data=outputs, jobs=clinvarbitrate_pm5)


### PR DESCRIPTION
Simple uplift of ClinvArbitration workflow to use Cohorts

Slightly more involved uplift of JointVcfQC and JointVcfMultiQC (note, these are not terminal stages in any workflow, so we... don't run them in production)
- Cohort -> MultiCohort
- Corrections to imports
- Only call self.expected_outputs() once
- Use built-in self.prefix and self.web_prefix (these Stages seem to predate the builtin Stage methods)

All tests and linting pass locally for me