### PR TITLE
add checks to stop duplicate None entries

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -81,6 +81,7 @@ class Combiner(CohortStage):
             # Get VDS IDs first and filter out from this list
             print('toml false v python False')
             print(f'{combiner_config.get("merge_only_vds")}')
+            exit(1)
             cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
             new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -76,9 +76,11 @@ class Combiner(CohortStage):
                 vds_paths.append(tmp_query_res)
                 sg_ids_in_vds = sg_ids_in_vds + tmp_sg_ids_in_vds
 
-        if combiner_config.get('merge_only_vds', 'false').lower() != 'true':
+        if combiner_config.get('merge_only_vds', False) is not True:
             # Get SG IDs from the cohort object itself, rather than call Metamist.
             # Get VDS IDs first and filter out from this list
+            print('toml false v python False')
+            print(f'{combiner_config.get("merge_only_vds")}')
             cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
             new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -79,9 +79,6 @@ class Combiner(CohortStage):
         if combiner_config.get('merge_only_vds', False) is not True:
             # Get SG IDs from the cohort object itself, rather than call Metamist.
             # Get VDS IDs first and filter out from this list
-            print('toml false v python False')
-            print(f'{combiner_config.get("merge_only_vds")}')
-            exit(1)
             cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
             new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -68,7 +68,7 @@ class Combiner(CohortStage):
         # create these as empty lists instead of None, they have the same truthiness
         vds_paths: list[str] = []
         sg_ids_in_vds: list[str] = []
-        new_sg_gvcfs: list[str] | None = None
+        new_sg_gvcfs: list[str] = []
 
         if combiner_config.get('vds_analysis_ids', None) is not None:
             for vds_id in combiner_config['vds_analysis_ids']:
@@ -76,11 +76,11 @@ class Combiner(CohortStage):
                 vds_paths.append(tmp_query_res)
                 sg_ids_in_vds = sg_ids_in_vds + tmp_sg_ids_in_vds
 
-        if not config_retrieve(['combiner', 'merge_only_vds'], None):
+        if combiner_config.get('merge_only_vds', 'false').lower() != 'true':
             # Get SG IDs from the cohort object itself, rather than call Metamist.
             # Get VDS IDs first and filter out from this list
             cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
-            new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.id not in sg_ids_in_vds]
+            new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
 
         if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1:
             return self.make_outputs(cohort, self.expected_outputs(cohort))
@@ -97,7 +97,7 @@ class Combiner(CohortStage):
             sequencing_type=workflow_config['sequencing_type'],
             tmp_prefix=tmp_prefix,
             genome_build=genome_build(),
-            gvcf_paths=new_sg_gvcfs,  # test None as default
+            gvcf_paths=new_sg_gvcfs,
             vds_paths=vds_paths,
         )
 


### PR DESCRIPTION
- Stop creating a list with multiple `None` values when there are samples that don't have a gvcf.
- Only try adding samples to the list of gvcfs to combine if `merge_only_vds = 'true'` is set in the combiner config