### PR TITLE
Only trim XY on SG IDs in this cohort

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.5
+current_version = 1.30.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.5
+  VERSION: 1.30.6
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -313,10 +313,17 @@ class TrimOffSexChromosomes(CohortStage):
         germline_calls = inputs.as_dict_by_target(GermlineCNVCalls)
         jobs = []
         for sgid, new_vcf in expected.items():
-            if sgid == 'placeholder':
+            if sgid == 'placeholder' or sgid not in cohort.get_sequencing_group_ids():
                 continue
             sg_vcf = germline_calls[sgid]['segments']
-            jobs.append(gcnv.trim_sex_chromosomes(sgid, str(sg_vcf), str(new_vcf), self.get_job_attrs(cohort)))
+            jobs.append(
+                gcnv.trim_sex_chromosomes(
+                    sgid,
+                    str(sg_vcf),
+                    str(new_vcf),
+                    self.get_job_attrs(cohort),
+                ),
+            )
         return self.make_outputs(cohort, data=expected, jobs=jobs)  # type: ignore
 
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -312,8 +312,9 @@ class TrimOffSexChromosomes(CohortStage):
         expected = self.expected_outputs(cohort)
         germline_calls = inputs.as_dict_by_target(GermlineCNVCalls)
         jobs = []
+        sg_ids_in_cohort = cohort.get_sequencing_group_ids()
         for sgid, new_vcf in expected.items():
-            if sgid == 'placeholder' or sgid not in cohort.get_sequencing_group_ids():
+            if sgid == 'placeholder' or sgid not in sg_ids_in_cohort:
                 continue
             sg_vcf = germline_calls[sgid]['segments']
             jobs.append(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.5',
+    version='1.30.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Quick follow-on to https://github.com/populationgenomics/production-pipelines/pull/986

That PR allows us to add a list of CPG IDs in config which will have all X/Y calls removed. Because we run as multiCohorts, that list can contain SG IDs from a range of cohorts.

The method that uses the contents of that file now needs to limit its behaviour to only SG IDs which belong to this exact Cohort, otherwise it will try and pull in samples which aren't part of this cohort, and will fail to find input paths