### PR TITLE
Update AC/AF attributes post-splitting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.1
+current_version = 1.30.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.1
+  VERSION: 1.30.2
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -57,7 +57,13 @@ def annotate_cohort(
     if long_read:
         mt = mt.drop('AF')
         mt = hl.variant_qc(mt)
-        mt = mt.annotate_rows(info=mt.info.annotate(AF=mt.variant_qc.AF, AN=mt.variant_qc.AN, AC=mt.variant_qc.AC))
+        mt = mt.annotate_rows(
+            info=mt.info.annotate(
+                AF=mt.variant_qc.AF,
+                AN=mt.variant_qc.AN,
+                AC=mt.variant_qc.AC,
+            ),
+        )
         mt = mt.drop('variant_qc')
 
     # Splitting multi-allelics. We do not handle AS info fields here - we handle

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -81,12 +81,7 @@ def annotate_cohort(
         mt = mt.drop('variant_qc')
 
     # split the AC/AF attributes into separate entries, overwriting the array in INFO
-    mt = mt.annotate_rows(
-        info=mt.info.annotate(
-            AF=mt.info.AF[mt.a_index - 1],
-            AC=mt.info.AC[mt.a_index - 1]
-        )
-    )
+    mt = mt.annotate_rows(info=mt.info.annotate(AF=mt.info.AF[mt.a_index - 1], AC=mt.info.AC[mt.a_index - 1]))
 
     logging.info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -80,13 +80,13 @@ def annotate_cohort(
         mt = mt.annotate_rows(info=mt.info.annotate(AF=mt.variant_qc.AF, AN=mt.variant_qc.AN, AC=mt.variant_qc.AC))
         mt = mt.drop('variant_qc')
 
-    else:
-        mt = mt.annotate_rows(
-            info=mt.info.annotate(
-                AF=mt.info.AF[mt.a_index - 1],
-                AC=mt.info.AC[mt.a_index - 1]
-            )
+    # split the AC/AF attributes into separate entries, overwriting the array in INFO
+    mt = mt.annotate_rows(
+        info=mt.info.annotate(
+            AF=mt.info.AF[mt.a_index - 1],
+            AC=mt.info.AC[mt.a_index - 1]
         )
+    )
 
     logging.info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -80,21 +80,18 @@ def annotate_cohort(
         mt = mt.annotate_rows(info=mt.info.annotate(AF=mt.variant_qc.AF, AN=mt.variant_qc.AN, AC=mt.variant_qc.AC))
         mt = mt.drop('variant_qc')
 
-    # don't fail if the AC/AF attributes are an inappropriate type
-    # don't fail if completely absent either
-    for attr in ['AC', 'AF']:
-        if attr not in mt.info:
-            mt = mt.annotate_rows(info=mt.info.annotate(**{attr: [1]}))
-        elif not isinstance(mt.info[attr], hl.ArrayExpression):
-            mt = mt.annotate_rows(info=mt.info.annotate(**{attr: [mt.info[attr]]}))
-
-    if 'AN' not in mt.info:
-        mt = mt.annotate_rows(info=mt.info.annotate(AN=1))
+    else:
+        mt = mt.annotate_rows(
+            info=mt.info.annotate(
+                AF=mt.info.AF[mt.a_index - 1],
+                AC=mt.info.AC[mt.a_index - 1]
+            )
+        )
 
     logging.info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(
-        AC=mt.info.AC[mt.a_index - 1],
-        AF=mt.info.AF[mt.a_index - 1],
+        AC=mt.info.AC,
+        AF=mt.info.AF,
         AN=mt.info.AN,
         aIndex=mt.a_index,
         wasSplit=mt.was_split,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.1',
+    version='1.30.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #975 

When we split out the AF/AC annotations, also overwrite the info.AF and info.AC attributes with the correct entries

~Is this compatible with long read? The long read pipeline was also being exposed to the same splitting downstream, but these attributes were populated post-splitting using variant_qc. Might need to step through with some real data~

The long-read amendment in this process is because our long-read VCFs have an entry-level AF annotation, and Hail can't tolerate the same named field in two locations. We have to drop AF at the entry level, then create an AF field based on the un-split data, so it's compatible with the downstream steps