### PR TITLE
Update pipeline Stages re:959

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -35,6 +35,7 @@ from cpg_workflows.workflow import (
     MultiCohortStage,
     StageInput,
     StageOutput,
+    get_multicohort,
     get_workflow,
     stage,
 )
@@ -1311,10 +1312,8 @@ class AnnotateDatasetSv(DatasetStage):
             get_logger().info(f'Skipping AnnotateDatasetSv mt subsetting for {dataset}')
             return None
 
-        assert dataset.cohort
-        assert dataset.cohort.multicohort
-        mt_path = inputs.as_path(target=dataset.cohort.multicohort, stage=AnnotateCohortSv, key='mt')
-        exclusion_file = inputs.as_path(dataset.cohort.multicohort, stage=CombineExclusionLists, key='exclusion_list')
+        mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortSv, key='mt')
+        exclusion_file = inputs.as_path(get_multicohort(), stage=CombineExclusionLists, key='exclusion_list')
 
         outputs = self.expected_outputs(dataset)
 

--- a/cpg_workflows/stages/joint_genotyping_qc.py
+++ b/cpg_workflows/stages/joint_genotyping_qc.py
@@ -84,8 +84,7 @@ class JointVcfHappy(SequencingGroupStage):
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
         """Queue jobs"""
-        assert sequencing_group.dataset.cohort
-        vcf_path = inputs.as_path(target=sequencing_group.dataset.cohort, stage=JointGenotyping, key='vcf')
+        vcf_path = inputs.as_path(target=get_multicohort(), stage=JointGenotyping, key='vcf')
 
         jobs = happy(
             b=get_batch(),

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from google.api_core.exceptions import PermissionDenied
 
-from cpg_utils import Path, to_path
+from cpg_utils import Path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
@@ -15,7 +15,15 @@ from cpg_workflows.jobs.seqr_loader import annotate_dataset_jobs, cohort_to_vcf_
 from cpg_workflows.query_modules import seqr_loader
 from cpg_workflows.targets import Dataset, MultiCohort
 from cpg_workflows.utils import get_logger, tshirt_mt_sizing
-from cpg_workflows.workflow import DatasetStage, MultiCohortStage, StageInput, StageOutput, get_workflow, stage
+from cpg_workflows.workflow import (
+    DatasetStage,
+    MultiCohortStage,
+    StageInput,
+    StageOutput,
+    get_multicohort,
+    get_workflow,
+    stage,
+)
 
 from .joint_genotyping import JointGenotyping
 from .vep import Vep
@@ -96,9 +104,7 @@ class AnnotateDataset(DatasetStage):
             get_logger().info(f'Skipping AnnotateDataset mt subsetting for {dataset}')
             return None
 
-        assert dataset.cohort
-        assert dataset.cohort.multicohort
-        mt_path = inputs.as_path(target=dataset.cohort.multicohort, stage=AnnotateCohort, key='mt')
+        mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohort, key='mt')
 
         jobs = annotate_dataset_jobs(
             mt_path=mt_path,

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -20,6 +20,7 @@ from cpg_workflows.workflow import (
     SequencingGroupStage,
     StageInput,
     StageOutput,
+    get_multicohort,
     get_workflow,
     stage,
 )
@@ -291,9 +292,7 @@ class AnnotateDatasetLRSv(DatasetStage):
             dataset (Dataset): SGIDs specific to this dataset/project
             inputs ():
         """
-        assert dataset.cohort
-        assert dataset.cohort.multicohort
-        mt_path = inputs.as_path(target=dataset.cohort.multicohort, stage=AnnotateCohortLRSv, key='mt')
+        mt_path = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortLRSv, key='mt')
 
         outputs = self.expected_outputs(dataset)
 


### PR DESCRIPTION
Relevant to this comment: https://github.com/populationgenomics/production-pipelines/pull/959#pullrequestreview-2409426480 on #959.

These methods/calls will become invalid in cpg-flow, and there's a simpler way to do the same thing right now. We should exchange the method calls we're using now with a future-compatible behaviour.