### PR TITLE
Quick hack to enable overriding the QoB JAR commit hash

### DIFF
--- a/cpg_workflows/batch.py
+++ b/cpg_workflows/batch.py
@@ -2,6 +2,9 @@
 Extending the Hail's `Batch` class.
 """
 
+from hail.backend.service_backend import ServiceBackend
+from hail.utils.java import Env
+
 
 def make_job_name(
     name: str,
@@ -22,3 +25,20 @@ def make_job_name(
     if part:
         name += f', {part}'
     return name
+
+
+_override_revision = None
+
+
+class OverrideServiceBackend(ServiceBackend):
+    @property
+    def jar_spec(self) -> dict:
+        return {'type': 'git_revision', 'value': _override_revision}
+
+
+def override_jar_spec(revision: str) -> None:
+    global _override_revision
+    _override_revision = revision
+    backend = Env.backend()
+    if isinstance(backend, ServiceBackend):
+        backend.__class__ = OverrideServiceBackend

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING
 
 from hail.vds import new_combiner
 
+from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
+from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import can_reuse, to_path
 
 if TYPE_CHECKING:  # TCH002 https://docs.astral.sh/ruff/rules/typing-only-third-party-import/
@@ -38,6 +40,8 @@ def run(
 
     if not can_reuse(to_path(output_vds_path)):
         init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
+        if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
+            override_jar_spec(jar_spec)
 
         if specific_intervals:
             logging.info(f'Using specific intervals: {specific_intervals}')


### PR DESCRIPTION
Enable the combiner code (and other code that may wish to) to override the QoB JAR used. In this case, if a `workflow.jar_spec_revision` config entry exists, the combiner will use the specified JAR instead of the default vanilla 0.2.133 release QoB JAR.

We could incorporate this into `init_batch()`, but that comes from cpg-utils. Limiting the changes required to production-pipelines simplifies deployment of this quick hack.

(We will also need to generate a JAR containing the fix before we can set the config item!)