### PR TITLE
Force list of Cohort IDs to be unique on startup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.6
+current_version = 1.30.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.6
+  VERSION: 1.30.7
 
 jobs:
   docker:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -58,24 +58,22 @@ def create_multicohort() -> MultiCohort:
     custom_cohort_ids = config_retrieve(['workflow', 'input_cohorts'], [])
 
     # get a unique set of cohort IDs
-    custom_cohort_ids_set = set(custom_cohort_ids)
+    custom_cohort_ids_unique = sorted(set(custom_cohort_ids))
 
     # if use of set removed any cohorts due to repetition, log them
-    if len(custom_cohort_ids_set) != len(custom_cohort_ids):
+    if len(custom_cohort_ids_unique) != len(custom_cohort_ids):
         get_logger(__file__).warning(
-            f'Removed {len(custom_cohort_ids) - len(custom_cohort_ids_set)} non-unique cohort IDs',
+            f'Removed {len(custom_cohort_ids) - len(custom_cohort_ids_unique)} non-unique cohort IDs',
         )
-        duplicated_cohort_ids = ', '.join(
-            {str(key) for key, value in Counter(custom_cohort_ids).items() if value > 1}
-        )
+        duplicated_cohort_ids = ', '.join({str(key) for key, value in Counter(custom_cohort_ids).items() if value > 1})
         get_logger(__file__).warning(f'Non-unique cohort IDs: {duplicated_cohort_ids}')
 
     multicohort = MultiCohort()
 
-    datasets_by_cohort = get_metamist().get_sgs_for_cohorts(custom_cohort_ids_set)
+    datasets_by_cohort = get_metamist().get_sgs_for_cohorts(custom_cohort_ids_unique)
 
     read_pedigree = config.get('read_pedigree', True)
-    for cohort_id in custom_cohort_ids_set:
+    for cohort_id in custom_cohort_ids_unique:
         cohort = multicohort.create_cohort(cohort_id)
         sgs_by_dataset_for_cohort = datasets_by_cohort[cohort_id]
         # TODO (mwelland): future optimisation following closure of #860

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -3,13 +3,14 @@ Metamist wrapper to get input sequencing groups.
 """
 
 import logging
+from collections import Counter
 
 from cpg_utils.config import config_retrieve, update_dict
 from cpg_workflows.filetypes import CramPath, GvcfPath
 
 from .metamist import AnalysisType, Assay, MetamistError, get_metamist, parse_reads
 from .targets import Cohort, MultiCohort, PedigreeInfo, SequencingGroup, Sex
-from .utils import exists
+from .utils import exists, get_logger
 
 _multicohort: MultiCohort | None = None
 
@@ -52,13 +53,29 @@ def create_multicohort() -> MultiCohort:
     Add cohorts in the multicohort.
     """
     config = config_retrieve(['workflow'])
-    custom_cohort_ids = set(config_retrieve(['workflow', 'input_cohorts'], []))
+
+    # pull the list of cohort IDs from the config
+    custom_cohort_ids = config_retrieve(['workflow', 'input_cohorts'], [])
+
+    # get a unique set of cohort IDs
+    custom_cohort_ids_set = set(custom_cohort_ids)
+
+    # if use of set removed any cohorts due to repetition, log them
+    if len(custom_cohort_ids_set) != len(custom_cohort_ids):
+        get_logger(__file__).warning(
+            f'Removed {len(custom_cohort_ids) - len(custom_cohort_ids_set)} non-unique cohort IDs',
+        )
+        duplicated_cohort_ids = ', '.join(
+            {str(value) for key, value in Counter(custom_cohort_ids).items() if value > 1}
+        )
+        get_logger(__file__).warning(f'Non-unique cohort IDs: {duplicated_cohort_ids}')
+
     multicohort = MultiCohort()
 
-    datasets_by_cohort = get_metamist().get_sgs_for_cohorts(custom_cohort_ids)
+    datasets_by_cohort = get_metamist().get_sgs_for_cohorts(custom_cohort_ids_set)
 
     read_pedigree = config.get('read_pedigree', True)
-    for cohort_id in custom_cohort_ids:
+    for cohort_id in custom_cohort_ids_set:
         cohort = multicohort.create_cohort(cohort_id)
         sgs_by_dataset_for_cohort = datasets_by_cohort[cohort_id]
         # TODO (mwelland): future optimisation following closure of #860

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -52,7 +52,7 @@ def create_multicohort() -> MultiCohort:
     Add cohorts in the multicohort.
     """
     config = config_retrieve(['workflow'])
-    custom_cohort_ids = config_retrieve(['workflow', 'input_cohorts'], [])
+    custom_cohort_ids = set(config_retrieve(['workflow', 'input_cohorts'], []))
     multicohort = MultiCohort()
 
     datasets_by_cohort = get_metamist().get_sgs_for_cohorts(custom_cohort_ids)

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -66,7 +66,7 @@ def create_multicohort() -> MultiCohort:
             f'Removed {len(custom_cohort_ids) - len(custom_cohort_ids_set)} non-unique cohort IDs',
         )
         duplicated_cohort_ids = ', '.join(
-            {str(value) for key, value in Counter(custom_cohort_ids).items() if value > 1}
+            {str(key) for key, value in Counter(custom_cohort_ids).items() if value > 1}
         )
         get_logger(__file__).warning(f'Non-unique cohort IDs: {duplicated_cohort_ids}')
 

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -311,7 +311,7 @@ class Metamist:
 
         return None
 
-    def get_sgs_for_cohorts(self, cohort_ids: list[str]) -> dict[str, dict[str, Any]]:
+    def get_sgs_for_cohorts(self, cohort_ids: set[str]) -> dict[str, dict[str, Any]]:
         """
         Retrieve the sequencing groups per dataset for a list of cohort IDs.
         """

--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -311,7 +311,7 @@ class Metamist:
 
         return None
 
-    def get_sgs_for_cohorts(self, cohort_ids: set[str]) -> dict[str, dict[str, Any]]:
+    def get_sgs_for_cohorts(self, cohort_ids: list[str]) -> dict[str, dict[str, Any]]:
         """
         Retrieve the sequencing groups per dataset for a list of cohort IDs.
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.6',
+    version='1.30.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_multicohort.py
+++ b/test/test_multicohort.py
@@ -252,7 +252,7 @@ def test_multicohort(mocker: MockFixture, tmp_path):
 
     # Testing Cohort Information
     assert len(multicohort.get_sequencing_groups()) == 4
-    assert multicohort.get_sequencing_group_ids() == ['CPGXXXX', 'CPGAAAA', 'CPGCCCCCC', 'CPGDDDDDD']
+    assert sorted(multicohort.get_sequencing_group_ids()) == ['CPGAAAA', 'CPGCCCCCC', 'CPGDDDDDD', 'CPGXXXX']
 
     # Test the projects they belong to
     assert multicohort.get_sequencing_groups()[0].dataset.name == 'projecta'


### PR DESCRIPTION
Cast the list of input cohorts as a set, forcing unique contents. This means that on startup we'll never set the same cohort up twice.

The expected type of the cohort list in `get_sgs_for_cohorts` is updated to be `set[str]`