### PR TITLE
Reduce repeated method calls

### DIFF
--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -56,6 +56,8 @@ class Align(SequencingGroupStage):
             / f'{sequencing_group.id}.markduplicates-metrics'
         )
 
+        outputs = self.expected_outputs(sequencing_group)
+
         try:
             jobs = align.align(
                 b=get_batch(),
@@ -65,11 +67,8 @@ class Align(SequencingGroupStage):
                 overwrite=sequencing_group.forced,
                 out_markdup_metrics_path=markdup_metrics_path,
             )
-            return self.make_outputs(
-                sequencing_group,
-                data=self.expected_outputs(sequencing_group),
-                jobs=jobs,
-            )
+            return self.make_outputs(sequencing_group, data=outputs, jobs=jobs)
+
         except MissingAlignmentInputException:
             if get_config()['workflow'].get('skip_sgs_with_missing_input'):
                 logging.error(f'No alignment inputs, skipping sequencing group {sequencing_group}')

--- a/cpg_workflows/stages/count.py
+++ b/cpg_workflows/stages/count.py
@@ -47,8 +47,7 @@ class Count(SequencingGroupStage):
         """
         Queue a job to count the reads with featureCounts.
         """
-        cram_path = inputs.as_path(sequencing_group, TrimAlignRNA, 'cram')
-        crai_path = inputs.as_path(sequencing_group, TrimAlignRNA, 'crai')
+        cram_input = inputs.as_dict(sequencing_group, TrimAlignRNA)
         potential_bam_path = sequencing_group.dataset.tmp_prefix() / 'bam' / f'{sequencing_group.id}.bam'
         potential_bai_path = sequencing_group.dataset.tmp_prefix() / 'bam' / f'{sequencing_group.id}.bam.bai'
         input_cram_or_bam: BamPath | CramPath | None = None
@@ -60,7 +59,7 @@ class Count(SequencingGroupStage):
             if potential_bam_path.exists() and potential_bai_path.exists():
                 input_cram_or_bam = BamPath(potential_bam_path, potential_bai_path)
             else:
-                input_cram_or_bam = CramPath(cram_path, crai_path)
+                input_cram_or_bam = CramPath(cram_input['cram'], cram_input['crai'])
 
         output_path = self.expected_outputs(sequencing_group)['count']
         summary_path = self.expected_outputs(sequencing_group)['summary']

--- a/cpg_workflows/stages/fraser.py
+++ b/cpg_workflows/stages/fraser.py
@@ -38,6 +38,8 @@ class Fraser(CohortStage):
         """
         Queue a job to run FRASER.
         """
+
+        outputs = self.expected_outputs(cohort)
         sequencing_groups = cohort.get_sequencing_groups()
 
         bam_or_cram_inputs: list[tuple[BamPath, None] | tuple[CramPath, Path]] = []
@@ -64,9 +66,9 @@ class Fraser(CohortStage):
         j = fraser.fraser(
             b=get_batch(),
             input_bams_or_crams=bam_or_cram_inputs,
-            output_fds_path=list(self.expected_outputs(cohort).values())[0],
+            output_fds_path=list(outputs.values())[0],
             cohort_name=cohort.name,
             job_attrs=self.get_job_attrs(),
             overwrite=cohort.forced,
         )
-        return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=j)
+        return self.make_outputs(cohort, data=outputs, jobs=j)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -53,10 +53,11 @@ class SetSGIDOrdering(CohortStage):
         return {'sgid_order': self.get_stage_cohort_prefix(cohort) / 'sgid_order.json'}
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
+        outputs = self.expected_outputs(cohort)
         sorted_sgids = sorted(cohort.get_sequencing_group_ids())
-        with self.expected_outputs(cohort)['sgid_order'].open('w') as f_handler:
+        with outputs['sgid_order'].open('w') as f_handler:
             json.dump(sorted_sgids, f_handler, indent=2)
-        return self.make_outputs(cohort, data=self.expected_outputs(cohort))
+        return self.make_outputs(cohort, data=outputs)
 
 
 @stage

--- a/cpg_workflows/stages/genotype.py
+++ b/cpg_workflows/stages/genotype.py
@@ -45,14 +45,15 @@ class Genotype(SequencingGroupStage):
         """
         Use function from the jobs module
         """
+        outputs = self.expected_outputs(sequencing_group)
 
         jobs = genotype.genotype(
             b=get_batch(),
-            output_path=self.expected_outputs(sequencing_group)['gvcf'],
+            output_path=outputs['gvcf'],
             sequencing_group_name=sequencing_group.id,
             cram_path=sequencing_group.cram or sequencing_group.make_cram_path(),
             tmp_prefix=self.tmp_prefix / sequencing_group.id,
             overwrite=sequencing_group.forced,
             job_attrs=self.get_job_attrs(sequencing_group),
         )
-        return self.make_outputs(sequencing_group, data=self.expected_outputs(sequencing_group), jobs=jobs)
+        return self.make_outputs(sequencing_group, data=outputs, jobs=jobs)

--- a/cpg_workflows/stages/outrider.py
+++ b/cpg_workflows/stages/outrider.py
@@ -25,6 +25,10 @@ class Outrider(CohortStage):
         """
         Generate outrider outputs.
         """
