### PR TITLE
Dont merge single VCFs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.0
+current_version = 1.30.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.0
+  VERSION: 1.30.1
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.0',
+    version='1.30.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #970 

When I translated the gCNV pipeline from Cohorts to MultiCohorts there were an UNBELIEVABLE number of issues, and unforeseen bugs.

Now the pipeline runs for each Cohort in parallel, then merges all the per-cohort joint-calls into a single massive callset prior to merging. This bug occurs when the MultiCohort contains a single Cohort - we try to `bcftools merge` a single VCF, which is not valid.