### PR TITLE
All ClinvArb. outputs as Path objects

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.4
+current_version = 1.31.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.4
+  VERSION: 1.31.5
 
 jobs:
   docker:

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -1,11 +1,13 @@
 [workflow]
 name = 'gcnv'
-intervals_path = 'gs://cpg-common-test/gCNV_resources/SSCRE_V2_intervals.interval_list'
 exclude_intervals = ['chrM']
 # Aim for 10-50Mbp genomic coverage per shard
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]
 allosomal_contigs = ['chrX', 'chrY']
 status_reporter = 'metamist'
+
+# This should be provided for each cohort, specific to the capture they were generated with
+#intervals_path = 'gs://cpg-common-test/gCNV_resources/SSCRE_V2_intervals.interval_list'
 
 # vague inspiration by the following config, though this likely represents low thresholds for subsampled test data
 # https://github.com/broadinstitute/gatk/blob/cfd4d87ec29ac45a68f13a37f30101f326546b7d/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json
@@ -16,11 +18,11 @@ gncv_max_pass_events = 30
 # update this when cpg_workflows.scripts.get_gencode_gtf.sh is re-run
 gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
 
-[gCNV]
-# add any CPG IDs to this list to strip their XY Calls from the final callset
-# this is a mitigation for gCNV's fiddly handling of aneuploidies
-# see https://github.com/populationgenomics/production-pipelines/pull/986
-aneuploid_samples = []
+## add any CPG IDs to this list to strip their XY Calls from the final callset
+## this is a mitigation for gCNV's fiddly handling of aneuploidies
+## see https://github.com/populationgenomics/production-pipelines/pull/986
+#[gCNV]
+#aneuploid_samples = []
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.4',
+    version='1.31.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Returning all outputs from the ClinvArbitration workflow as Path objects to make the interface easier.

https://batch.hail.populationgenomics.org.au/batches/530638/jobs/1

Relevant to https://github.com/populationgenomics/production-pipelines/issues/611

I have a Stage which returned a String and a Path, and i wanted to use them downstream. I have to use as_path and as_str to pull each argument from a single stage. Very dumb. 

The inputs.as_X methods should be replaced with a generic "get all outputs from this stage" without any stupid half-baked type casting middle managing methods. They literally fail unless the variable is already the given type, so why are we re-casting variables with their current type. I'll be recreating #611 in the new cpg-flow repo.

---

Sliding in a sneaky additional change - the default gCNV config file should not actively set the aneuploidies list or exome capture path. These must be provided by the cohort-specific config.