### PR TITLE
Correction to AC/AF patch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.2
+current_version = 1.30.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.2
+  VERSION: 1.30.3
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -90,17 +90,19 @@ def annotate_cohort(
     logging.info('Annotating with seqr-loader fields: round 1')
 
     # split the AC/AF attributes into separate entries, overwriting the array in INFO
+    # these elements become a 1-element array
     mt = mt.annotate_rows(
         info=mt.info.annotate(
-            AF=mt.info.AF[mt.a_index - 1],
-            AC=mt.info.AC[mt.a_index - 1],
+            AF=[mt.info.AF[mt.a_index - 1]],
+            AC=[mt.info.AC[mt.a_index - 1]],
         ),
     )
 
     logging.info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(
-        AC=mt.info.AC,
-        AF=mt.info.AF,
+        # still taking just a single value here for downstream compatibility in Seqr
+        AC=mt.info.AC[0],
+        AF=mt.info.AF[0],
         AN=mt.info.AN,
         aIndex=mt.a_index,
         wasSplit=mt.was_split,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.2',
+    version='1.30.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
As spotted on the call - the update to `mt.info.AF/AC` should create an array with a single element. In the previous PR I just re-created the original code which was incorrect - I tested it correctly locally, but didn't put the correct code change into the PR. Dumb.

I've updated this to create the MT.INFO.X as a single-element list, and the MT.X versions are still a single scalar, no list. This is to preserve compatibility with whatever uses these annotations downstream

