### PR TITLE
Remove annotate cohort repartition

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.3
+current_version = 1.30.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.3
+  VERSION: 1.30.4
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.3',
+    version='1.30.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #981 

See https://batch.hail.populationgenomics.org.au/batches/529254?q=&last_job_id=7850

7850 jobs, 3.5 hours, and $11 deep in this subsetting, almost every single job has been related to the repartitioning. This is the smallest subset cohort we have in the genome callset.

This just isn't a good use of time or money.