### PR TITLE
Correction to VDS/Mt script namespacing

### DIFF
--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -103,7 +103,7 @@ def cli_main():
         vds_in=args.input,
         dense_mt_out=args.output,
         partitions=args.partitions,
-        sites_only=args.site_only,
+        sites_only=args.sites_only,
     )
 
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -113,7 +113,7 @@ class GVCFCombiner(MultiCohortStage):
             tmp_prefix=str(self.tmp_prefix / 'temp_dir'),
             genome_build=genome_build(),
             gvcf_paths=new_sg_gvcfs,
-            vds_paths=[vds_path],
+            vds_paths=[vds_path] if vds_path else None,
         )
 
         return self.make_outputs(multicohort, outputs, j)


### PR DESCRIPTION
site_only -> site_only

if there are no VDS paths to use as input, send None. Don't send a list of None, which is interpreted as a value, causing a failure later on in Hail

I am having a bad day