### PR TITLE
Fix broken gCNV Annotation pipeline

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.29.4
+current_version = 1.29.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.29.4
+  VERSION: 1.29.5
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample.toml
+++ b/configs/defaults/gatk_sv_multisample.toml
@@ -3,6 +3,9 @@ name = 'gatk_sv'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 status_reporter = 'metamist'
 
+# update this when cpg_workflows.scripts.get_gencode_gtf.sh is re-run
+gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
+
 # Write dataset MTs for these datasets. Required for the AnnotateDatasetSv stage.
 # write_mt_for_datasets = []
 

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -13,6 +13,9 @@ num_samples_per_scatter_block = 10
 gncv_max_events = 320
 gncv_max_pass_events = 30
 
+# update this when cpg_workflows.scripts.get_gencode_gtf.sh is re-run
+gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
+
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
 gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -13,7 +13,7 @@ from cpg_utils.hail_batch import command, fasta_res_group, get_batch, query_comm
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.query_modules import seqr_loader
 from cpg_workflows.resources import HIGHMEM
-from cpg_workflows.scripts import upgrade_ped_with_inferred, seqr_loader_cnv
+from cpg_workflows.scripts import seqr_loader_cnv, upgrade_ped_with_inferred
 from cpg_workflows.utils import can_reuse, chunks
 
 
@@ -707,7 +707,7 @@ def annotate_dataset_jobs_cnv(
         f'--mt_out {out_mt_path} '
         f'--checkpoint {str(tmp_prefix / "checkpoints")} '
         'dataset '  # use the annotate_DATASET functionality
-        f'--mt_in {str(subset_mt_path)} '
+        f'--mt_in {str(subset_mt_path)} ',
     )
 
     if subset_j:

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -13,7 +13,7 @@ from cpg_utils.hail_batch import command, fasta_res_group, get_batch, query_comm
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.query_modules import seqr_loader
 from cpg_workflows.resources import HIGHMEM
-from cpg_workflows.scripts import seqr_loader_cnv, upgrade_ped_with_inferred
+from cpg_workflows.scripts import upgrade_ped_with_inferred
 from cpg_workflows.utils import can_reuse, chunks
 
 

--- a/cpg_workflows/jobs/seqr_loader_sv.py
+++ b/cpg_workflows/jobs/seqr_loader_sv.py
@@ -23,12 +23,15 @@ def annotate_cohort_jobs_sv(
 
     j = get_batch().new_job('Annotate cohort', job_attrs)
     j.image(get_config()['workflow']['driver_image'])
+    gencode_gz = get_config()['worfklow']['gencode_gtf_file']
+    gencode_gtf_local = get_batch().read_input(str(gencode_gz))
     j.command(
         query_command(
             seqr_loader_sv,
             seqr_loader_sv.annotate_cohort_sv.__name__,
             str(vcf_path),
             str(out_mt_path),
+            str(gencode_gtf_local),
             str(checkpoint_prefix),
             setup_gcp=True,
         ),

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -7,13 +7,8 @@ import logging
 
 import hail as hl
 
-from cpg_utils.config import get_config
 from cpg_utils.hail_batch import genome_build
-from cpg_workflows.query_modules.seqr_loader_sv import (
-    download_gencode_gene_id_mapping,
-    get_expr_for_xpos,
-    parse_gtf_from_local,
-)
+from cpg_workflows.query_modules.seqr_loader_sv import get_expr_for_xpos, parse_gtf_from_local
 from cpg_workflows.utils import checkpoint_hail, read_hail
 
 # I'm just going to go ahead and steal these constants from their seqr loader
@@ -30,7 +25,7 @@ NON_GENE_PREDICTIONS = {
 }
 
 
-def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str | None = None):
+def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, checkpoint_prefix: str | None = None):
     """
     Translate an annotated gCNV VCF into a Seqr-ready format
     Relevant gCNV specific schema
@@ -40,6 +35,7 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str
     Args:
         vcf_path (str): Where is the VCF??
         out_mt_path (str): And where do you need output!?
+        gencode_gz (str): The path to a compressed GENCODE GTF file
         checkpoint_prefix (str): CHECKPOINT!@!!
     """
 
@@ -93,8 +89,7 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, checkpoint_prefix: str
     mt = checkpoint_hail(mt, 'initial_annotation_round.mt', checkpoint_prefix)
 
     # get the Gene-Symbol mapping dict
