### PR TITLE
Resume sample qc from checkpoints

### DIFF
--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -114,7 +114,6 @@ def impute_sex(
                 )
                 vds = VariantDataset(reference_data=vds.reference_data, variant_data=tmp_variant_data).checkpoint(
                     str(tmp_prefix / f'{name}_checkpoint.vds'),
-                    overwrite=True,
                 )
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -15,7 +15,7 @@ from gnomad.sample_qc.pipeline import annotate_sex
 
 
 def run(vds_path: str, out_sample_qc_ht_path: str, tmp_prefix: str):
-    if can_reuse(out_sample_qc_ht_path, overwrite=True):
+    if can_reuse(out_sample_qc_ht_path):
         return []
 
     ht = initialise_sample_table()

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -29,7 +29,7 @@ def run(vds_path: str, out_sample_qc_ht_path: str, tmp_prefix: str):
 
     # Run Hail sample-QC stats:
     sqc_ht_path = to_path(tmp_prefix) / 'sample_qc.ht'
-    if can_reuse(sqc_ht_path, overwrite=True):
+    if can_reuse(sqc_ht_path):
         sqc_ht = hl.read_table(str(sqc_ht_path))
     else:
         # Filter to autosomes:

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -84,7 +84,7 @@ def impute_sex(
     Impute sex based on coverage.
     """
     checkpoint_path = tmp_prefix / 'sample_qc' / 'sex.ht'
-    if can_reuse(str(checkpoint_path), overwrite=True):
+    if can_reuse(str(checkpoint_path)):
         sex_ht = hl.read_table(str(checkpoint_path))
         return ht.annotate(**sex_ht[ht.s])
 

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -103,7 +103,7 @@ def impute_sex(
     for name in ['lcr_intervals_ht', 'seg_dup_intervals_ht']:
         interval_table = hl.read_table(reference_path(f'gnomad/{name}'))
         if interval_table.count() > 0:
-            vds_tmp_path = to_path(tmp_prefix) / f'{name}_checkpoint.vds'
+            vds_tmp_path = tmp_prefix / f'{name}_checkpoint.vds'
             if can_reuse(vds_tmp_path):
                 vds = hl.vds.read_vds(str(vds_tmp_path))
             else:
@@ -113,7 +113,7 @@ def impute_sex(
                     keep=False,
                 )
                 vds = VariantDataset(reference_data=vds.reference_data, variant_data=tmp_variant_data).checkpoint(
-                    str(tmp_prefix / f'{name}_checkpoint.vds'),
+                    str(vds_tmp_path),
                 )
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -197,7 +197,7 @@ def test_sample_qc(mocker: MockFixture, tmp_path: Path):
     )
 
     # skip can_reuse, implicit skip of existence checks
-    mocker.patch('cpg_workflows.large_cohort.combiner.can_reuse', lambda x: False)
+    mocker.patch('cpg_workflows.large_cohort.sample_qc.can_reuse', lambda x: False)
 
     # open that VDS into a job temp location
     decompress_into_job_tmp(tmp_path, [compressed_vds_path])


### PR DESCRIPTION
As per the example in this batch [here](https://batch.hail.populationgenomics.org.au/batches/530586), SampleQC was first pre-empted, and then on the rerun it 1) repeated the slow/costly sample QC annotation due to some extra `overwrite=True` settings, and then 2) failed as it tried to overwrite a tmp checkpoint file that already exists.

These changes remove the `overwrite=True` so that checkpointed files can be used for sample QC and sex imputation, and adds additional checks for existing checkpoint files to the interval filtering section.