+
+        # TODO this should probably be changed to self.prefix
+        # TODO this only runs on one cohort, and the cohort only has one analysis dataset assc.
+        # TODO 'outrider' would be included in self.prefix, as it's the result of self.name (the stage)
         dataset_prefix = cohort.get_sequencing_groups()[0].dataset.prefix()
         return {cohort.name: dataset_prefix / 'outrider' / f'{cohort.name}.outrider.RData'}
 
@@ -32,15 +36,16 @@ class Outrider(CohortStage):
         """
         Queue a job to run outrider.
         """
+        outputs = self.expected_outputs(cohort)
         count_inputs = [
             inputs.as_path(sequencing_group, Count, 'count') for sequencing_group in cohort.get_sequencing_groups()
         ]
         j = outrider.outrider(
             b=get_batch(),
             input_counts=count_inputs,
-            output_rdata_path=list(self.expected_outputs(cohort).values())[0],
+            output_rdata_path=list(outputs.values())[0],
             cohort_name=cohort.name,
             job_attrs=self.get_job_attrs(),
             overwrite=cohort.forced,
         )
-        return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=j)
+        return self.make_outputs(cohort, data=outputs, jobs=j)

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -48,6 +48,8 @@ class BamToCram(SequencingGroupStage):
         assert (
             sequencing_group.sequencing_type == 'genome'
         ), f'Only genome sequencing type is supported for BAM to CRAM conversion, unavailable for {sequencing_group.id}'
+
+        outputs = self.expected_outputs(sequencing_group)
         input_bam = b.read_input_group(bam=str(sequencing_group.alignment_input))
         job, output_cram = bam_to_cram.bam_to_cram(
             b=get_batch(),
@@ -57,6 +59,6 @@ class BamToCram(SequencingGroupStage):
             requested_nthreads=1,
             reference_fasta_path=reference_path('broad/ref_fasta'),
         )
-        b.write_output(output_cram, str(self.expected_outputs(sequencing_group)['cram']).removesuffix('.cram'))
+        b.write_output(output_cram, str(outputs['cram']).removesuffix('.cram'))
 
-        return self.make_outputs(sequencing_group, data=self.expected_outputs(sequencing_group), jobs=[job])
+        return self.make_outputs(sequencing_group, data=outputs, jobs=[job])

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -74,22 +74,23 @@ class Stripy(SequencingGroupStage):
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
-        cram_path = inputs.as_path(sequencing_group, Align, 'cram')
-        crai_path = inputs.as_path(sequencing_group, Align, 'crai')
+
+        outputs = self.expected_outputs(sequencing_group)
+        cram_input = inputs.as_path(sequencing_group, Align)
 
         jobs = []
         j = stripy.stripy(
             b=get_batch(),
             sequencing_group=sequencing_group,
-            cram_path=CramPath(cram_path, crai_path),
+            cram_path=CramPath(cram_input['cram'], cram_input['crai']),
             target_loci=get_config()['stripy']['target_loci'],
-            log_path=self.expected_outputs(sequencing_group)['stripy_log'],
+            log_path=outputs['stripy_log'],
             analysis_type=get_config()['stripy']['analysis_type'],
-            out_path=self.expected_outputs(sequencing_group)['stripy_html'],
-            json_path=self.expected_outputs(sequencing_group)['stripy_json'],
+            out_path=outputs['stripy_html'],
+            json_path=outputs['stripy_json'],
             custom_loci_path=get_config()['stripy']['custom_loci_path'],
             job_attrs=self.get_job_attrs(sequencing_group),
         )
         jobs.append(j)
 
-        return self.make_outputs(sequencing_group, data=self.expected_outputs(sequencing_group), jobs=jobs)
+        return self.make_outputs(sequencing_group, data=outputs, jobs=jobs)


### PR DESCRIPTION
Picked up during https://github.com/populationgenomics/production-pipelines/pull/955

We have a bad habit of unnecessarily repeated method calls. Two main offenders are treated here:

The first is Stage B picking up multiple outputs from Stage A. Instead of grabbing both at once:
```
StageA_Inputs = inputs.as_dict(target, StageA)
in_1 = StageA_Inputs['one']
in_2 = StageA_Inputs['two']
```

We regularly get each input separately:
```
in_1 = inputs.as_dict(target, StageA, 'one')
in_2 = inputs.as_dict(target, StageA, 'two')
```

Seems pretty innocent, but duplicates the method calls, most of which cascade down through continued regeneration of the alignment_inputs_hash. We're probably doing more hashing than a Bitcoin miner, and no $BTC to show for it.

Second example is the repeated generation of the expected_outputs, e.g. 
```
json_path = self.expected_outputs(dataset)['json']
html_path = self.expected_outputs(dataset)['html']
checks_path = self.expected_outputs(dataset)['checks']
...
return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=jobs)
```

Which could be simplified down to 
```
outputs = self.expected_outputs(dataset)
json_path = outputs['json']
html_path = outputs['html']
checks_path = outputs['checks']
...
return self.make_outputs(dataset, data=outputs, jobs=jobs)
```

Resulting in only a single call to `self.expected_outputs` instead of 4, and all the resulting non-calls of the hashing algorithm.

I don't _know_ how much time this will save, but we have pipelines that take 40 mins to start up, and this probably isn't helping.