-    gene_id_mapping_file = download_gencode_gene_id_mapping(get_config().get('gencode_release', '46'))
-    gene_id_mapping = parse_gtf_from_local(gene_id_mapping_file)
+    gene_id_mapping = parse_gtf_from_local(gencode_gz)
 
     # find all the column names which contain Gene symbols
     conseq_predicted_gene_cols = [

--- a/cpg_workflows/query_modules/seqr_loader_cnv.py
+++ b/cpg_workflows/query_modules/seqr_loader_cnv.py
@@ -4,12 +4,14 @@ Hail Query functions for seqr loader; SV edition.
 
 import datetime
 import logging
+from argparse import ArgumentParser
+from os.path import join
 
 import hail as hl
 
 from cpg_utils.hail_batch import genome_build
 from cpg_workflows.query_modules.seqr_loader_sv import get_expr_for_xpos, parse_gtf_from_local
-from cpg_workflows.utils import checkpoint_hail, read_hail
+from cpg_workflows.utils import chunks, read_hail
 
 # I'm just going to go ahead and steal these constants from their seqr loader
 GENE_SYMBOL = 'gene_symbol'
@@ -25,7 +27,7 @@ NON_GENE_PREDICTIONS = {
 }
 
 
-def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, checkpoint_prefix: str | None = None):
+def annotate_cohort_gcnv(vcf: str, mt_out: str, gencode: str, checkpoint: str, *args, **kwargs):
     """
     Translate an annotated gCNV VCF into a Seqr-ready format
     Relevant gCNV specific schema
@@ -33,18 +35,18 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, check
     Relevant gCNV loader script
     https://github.com/populationgenomics/seqr-loading-pipelines/blob/master/luigi_pipeline/seqr_gcnv_loading.py
     Args:
-        vcf_path (str): Where is the VCF??
-        out_mt_path (str): And where do you need output!?
-        gencode_gz (str): The path to a compressed GENCODE GTF file
-        checkpoint_prefix (str): CHECKPOINT!@!!
+        vcf (str): Where is the VCF??
+        mt_out (str): And where do you need output!?
+        gencode (str): The path to a compressed GENCODE GTF file
+        checkpoint (str): location we can write checkpoints to
     """
 
     logger = logging.getLogger('annotate_cohort_gcnv')
     logger.setLevel(logging.INFO)
 
-    logger.info(f'Importing SV VCF {vcf_path}')
+    logger.info(f'Importing SV VCF {vcf}')
     mt = hl.import_vcf(
-        vcf_path,
+        vcf,
         array_elements_required=False,
         force_bgz=True,
         reference_genome=genome_build(),
@@ -53,7 +55,7 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, check
 
     # add attributes required for Seqr
     mt = mt.annotate_globals(
-        sourceFilePath=vcf_path,
+        sourceFilePath=vcf,
         genomeVersion=genome_build().replace('GRCh', ''),
         hail_version=hl.version(),
         datasetType='SV',
@@ -85,12 +87,6 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, check
         num_exon=hl.agg.max(mt.NP),
     )
 
-    # save those changes
-    mt = checkpoint_hail(mt, 'initial_annotation_round.mt', checkpoint_prefix)
-
-    # get the Gene-Symbol mapping dict
-    gene_id_mapping = parse_gtf_from_local(gencode_gz)
-
     # find all the column names which contain Gene symbols
     conseq_predicted_gene_cols = [
         gene_col
@@ -111,15 +107,29 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, check
         ),
     )
 
+    mt = mt.checkpoint('pre-gene_annotation.mt', overwrite=True)
+
+    # this next section is currently failing - the dictionary of genes is too large
+    # to be used in an annotation expression. At least... I think it is
+    # for i, chunks in enumerate(chunks(gene_id_mapping, 100)):
+
+    # get the Gene-Symbol mapping dict
+    gene_id_mappings = parse_gtf_from_local(gencode, chunk_size=15000)
+
     # overwrite symbols with ENSG IDs in these columns
     # not sure why this is required, I think SV annotation came out
     # with ENSGs from the jump, but this is all symbols
