### PR TITLE
Allow no-metamist checks for existing VDSs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.0
+current_version = 1.31.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.0
+  VERSION: 1.31.1
 
 jobs:
   docker:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -16,6 +16,7 @@ LATEST_ANALYSIS_QUERY = gql(
     query LatestAnalysisEntry($dataset: String!, $type: String!) {
         project(name: $dataset) {
             analyses(active: {eq: true}, type: {eq: $type}, status: {eq: COMPLETED}) {
+                meta
                 output
                 sequencingGroups {
                     id

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.0',
+    version='1.31.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
A quick patch - the previous combiner (large_cohort) already ran and wrote a metamist entry.

Failing run: https://batch.hail.populationgenomics.org.au/batches/530539/jobs/1

In this instance it's finding the previous VDS and failing because I forgot to request `meta` in the gql.

This will also fail because it won't fine any new samples, so it won't write any new output. This adds a toggle where we can prevent this metamist query if we want to always build a new VDS.

There's a complication here where we have a VDS already (yay), but it's not in the right location (boo), so it will avoid writing a new VDS to the location we need it. 