### PR TITLE
Allow hail JAR override

### DIFF
--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -26,6 +26,12 @@ def annotate_cohort(
     annotations.
     """
 
+    from cpg_utils.config import config_retrieve
+    from cpg_workflows.batch import override_jar_spec
+
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
+        override_jar_spec(jar_spec)
+
     # tune the logger correctly
     logging.getLogger().setLevel(logging.INFO)
 
@@ -203,6 +209,13 @@ def subset_mt_to_samples(mt_path: str, sample_ids: list[str], out_mt_path: str, 
         exclusion_file (str, optional): path to a file containing samples to remove from the
                                         subset prior to extracting
     """
+
+    from cpg_utils.config import config_retrieve
+    from cpg_workflows.batch import override_jar_spec
+
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
+        override_jar_spec(jar_spec)
+
     logging.basicConfig(level=logging.INFO)
 
     mt = hl.read_matrix_table(mt_path)
@@ -255,6 +268,13 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
     """
     Add dataset-level annotations.
     """
+
+    from cpg_utils.config import config_retrieve
+    from cpg_workflows.batch import override_jar_spec
+
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
+        override_jar_spec(jar_spec)
+
     mt = hl.read_matrix_table(mt_path)
 
     # Convert the mt genotype entries into num_alt, gq, ab, dp, and sample_id.

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -6,8 +6,9 @@ import logging
 
 import hail as hl
 
-from cpg_utils.config import get_config, reference_path
+from cpg_utils.config import config_retrieve, get_config, reference_path
 from cpg_utils.hail_batch import genome_build
+from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.large_cohort.load_vqsr import load_vqsr
 from cpg_workflows.utils import checkpoint_hail
 from hail_scripts.computed_fields import variant_id, vep
@@ -26,9 +27,9 @@ def annotate_cohort(
     annotations.
     """
 
-    from cpg_utils.config import config_retrieve
-    from cpg_workflows.batch import override_jar_spec
-
+    # this overrides the jar spec for the current session
+    # and requires `init_batch()` to be called before any other hail methods
+    # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
     if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
         override_jar_spec(jar_spec)
 
@@ -210,9 +211,9 @@ def subset_mt_to_samples(mt_path: str, sample_ids: list[str], out_mt_path: str, 
                                         subset prior to extracting
     """
 
-    from cpg_utils.config import config_retrieve
-    from cpg_workflows.batch import override_jar_spec
-
+    # this overrides the jar spec for the current session
+    # and requires `init_batch()` to be called before any other hail methods
+    # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
     if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
         override_jar_spec(jar_spec)
 
@@ -258,6 +259,12 @@ def vcf_from_mt_subset(mt_path: str, out_vcf_path: str):
         out_vcf_path (str): path of the vcf.bgz to generate
     """
 
+    # this overrides the jar spec for the current session
+    # and requires `init_batch()` to be called before any other hail methods
+    # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
+        override_jar_spec(jar_spec)
+
     mt = hl.read_matrix_table(mt_path)
     logging.info(f'Dataset MT dimensions: {mt.count()}')
     hl.export_vcf(mt, out_vcf_path, tabix=True)
@@ -269,9 +276,9 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
     Add dataset-level annotations.
     """
 
-    from cpg_utils.config import config_retrieve
-    from cpg_workflows.batch import override_jar_spec
-
+    # this overrides the jar spec for the current session
+    # and requires `init_batch()` to be called before any other hail methods
+    # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
     if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
         override_jar_spec(jar_spec)
 


### PR DESCRIPTION
See [this thread](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1731047651300539) for my "what the hell is going on" write up. 

In an effort to confirm/rule out the exact Hail JAR file as a cause of our cost explosions, we'd like the ability to override the JAR file used in each of the AnnotateCohort, MT subsetting, and AnnotateDataset jobs. This is one revert-able commit that includes this change in all relevant places.

Q. will the interaction between the new (0.2.133) JAR file and the exact version of Hail installed in the cpg_workflows image have any interplay? i.e. to test that 133 is the cause, and 132 is _not_, should this build use a pinned version of Hail at 0.2.132 _and_ a JAR override to point to 132?

The test runs we already have are expensive and on 133, so we already have a baseline. The combination of things we need are:
- Hail version in the cpg_workflows image
- Hail version in the selected JAR file
- Current version of this codebase which will permit controlling the JAR file used