### PR TITLE
Add ability to spawn multiple loggers

### DIFF
--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -23,7 +23,10 @@ from hailtop.batch import ResourceFile
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config
 
-DEFAULT_LOG_FORMAT = '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s'
+DEFAULT_LOG_FORMAT = config_retrieve(
+    ['workflow', 'logger', 'default_format'],
+    '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s',
+)
 LOGGERS: dict[str, logging.Logger] = {}
 
 

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -22,10 +22,7 @@ from hailtop.batch import ResourceFile
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config
 
-DEFAULT_LOG_FORMAT = config_retrieve(
-    ['workflow', 'log_format'],
-    '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s',
-)
+DEFAULT_LOG_FORMAT = '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s'
 LOGGERS: dict[str, logging.Logger] = {}
 
 
@@ -38,7 +35,7 @@ def get_logger(
     creates a logger instance (so as not to use the root logger)
     Args:
         logger_name (str):
-        log_level (int): logging level, defaults to INFO
+        log_level (int): logging level, defaults to INFO. Can be overridden by config
         fmt_string (str): format string for this logger, defaults to DEFAULT_LOG_FORMAT
     Returns:
         a logger instance, if required create it first
@@ -46,12 +43,16 @@ def get_logger(
 
     if logger_name not in LOGGERS:
 
+        # allow a log-level & format override on a name basis
+        log_level = config_retrieve(['workflow', 'logger', logger_name, 'level'], log_level)
+        fmt_string = config_retrieve(['workflow', 'logger', logger_name, 'format'], fmt_string)
+
         # create a named logger
         new_logger = logging.getLogger(logger_name)
         new_logger.setLevel(log_level)
 
         # unless otherwise specified, use coloredlogs
-        if config_retrieve(['workflow', 'use_colored_logs'], True):
+        if config_retrieve(['workflow', 'logger', logger_name, 'use_colored_logs'], True):
             coloredlogs.install(level=log_level, fmt=fmt_string, logger=new_logger)
 
         # create a stream handler to write output

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -21,7 +21,11 @@ from hailtop.batch import ResourceFile
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config
 
-DEFAULT_LOG_FORMAT = '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s'
+DEFAULT_LOG_FORMAT = config_retrieve(
+    'workflow',
+    'log_format',
+    '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s',
+)
 LOGGERS: dict[str, logging.Logger] = {}
 
 

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -2,6 +2,7 @@
 Utility functions and constants.
 """
 
+import coloredlogs
 import logging
 import re
 import string
@@ -42,13 +43,16 @@ def get_logger(
     Returns:
         a logger instance, if required create it first
     """
-    if logger_name not in LOGGERS:
 
-        # TODO optionally install the coloredlogs module (useless in production, useful to debug?)
+    if logger_name not in LOGGERS:
 
         # create a named logger
         new_logger = logging.getLogger(logger_name)
         new_logger.setLevel(log_level)
+
+        # unless otherwise specified, use coloredlogs
+        if config_retrieve(['workflow', 'use_colored_logs'], True):
+            coloredlogs.install(level=log_level, fmt=fmt_string, logger=new_logger)
 
         # create a stream handler to write output
         stream_handler = logging.StreamHandler(sys.stdout)

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -22,8 +22,7 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config
 
 DEFAULT_LOG_FORMAT = config_retrieve(
-    'workflow',
-    'log_format',
+    ['workflow', 'log_format'],
     '%(asctime)s - %(name)s - %(pathname)s: %(lineno)d - %(levelname)s - %(message)s',
 )
 LOGGERS: dict[str, logging.Logger] = {}

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -2,7 +2,6 @@
 Utility functions and constants.
 """
 
-import coloredlogs
 import logging
 import re
 import string
@@ -15,6 +14,8 @@ from itertools import chain, islice
 from os.path import basename, dirname, join
 from random import choices
 from typing import Union, cast
+
+import coloredlogs
 
 import hail as hl
 from hailtop.batch import ResourceFile


### PR DESCRIPTION
Very related to https://cpg-populationanalysis.atlassian.net/browse/SET-242

We use the root logger everywhere. That's bad 
- the settings we apply (log level, format string) can get overridden by other libraries using the root logger
- we can't add separate logging granularity to the workflow setup and the pipeline Stage logic (i.e. I want to run a pipeline with debug settings, but I don't want to log every metamist call at debug level)
- we don't currently have the granularity to override the format strings. Our current log prints contain the full datetime (`YYYY-MM-DD HH:MM:SS`), which means that we cannot do a direct comparison of any two logging outputs - the seconds are guaranteed to differ between executions

This PR proposes fleshing out the `get_logger` method we already have to do a few more fun things:

... MATT TO COMPLETE THIS PR

Ideally every instance of `logging.LEVEL(message)` in prod-pipes would be changed to use a named logger, whether that's pipeline-wide, per-module, whatever.