### PR TITLE
SingleSample VCF from VDS correction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.4
+current_version = 1.31.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.4
+  VERSION: 1.31.5
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/extract_single_sample_vcf_from_mt.py
+++ b/cpg_workflows/scripts/extract_single_sample_vcf_from_mt.py
@@ -10,7 +10,12 @@ import hail as hl
 from cpg_utils.hail_batch import init_batch
 
 
-def single_sample_vcf_from_dataset_vcf(input_mt: str, sample_id: str, out_path: str) -> None:
+def single_sample_vcf_from_dataset_vcf(
+    input_mt: str,
+    sample_id: str,
+    out_path: str,
+    clean: bool = True,
+) -> None:
     """
     takes the validation datatset MatrixTable, filters to single sample
     removes variants not relevant to this sample, and writes to VCF
@@ -18,22 +23,30 @@ def single_sample_vcf_from_dataset_vcf(input_mt: str, sample_id: str, out_path: 
         input_mt (str): where to read the MT
         sample_id (str): this Sequencing Group ID
         out_path (str): where to write the VCF to
+        clean (bool): if True, remove any variant sites which are not PASS or have no calls
     """
 
     init_batch()
+
     # read full MT
     mt = hl.read_matrix_table(input_mt)
 
     # filter to this column
     mt = mt.filter_cols(mt.s == sample_id)
 
-    # filter to this sample's non-ref calls
-    mt = hl.variant_qc(mt)
+    if clean:
 
-    # filter out any Filter-failures and non-calls for this sample
-    mt = mt.filter_rows(
-        (mt.variant_qc.n_non_ref > 0) & (mt.filters.length() == 0),
-    )
+        # filter to this sample's non-ref calls
+        mt = hl.variant_qc(mt)
+        mt = mt.filter_rows(mt.variant_qc.n_non_ref > 0)
+
+        # We need to check if this field exists on the row
+        # it will for ingestion from VCF, but not for VDS derived data
+        if 'filters' in mt.row:
+            mt = mt.filter_rows(mt.filters.length() == 0)
+
+        # drop the variant QC content before writing out
+        mt = mt.drop('variant_qc')
 
     hl.export_vcf(mt, out_path, tabix=True)
 
@@ -43,12 +56,18 @@ def cli_main():
     parser.add_argument('--input', help='The MT to read from')
     parser.add_argument('--sample_id', help='The sample ID to filter to')
     parser.add_argument('--output', help='The VCF to write to')
+    parser.add_argument(
+        '--clean',
+        help='If used, remove variants with no calls or not PASS',
+        action='store_true',
+    )
     args = parser.parse_args()
 
     single_sample_vcf_from_dataset_vcf(
         input_mt=args.input,
         sample_id=args.sample_id,
         out_path=args.output,
+        clean=args.clean,
     )
 
 

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -38,7 +38,8 @@ class ValidationMtToVcf(SequencingGroupStage):
             f'ss_vcf_from_mt '
             f'--input {input_mt} '
             f'--sample_id {sequencing_group.id} '
-            f'--output {str(exp_output)} ',
+            f'--output {str(exp_output)} '
+            '--clean ',
         )
 
         return self.make_outputs(sequencing_group, data=exp_output, jobs=job)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.4',
+    version='1.31.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Another day, another gVCF -> VDS -> MT -> VCF -> Validation hiccup. Here the issue is that MTs that originate from VDSs don't have the FILTERS field, it simply doesn't exist. The 'single sample VCF from MT' script expected a Filters column, so we run into a failure when running the `mt.filters.length() == 0` test. When we write the MT to VCF it does generate an empty FILTERS field on all variant rows, so there are no other compatibility issues with downstream tools (VEP, Hap.py, VQSR).

Couple of changes:

1. Drop `gvcf_info` completely. We can put it back in later if we need it, but for now we can't export VCFs with this field present, so strip it out early on
2. Add a `--clean` flag to the VCF-from-MT script. If used this will remove all non-variant rows, AND filter on `mt.filters` (but only if `filters` exists in the MT)
3.  Drops `mt.variant_qc` before writing the VCF. I think this would have been dropped anyway, but just to make sure
4. Replace `repartition` with `naive_coalesce` - there are genuinely empty partitions (at least in the validation dataset), so reducing the number of partitions can be done cheaply by removing empty ones completely. Computationally this is much cheaper than doing a full repartition. I'm not sure if we'll use this route anyway, as it would be better for us to feed exact partitions into the combiner up front.