### PR TITLE
Patch usage of VCF extractor

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.2
+current_version = 1.31.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.2
+  VERSION: 1.31.3
 
 jobs:
   docker:

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -34,7 +34,12 @@ class ValidationMtToVcf(SequencingGroupStage):
 
         job = get_batch().new_job(f'{sequencing_group.id} VCF from dataset MT')
         job.image(config_retrieve(['workflow', 'driver_image']))
-        job.command(f'ss_vcf_from_mt {input_mt} {sequencing_group.id} {str(exp_output)}')
+        job.command(
+            f'ss_vcf_from_mt '
+            f'--input {input_mt} '
+            f'--sample_id{sequencing_group.id} '
+            f'--output{str(exp_output)} ',
+        )
 
         return self.make_outputs(sequencing_group, data=exp_output, jobs=job)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.2',
+    version='1.31.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Not sure what to say here... I used this process last week to run e2e validation, then somehow changed the interface. Not sure how or why that happened. 

Going from a query_command/pythonJob to a separate script, I enforced `--flag` arguments using argparse. This now needs to be used when the script is being called. 🤦 

Previously arguments were just passed as 3 non-keyword args. Argparse could do that, but I'd prefer to be explicit