### PR TITLE
Add combiner restore functionality mw edit

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -33,9 +33,16 @@ class Combiner(CohortStage):
         output_vds_name: str = slugify(
             f"{workflow_config['cohort']}-{workflow_config['sequencing_type']}-{combiner_config['vds_version']}",
         )
+
+        # include the list of all VDS IDs in the plan name
+        if vds_ids := config_retrieve(['combiner', 'vds_analysis_ids']):
+            ids_list_as_string = '_'.join(sorted(vds_ids))
+            combiner_plan_name = f'combiner_{ids_list_as_string}'
+        else:
+            combiner_plan_name = 'combiner'
         return {
             'vds': cohort.analysis_dataset.prefix() / 'vds' / f'{output_vds_name}.vds',
-            'combiner_plan': str(self.tmp_prefix / 'combiner_plan.json'),
+            'combiner_plan': str(self.tmp_prefix / f'{combiner_plan_name}.json'),
         }
 
     def get_vds_ids_output(self, vds_id: int) -> Tuple[str, list[str]]:


### PR DESCRIPTION
A thought on how I'd do this 

expected_outputs returns a dict of 2 entries - the VDS path itself, and the combiner plan path

- Combiner plan JSON path contains the `output_version` (hash made of CRAM paths), so it's explicitly linked to a set of Sequencing Groups. We'll never accidentally resume the wrong run.
- It also includes all the VDS Analysis IDs we're mixing into the plan

This makes the full plan path something unique, deterministic, and not something that can be manually overridden.

- `self.expected_outputs` is called once and saved as a very mild efficiency benefit.