### PR TITLE
Ca$h the Ha$h

### DIFF
--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -2,11 +2,11 @@
 Targets for workflow stages: SequencingGroup, Dataset, Cohort.
 """
 
-import copy
 import hashlib
 import logging
 from dataclasses import dataclass
 from enum import Enum
+from functools import cache
 from typing import Optional
 
 import pandas as pd
@@ -41,6 +41,7 @@ class Target:
         """
         return [s.id for s in self.get_sequencing_groups(only_active=only_active)]
 
+    @cache
     def alignment_inputs_hash(self) -> str:
         """
         Unique hash string of sample alignment inputs. Useful to decide

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -14,7 +14,7 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import dataset_path, get_config, reference_path, web_url
 from cpg_workflows.filetypes import AlignmentInput, BamPath, CramPath, FastqPairs, GvcfPath
 from cpg_workflows.metamist import Assay
-from cpg_workflows.utils import alignment_inputs_hash_mc, cohort_inputs_hash_by_id, dataset_inputs_hash_by_id
+from cpg_workflows.workflow import alignment_inputs_hash_mc, cohort_inputs_hash_by_id, dataset_inputs_hash_by_id
 
 
 class Target:

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -2,7 +2,6 @@
 Utility functions and constants.
 """
 
-import hashlib
 import logging
 import re
 import string
@@ -21,46 +20,8 @@ from hailtop.batch import ResourceFile
 
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config
-from cpg_workflows.workflow import get_multicohort
 
 LOGGER: logging.Logger | None = None
-
-
-@lru_cache(1)
-def alignment_inputs_hash_mc() -> str:
-    """
-    Unique hash string of sample alignment inputs. Useful to decide
-    whether the analysis on the target needs to be rerun.
-    """
-    all_sgs = get_multicohort().get_sequencing_groups()
-    s = ' '.join(sorted(' '.join(str(s.alignment_input)) for s in all_sgs if s.alignment_input))
-    return f'{hashlib.sha256(s.encode()).hexdigest()[:38]}_{len(all_sgs)}'
-
-
-@lru_cache
-def cohort_inputs_hash_by_id(cohort_id: str) -> str:
-    """
-    Unique hash string of sample alignment inputs. Useful to decide
-    whether the analysis on the target needs to be rerun.
-    """
-    if (cohort := get_multicohort().get_cohort_by_name(cohort_id)) is None:
-        raise ValueError(f'Cohort {cohort_id} not found')
-    all_sgs = cohort.get_sequencing_groups()
-    s = ' '.join(sorted(' '.join(str(s.alignment_input)) for s in all_sgs if s.alignment_input))
-    return f'{hashlib.sha256(s.encode()).hexdigest()[:38]}_{len(all_sgs)}'
-
-
-@lru_cache
-def dataset_inputs_hash_by_id(dataset_id: str) -> str:
-    """
-    Unique hash string of sample alignment inputs. Useful to decide
-    whether the analysis on the target needs to be rerun.
-    """
-    if (dataset := get_multicohort().get_dataset_by_name(dataset_id)) is None:
-        raise ValueError(f'Dataset {dataset_id} not found')
-    all_sgs = dataset.get_sequencing_groups()
-    s = ' '.join(sorted(' '.join(str(s.alignment_input)) for s in all_sgs if s.alignment_input))
-    return f'{hashlib.sha256(s.encode()).hexdigest()[:38]}_{len(all_sgs)}'
 
 
 def get_logger(logger_name: str | None = None, log_level: int = logging.INFO) -> logging.Logger:

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -378,7 +378,7 @@ class Stage(Generic[TargetT], ABC):
         # Dependencies. Populated in workflow.run(), after we know all stages.
         self.required_stages: list[Stage] = []
 
-        self.status_reporter = get_workflow().status_reporter
+        self.status_reporter = get_workflow().status_reporter  # type: ignore
         # If `analysis_type` is defined, it will be used to create/update Analysis
         # entries in Metamist.
         self.analysis_type = analysis_type


### PR DESCRIPTION
The 'generate a hash method of all SG BAM/CRAM paths' method is at the Target level, and takes no arguments. I can't see a reason not to cache the result.

https://github.com/populationgenomics/production-pipelines/pull/956 Is an attempt to stop doing redundant calls all over the place, but this is a way simpler fix that should also improve startup times in large cohorts. 

We've gotten used to 20-30 mins being a reasonable startup time, but given that we already cache existence checks as much as possible, it's reasonable to knock out continuously re-hashing massive strings just to find out which file paths we need to check 👀  I don't see what else in this codebase should be taking so long during startup.

I've tried and failed a few different ways -
- Cache'ing on the instance method (Target.alignment_inputs_hash) fails linting because caching an instance method is bad. It would result in each class instance being saved in the LRU cache, and not being killed by the garbage collector so it fails the ruff rule `B019`. I actually think this is fine, as SequencingGroups don't have this method, so there's only one instance of each MultiCohort, Cohort, and Dataset, and we don't want any of them garbage collected during pipeline setup anyway.
    - I still think this is the best approach, especially if we want to run a quick test and see if this is a meaningful speedup: commit [here](https://github.com/populationgenomics/production-pipelines/pull/957/commits/37f84000568a1c901c201db62064117c3b5b3e8d). We can add an ignore on the ruff rule, as our pipeline has a really low upper bound on number of Cohorts/Datasets/MC instantiated at any one time.
    
- Plan B was to make a separate method to be called by MultiCohorts, Cohorts, and Datasets. This method would take no arguments (MultiCohort), or the ID of the instance (Dataset or Cohort). In the method we would get the current MultiCohort and either:
    - use it directly to get SGs
    - use the Dataset/Cohort ID provided as argument to get the corresponding Cohort/Dataset, then get its SGs.

That is the current state of this PR, and in theory it plays well because we're only ever have to cache against a String ID - getting the class instance is done inside the method, everybody is happy.

Except this doesn't work - `workflow.py` pulls in all the Targets, so inside the `targets.py` file we can't import `get_multicohort` from `workflow.py` - circular import. I've tried putting it in `utils.py`, still circular, as utils is imported during `workflow.py`, so it can't import from it. 

I tried breaking this off into a separate `hashes.py` file entirely, but the fundamental issue is that the way to get hashes from a target needs to be known by the Targets, and inside the method there's an import/call of get_workflow. That's just a built in circular import, so it kills pipeline startup. 