-    for col_name in conseq_predicted_gene_cols:
-        mt = mt.annotate_rows(
-            info=mt.info.annotate(
-                **{col_name: hl.map(lambda gene: gene_id_mapping.get(gene, gene), mt.info[col_name])},
-            ),
-        )
+    for i, gene_id_mapping in enumerate(gene_id_mappings):
+        logging.info(f'Processing gene ID mapping chunk {i}')
+        for col_name in conseq_predicted_gene_cols:
+            mt = mt.annotate_rows(
+                info=mt.info.annotate(
+                    **{col_name: hl.map(lambda gene: gene_id_mapping.get(gene, gene), mt.info[col_name])},
+                ),
+            )
+
+        # # checkpoint this chunk
+        mt = mt.checkpoint(join(checkpoint, f'fragment_{i}.mt'))
 
     mt = mt.annotate_rows(
         # this expected mt.variant_name to be present, and it's not
@@ -168,21 +178,21 @@ def annotate_cohort_gcnv(vcf_path: str, out_mt_path: str, gencode_gz: str, check
     )
 
     # write this output
-    mt.write(out_mt_path, overwrite=True)
+    mt.write(mt_out, overwrite=True)
 
 
-def annotate_dataset_gcnv(mt_path: str, out_mt_path: str):
+def annotate_dataset_gcnv(mt_in: str, mt_out: str, *args, **kwargs):
     """
     process data specific to samples in this dataset
     do this after sub-setting to specific samples
     Args:
-        mt_path (str): path to the annotated MatrixTable
-        out_mt_path (str): and where do you want it to end up?
+        mt_in (str): path to the annotated MatrixTable
+        mt_out (str): and where do you want it to end up?
     """
 
     logging.info('Annotating genotypes')
 
-    mt = read_hail(mt_path)
+    mt = read_hail(mt_in)
 
     # adding in the GT here, that may cause problems later?
     mt = mt.annotate_rows(
@@ -269,5 +279,33 @@ def annotate_dataset_gcnv(mt_path: str, out_mt_path: str):
     )
     logging.info('Genotype fields annotated')
     mt.describe()
-    mt.write(out_mt_path, overwrite=True)
-    logging.info(f'Written gCNV MT to {out_mt_path}')
+    mt.write(mt_out, overwrite=True)
+    logging.info(f'Written gCNV MT to {mt_out}')
+
+
+# add an entrypoint?
+if __name__ == '__main__':
+    # enable Info-level logging
+    logging.basicConfig(level=logging.INFO)
+
+    # set up an argument parser to allow two separate entrypoints
+    parser = ArgumentParser()
+    # this argument is used for both entrypoints
+    parser.add_argument('--mt_out', help='Path to the MatrixTable, input or output', required=True)
+    parser.add_argument('--checkpoint', help='Dir to write checkpoints to', required=True)
+    subparsers = parser.add_subparsers()
+
+    # a parser for the AnnotateCohort method
+    cohort_parser = subparsers.add_parser('cohort')
+    cohort_parser.add_argument('--vcf', help='Path to input VCF file')
+    cohort_parser.add_argument('--gencode', help='Path to input gencode GTF file')
+    cohort_parser.set_defaults(func=annotate_cohort_gcnv)
+
+    # a parser for the AnnotateDataset method
+    cohort_parser = subparsers.add_parser('dataset')
+    cohort_parser.add_argument('--mt_in', help='Path to input MT')
+    cohort_parser.set_defaults(func=annotate_dataset_gcnv)
+
+    args = parser.parse_args()
+
+    args.func(**vars(args))

--- a/cpg_workflows/query_modules/seqr_loader_sv.py
+++ b/cpg_workflows/query_modules/seqr_loader_sv.py
@@ -143,10 +143,7 @@ def parse_gtf_from_local(gtf_path: str, chunk_size: int | None = None) -> hl.dic
         return [hl.literal(gene_id_mapping)]
 
     # hail can't impute the type of a generator, so do this in baby steps
-    sub_dictionaries = [
-        {key: gene_id_mapping[key] for key in keys}
-        for keys in generator_chunks(all_keys, chunk_size)
-    ]
+    sub_dictionaries = [{key: gene_id_mapping[key] for key in keys} for keys in generator_chunks(all_keys, chunk_size)]
 
     return [hl.literal(each_dict) for each_dict in sub_dictionaries]
 
@@ -250,7 +247,7 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, gencode_gz: str, checkpo
 
     # save those changes
     if checkpoint:
-        mt = mt.checkpoint(join(checkpoint,  'initial_annotation_round.mt'))
+        mt = mt.checkpoint(join(checkpoint, 'initial_annotation_round.mt'))
 
     # get the Gene-Symbol mapping dict
     gene_id_mapping = parse_gtf_from_local(gencode_gz)[0]

--- a/cpg_workflows/scripts/get_gencode_gtf.sh
+++ b/cpg_workflows/scripts/get_gencode_gtf.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# use this get_gencode_gtf.sh script to download the latest GENCODE GTF file
+# and place it in the appropriate place in the CPG bucket
+
+set -ex
+
+GENCODE_VERSION=${1:-"47"}
+
+# download the GTF file
+wget -O gencode.gtf.gz "https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_${GENCODE_VERSION}/gencode.v${GENCODE_VERSION}.annotation.gtf.gz"
+
+# don't unzip the file - unzipping inflates from ~50MB to ~1.8GB, and transfer is probably the bottleneck
+# place the file in the place in the CPG bucket
+gsutil cp gencode.gtf "gs://cpg-common-main/references/hg38/v0/gencode_${GENCODE_VERSION}.gtf.gz"

--- a/cpg_workflows/scripts/seqr_loader_cnv.py
+++ b/cpg_workflows/scripts/seqr_loader_cnv.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 from os.path import join
 
 import hail as hl
+
 from cpg_utils.hail_batch import genome_build, init_batch
 from cpg_workflows.query_modules.seqr_loader_sv import get_expr_for_xpos, parse_gtf_from_local
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -9,9 +9,8 @@ from google.api_core.exceptions import PermissionDenied
 
 from cpg_utils import Path, to_path
 from cpg_utils.config import AR_GUID_NAME, config_retrieve, image_path, reference_path, try_get_ar_guid
-from cpg_utils.hail_batch import get_batch, query_command
+from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs import gcnv
-from cpg_workflows.scripts import seqr_loader_cnv
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_images, get_references, queue_annotate_sv_jobs
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.targets import Cohort, Dataset, MultiCohort, SequencingGroup
@@ -625,7 +624,7 @@ class AnnotateCohortgCNV(MultiCohortStage):
             f'--checkpoint {str(self.tmp_prefix / "checkpoints")} '
             f'cohort '  # use the annotate_COHORT functionality
             f'--vcf {vcf_path} '
-            f'--gencode {gencode_gtf_local} '
+            f'--gencode {gencode_gtf_local} ',
         )
 
         return self.make_outputs(multicohort, data=outputs, jobs=j)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -11,7 +11,7 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import AR_GUID_NAME, config_retrieve, image_path, reference_path, try_get_ar_guid
 from cpg_utils.hail_batch import get_batch, query_command
 from cpg_workflows.jobs import gcnv
