### PR TITLE
Pin hail in the image back to 0.2.132

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.7
+current_version = 1.30.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.30.7
+  VERSION: 1.30.8
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
         'cpg-utils>=5.1.1',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        'hail==0.2.133',  # Pin Hail at CPG's installed version
+        # Pin Hail to the release prior to 0.2.133
+        # see https://centrepopgen.slack.com/archives/C018KFBCR1C/p1731047651300539
+        'hail==0.2.132',
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
         'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.30.7',
+    version='1.30.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Based on some recent cost explosions I'd like to try setting the default version of Hail installed with the cpg_workflows package back to 0.2.132 (prior to the attempted patch for the StreamConstraintsException, which wasn't actually fixed in 133)