### PR TITLE
Fix SampleQC Pulling Combiner Output as Dictionary

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -136,7 +136,7 @@ class SampleQC(CohortStage):
             query_command(
                 sample_qc,
                 sample_qc.run.__name__,
-                str(inputs.as_path(cohort, Combiner)),
+                str(inputs.as_path(cohort, Combiner, key='vds')),
                 str(self.expected_outputs(cohort)),
                 str(self.tmp_prefix),
                 setup_gcp=True,


### PR DESCRIPTION
Combiner now returns a dictionary, we need to get the vds path of that dictionary instead of the entire dictionary. This error has cropped up here: https://batch.hail.populationgenomics.org.au/batches/530560/jobs/1

`as_path` has a `key` parameter that we can get.