-from cpg_workflows.query_modules import seqr_loader_cnv
+from cpg_workflows.scripts import seqr_loader_cnv
 from cpg_workflows.stages.gatk_sv.gatk_sv_common import get_images, get_references, queue_annotate_sv_jobs
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.targets import Cohort, Dataset, MultiCohort, SequencingGroup
@@ -612,23 +612,20 @@ class AnnotateCohortgCNV(MultiCohortStage):
         Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
         """
 
-        vcf_path = inputs.as_path(target=multicohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf')
+        vcf_path = str(inputs.as_path(target=multicohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf'))
         outputs = self.expected_outputs(multicohort)
 
         j = get_batch().new_job('annotate gCNV cohort', self.get_job_attrs(multicohort))
-        j.image(image_path('cpg_workflows'))
+        j.image(config_retrieve(['worfklow', 'driver_image']))
         gencode_gz = config_retrieve(['worfklow', 'gencode_gtf_file'])
         gencode_gtf_local = get_batch().read_input(str(gencode_gz))
         j.command(
-            query_command(
-                seqr_loader_cnv,
-                seqr_loader_cnv.annotate_cohort_gcnv.__name__,
-                str(vcf_path),
-                str(outputs['mt']),
-                str(gencode_gtf_local),
-                str(self.tmp_prefix / 'checkpoints'),
-                setup_gcp=True,
-            ),
+            'seqr_loader_cnv '
+            f'--mt_out {str(outputs["mt"])} '
+            f'--checkpoint {str(self.tmp_prefix / "checkpoints")} '
+            f'cohort '  # use the annotate_COHORT functionality
+            f'--vcf {vcf_path} '
+            f'--gencode {gencode_gtf_local} '
         )
 
         return self.make_outputs(multicohort, data=outputs, jobs=j)
@@ -660,7 +657,7 @@ class AnnotateDatasetCNV(DatasetStage):
         jobs = gcnv.annotate_dataset_jobs_cnv(
             mt_path=mt_in,
             sgids=dataset.get_sequencing_group_ids(),
-            out_mt_path=outputs['mt'],
+            out_mt_path=str(outputs['mt']),
             tmp_prefix=self.tmp_prefix / dataset.name / 'checkpoints',
             job_attrs=self.get_job_attrs(dataset),
         )

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -617,12 +617,15 @@ class AnnotateCohortgCNV(MultiCohortStage):
 
         j = get_batch().new_job('annotate gCNV cohort', self.get_job_attrs(multicohort))
         j.image(image_path('cpg_workflows'))
+        gencode_gz = config_retrieve(['worfklow', 'gencode_gtf_file'])
+        gencode_gtf_local = get_batch().read_input(str(gencode_gz))
         j.command(
             query_command(
                 seqr_loader_cnv,
                 seqr_loader_cnv.annotate_cohort_gcnv.__name__,
                 str(vcf_path),
                 str(outputs['mt']),
+                str(gencode_gtf_local),
                 str(self.tmp_prefix / 'checkpoints'),
                 setup_gcp=True,
             ),

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
             'mt_to_es = cpg_workflows.scripts.mt_to_es_without_dataproc:main',
             # Generate new intervals from a MatrixTable
             'new_intervals_from_mt = cpg_workflows.scripts.generate_new_intervals:cli_main',
-            # Generate new intervals from a MatrixTable
             'seqr_loader_cnv = cpg_workflows.scripts.seqr_loader_cnv:cli_main',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
             'mt_to_es = cpg_workflows.scripts.mt_to_es_without_dataproc:main',
             # Generate new intervals from a MatrixTable
             'new_intervals_from_mt = cpg_workflows.scripts.generate_new_intervals:cli_main',
+            # Generate new intervals from a MatrixTable
+            'seqr_loader_cnv = cpg_workflows.scripts.seqr_loader_cnv:cli_main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.29.4',
+    version='1.29.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Problem!

- We can't complete gCNV runs anymore, they're broken

## Reason!

See https://batch.hail.populationgenomics.org.au/batches/518770/jobs/358 as an example - nothing but a miserable Hail dump exception. 

@EddieLF tracked the issue to the worker batch, e.g. https://batch.hail.populationgenomics.org.au/batches/518781/jobs/4

```
Caused by: com.fasterxml.jackson.core.exc.StreamConstraintsException: 
String length (20051112) exceeds the maximum length (20000000)
```

I did some poking around and tracked the problem down to [here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/query_modules/seqr_loader_cnv.py#L125). In the gCNV and GATK-SV workflows we load up a GTF file from Gencode, parse it as a dictionary, then use that dict to update the gene symbols to ENSGs. I guess this dictionary grows over time, but it now contains upwards of 40k entries, each being a key: value mapping of long Strings. This exceeds the 20MB cap in Spark when creating and evaluating expressions. 

This change covers a few things:

1. We currently get the Gencode GTF file each time AnnotateCohort runs in the gCNV or GATK-SV pipelines, copy it as a local file, then throw it away. This adds a script we can run to get a specific version of this file and copy it into the common bucket. It's added as a config entry for the gCNV and GATK-SV pipelines, which should save a few mins each run.
2. When parsing this file there's an optional argument for `chunk_size`. Instead of returning a single dictionary, this gives more granular control to break that monolith up into smaller dicts
3. Using this collection of smaller dicts in the gCNV pipeline, we annotate with each fragment in turn, then write a checkpoint. This forces Hail's lazy evaluation, so the size of the expression being passed around is tiny. The MTs in general about only a few MB in size, so there's no issues with writing multiple checkpoints. I don't think GATK-SV has failed yet, so I've not made the same edits there.
4. The AnnotateCohort/Dataset script is currently run using query_command, and I really hate that, so I've written a command line ArgParse entrypoint, and this will now work as a standalone script.