### PR TITLE
Adds additional VEP annotations into the simple annotation script

### DIFF
--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -172,7 +172,7 @@ def annotate_localised_vcfs(
         vep_job.command(
             f"""
             vep
-            '--format vcf
+            --format vcf
             -i {vcf}
             --vcf
             --compress_output bgzip

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -171,25 +171,25 @@ def annotate_localised_vcfs(
         vep_job.command(f'FASTA={vep_dir}/vep/homo_sapiens/*/Homo_sapiens.GRCh38*.fa.gz && echo $FASTA')
         vep_job.command(
             f"""
-            vep
-            --format vcf
-            -i {vcf}
-            --vcf
-            --compress_output bgzip
-            --no_stats
-            --dir_cache {vep_dir}/vep/
-            --species homo_sapiens
-            --cache
-            --offline
-            --assembly GRCh38
-            --fa ${{FASTA}}
-            -o {vep_job.vcf["vcf.bgz"]}
-            --protein
-            --af_gnomadg
-            --af_gnomade
-            --mane_select
-            --plugin AlphaMissense,file={vep_dir}/AlphaMissense_hg38.tsv.gz
-            --plugin LoF,{",".join(f"{k}:{v}" for k, v in loftee_conf.items())}
+            vep \
+            --format vcf \
+            -i {vcf} \
+            --vcf \
+            --compress_output bgzip \
+            --no_stats \
+            --dir_cache {vep_dir}/vep/ \
+            --species homo_sapiens \
+            --cache \
+            --offline \
+            --assembly GRCh38 \
+            --fa ${{FASTA}} \
+            -o {vep_job.vcf["vcf.bgz"]} \
+            --protein \
+            --af_gnomadg \
+            --af_gnomade \
+            --mane_select \
+            --plugin AlphaMissense,file={vep_dir}/AlphaMissense_hg38.tsv.gz \
+            --plugin LoF,{",".join(f"{k}:{v}" for k, v in loftee_conf.items())} \
             --plugin UTRAnnotator,file=$UTR38
             """,
         )

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -187,6 +187,7 @@ def annotate_localised_vcfs(
             --protein
             --af_gnomadg
             --af_gnomade
+            --mane_select
             --plugin AlphaMissense,file={vep_dir}/AlphaMissense_hg38.tsv.gz
             --plugin LoF,{",".join(f"{k}:{v}" for k, v in loftee_conf.items())}
             --plugin UTRAnnotator,file=$UTR38

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -15,7 +15,7 @@ from os.path import join
 from hailtop.batch import ResourceFile
 from hailtop.batch.job import BashJob
 
-from cpg_utils import to_path, Path
+from cpg_utils import Path, to_path
 from cpg_utils.config import image_path, output_path, reference_path
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.bcftools import naive_concat_vcfs
@@ -194,9 +194,7 @@ def minimal_annotation(
             """,
         )
         vep_job.command(f'tabix -p vcf {vep_job.vcf[VCF_BGZ_SUFFIX]}')
-
-        if isinstance(output_dir, str):
-            get_batch().write_output(vep_job.vcf, join(output_dir, str(job_number)))
+        get_batch().write_output(vep_job.vcf, join(output_dir, str(job_number)))
 
         annotation_jobs.append(vep_job)
         # keep a list of the in-batch VCF paths
@@ -280,9 +278,7 @@ def annotate_localised_vcfs(
             """,
         )
         vep_job.command(f'tabix -p vcf {vep_job.vcf[VCF_BGZ_SUFFIX]}')
-
-        if isinstance(output_dir, str):
-            get_batch().write_output(vep_job.vcf, join(output_dir, str(job_number)))
+        get_batch().write_output(vep_job.vcf, join(output_dir, str(job_number)))
 
         annotation_jobs.append(vep_job)
         # keep a list of the in-batch VCF paths

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -289,7 +289,11 @@ def annotate_localised_vcfs(
     return ordered_annotated, annotation_jobs
 
 
-def split_and_annotate_vcf(vcf_in: str | ResourceFile, out_vcf: str, minimal: bool = True) -> tuple[ResourceFile, list[BashJob]]:
+def split_and_annotate_vcf(
+    vcf_in: str | ResourceFile,
+    out_vcf: str,
+    minimal: bool = True,
+) -> tuple[ResourceFile, list[BashJob]]:
     """
     take a path to a VCF (in GCP), or a ResourceFile (with implicit accompanying index)
     split that VCF into separate chromosomes (dumb split, but fine for small inputs)
@@ -314,7 +318,8 @@ def split_and_annotate_vcf(vcf_in: str | ResourceFile, out_vcf: str, minimal: bo
 
     # split the whole vcf into chromosomes, but keep accurate ordering for all chunks
     ordered_output_vcfs, bcftools_job = split_vcf_by_chromosome(
-        localised_vcf=vcf_in_batch, output_dir=vcf_fragments_dir,
+        localised_vcf=vcf_in_batch,
+        output_dir=vcf_fragments_dir,
     )
 
     # new path, also in tmp

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -163,9 +163,23 @@ def annotate_localised_vcfs(
 
         vep_job.command(f'FASTA={vep_dir}/vep/homo_sapiens/*/Homo_sapiens.GRCh38*.fa.gz && echo $FASTA')
         vep_job.command(
-            f'vep --format vcf --vcf --compress_output bgzip --no_stats --fork 4 --dir_cache {vep_dir}/vep/ '
+            f'vep '
+            f'--format vcf '                 # output format
+            f'-i {vcf} '                     # input VCF
+            f'--vcf '                        # input format
+            f'--compress_output bgzip '
+            f'--no_stats '
+            f'--dir_cache {vep_dir}/vep/ '
             f'-o {vep_job.vcf["vcf.bgz"]} '
-            f'-i {vcf} --protein --species homo_sapiens --cache --offline --assembly GRCh38 --fa ${{FASTA}}',
+            f'--protein '
+            f'--variant_class '
+            f'--af_gnomadg '                  # add gnomAD Genomes AF
+            f'--af_gnomade '                  # add gnomAD Exomes AF
+            f'--species homo_sapiens '
+            f'--cache '
+            f'--offline '
+            f'--assembly GRCh38 '
+            f'--fa ${{FASTA}}',
         )
         vep_job.command(f'tabix -p vcf {vep_job.vcf["vcf.bgz"]}')
 

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -182,7 +182,6 @@ def annotate_localised_vcfs(
             f'--dir_cache {vep_dir}/vep/ '
             f'-o {vep_job.vcf["vcf.bgz"]} '
             f'--protein '
-            f'--variant_class '
             f'--af_gnomadg '                  # add gnomAD Genomes AF
             f'--af_gnomade '                  # add gnomAD Exomes AF
             f'--species homo_sapiens '

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -9,8 +9,8 @@ Minimal annotation set to improve runtimes
 Long-running/whole-genome VEP tasks could be improved by localising and unpacking the VEP cache inside the VM
 """
 import logging
-from os.path import join
 from argparse import ArgumentParser
+from os.path import join
 
 from hailtop.batch import ResourceFile
 from hailtop.batch.job import BashJob
@@ -169,27 +169,28 @@ def annotate_localised_vcfs(
         }
 
         vep_job.command(f'FASTA={vep_dir}/vep/homo_sapiens/*/Homo_sapiens.GRCh38*.fa.gz && echo $FASTA')
-        vep_job.command(f"""
-            vep 
-            '--format vcf 
-            -i {vcf} 
-            --vcf 
-            --compress_output bgzip 
-            --no_stats 
-            --dir_cache {vep_dir}/vep/ 
-            --species homo_sapiens 
-            --cache 
-            --offline 
-            --assembly GRCh38 
-            --fa ${{FASTA}} 
-            -o {vep_job.vcf["vcf.bgz"]} 
-            --protein 
-            --af_gnomadg 
-            --af_gnomade 
+        vep_job.command(
+            f"""
+            vep
+            '--format vcf
+            -i {vcf}
+            --vcf
+            --compress_output bgzip
+            --no_stats
+            --dir_cache {vep_dir}/vep/
+            --species homo_sapiens
+            --cache
+            --offline
+            --assembly GRCh38
+            --fa ${{FASTA}}
+            -o {vep_job.vcf["vcf.bgz"]}
+            --protein
+            --af_gnomadg
+            --af_gnomade
             --plugin AlphaMissense,file={vep_dir}/AlphaMissense_hg38.tsv.gz
-            --plugin LoF,{",".join(f"{k}:{v}" for k, v in loftee_conf.items())} 
-            --plugin UTRAnnotator,file=$UTR38 
-            """
+            --plugin LoF,{",".join(f"{k}:{v}" for k, v in loftee_conf.items())}
+            --plugin UTRAnnotator,file=$UTR38
+            """,
         )
         vep_job.command(f'tabix -p vcf {vep_job.vcf["vcf.bgz"]}')
 

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -298,7 +298,7 @@ def split_and_annotate_vcf(vcf_in: str | ResourceFile, out_vcf: str, minimal: bo
     Args:
         vcf_in (str): path to an input VCF file, or a pre-localised ResourceFile
         out_vcf (str): path to final output
-        minimal (bool): whether to use the minimal annotation set
+        minimal (bool): whether to use the minimal annotation set, default is True (for ClinvArbitration)
     """
 
     # allow for situations where this VCF was already a localised Resource


### PR DESCRIPTION
The super minimal annotation script which is in use for ClinvArbitration is SUPER minimal. It's missing a number of things we've come to rely on in Talos - MANE transcript ID, population frequencies, LOFTEE, Alpha Missense

This adds a second 'minimal annotation' variant, which can be accessed by CLI parameter. If `-m` is used, or the annotation is accessed from the ClinvArbitration stage directly, we run SUPER minimal fast annotation. 

Otherwise, we add those other good things. The VCFs are still chopped coarsely instead of over hundreds of fragments, and the end result is still a VCF, instead of being made into a JSON -> Hail Table, but it should serve as a reference for the minimal ideal implementation of VEP annotation for Talos. Miah is currently pulling together what a Talos deployment plan would look like, from VEP on up, so this can serve as a useful reference