### PR TITLE
Happy meta updater fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.6
+current_version = 1.31.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.6
+  VERSION: 1.31.7
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -7,25 +7,25 @@ from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import fasta_res_group, get_batch
 
 
-def get_sample_truth_data(sequencing_group_id: str):
+def get_sample_truth_data(sample_ext_id: str):
     """
     retrieve the reference truth specific to this individual
 
     Args:
-        sequencing_group_id (str):
+        sample_ext_id (str):
 
     Returns:
         The specific truth data from config
     """
 
-    ref_data = config_retrieve(['references', sequencing_group_id])
+    ref_data = config_retrieve(['references', sample_ext_id])
     assert all(key in ref_data for key in ['vcf', 'index', 'bed'])
     return ref_data
 
 
 def run_happy_on_vcf(
     vcf_path: str,
-    sequencing_group_ext_id: str,
+    sample_ext_id: str,
     out_prefix: str,
 ):
     """
@@ -34,21 +34,21 @@ def run_happy_on_vcf(
 
     Args:
         vcf_path (str): path to the single-sample VCF
-        sequencing_group_ext_id (str): external ID to find reference data
+        sample_ext_id (str): external ID to find reference data
         out_prefix (str): where to export happy outputs
 
     Returns:
         This Job or None
     """
 
-    happy_j = get_batch().new_job(f'Run Happy on {sequencing_group_ext_id} VCF')
+    happy_j = get_batch().new_job(f'Run Happy on {sample_ext_id} VCF')
     happy_j.image(image_path('hap-py')).memory('100Gi').storage('100Gi').cpu(4)
 
     # region: read input data into batch
     vcf_input = get_batch().read_input_group(vcf=vcf_path, index=f'{vcf_path}.tbi')
 
     # read in sample-specific truth data from config
-    ref_data = get_sample_truth_data(sequencing_group_ext_id)
+    ref_data = get_sample_truth_data(sample_ext_id)
     truth_input = get_batch().read_input_group(vcf=ref_data['vcf'], index=ref_data['index'], bed=ref_data['bed'])
 
     happy_j.declare_resource_group(

--- a/cpg_workflows/stages/happy_validation.py
+++ b/cpg_workflows/stages/happy_validation.py
@@ -62,9 +62,9 @@ def update_happy_meta(output_path: str) -> dict:
     }
 
     happy_handle = to_path(output_path)
-    cpg_id: str = happy_handle.name.split('.')[0]
+    sample_ext_id: str = happy_handle.name.split('__')[0]
 
-    ref_data = get_sample_truth_data(sequencing_group_id=cpg_id)
+    ref_data = get_sample_truth_data(sample_ext_id=sample_ext_id)
 
     # populate a dictionary of results for this sequencing group
     summary_data = {
@@ -98,7 +98,10 @@ def update_happy_meta(output_path: str) -> dict:
 class ValidationHappyOnVcf(SequencingGroupStage):
     def expected_outputs(self, sequencing_group: SequencingGroup):
         output_prefix = (
-            sequencing_group.dataset.prefix() / 'validation' / get_workflow().output_version / sequencing_group.id
+            sequencing_group.dataset.prefix()
+            / 'validation'
+            / get_workflow().output_version
+            / f'{sequencing_group.external_id}__{sequencing_group.id}'
         )
         return {
             'vcf': to_path(f'{output_prefix}.happy.vcf.bgz'),
@@ -120,13 +123,16 @@ class ValidationHappyOnVcf(SequencingGroupStage):
 
         # set the prefix to write outputs to
         output_prefix = (
-            sequencing_group.dataset.prefix() / 'validation' / get_workflow().output_version / sequencing_group.id
+            sequencing_group.dataset.prefix()
+            / 'validation'
+            / get_workflow().output_version
+            / f'{sequencing_group.external_id}__{sequencing_group.id}'
         )
 
         exp_outputs = self.expected_outputs(sequencing_group)
         job = run_happy_on_vcf(
             vcf_path=str(input_vcf),
-            sequencing_group_ext_id=sequencing_group.external_id,
+            sample_ext_id=sequencing_group.external_id,
             out_prefix=str(output_prefix),
         )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.6',
+    version='1.31.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The Config entry for the validation data is keyed on external sample ID (e.g. `HG001_NA12878`) instead of our internal ID (CPG***). The updater method which uploads the result to Metamist only had access to the CPG ID in the file name, so the updater couldn't access the relevant part of the config file. 

This changes the filename result to contain both the internal and external ID, so the metamist updater can find the correct data. It also slightly changes the variable name in a couple of places to make it clear that this should be an external, not and internal, identifier.

https://batch.hail.populationgenomics.org.au/batches/530843/jobs/7 as an example failure