### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='cpg-workflows',
+    name='cpg_workflows',
     # This tag is automatically updated by bumpversion
     version='1.31.7',
     description='CPG workflows for Hail Batch',


### PR DESCRIPTION
Set the package name to `cpg_workflows` instead of `cpg-workflows` to be PEP 625 compliant for pypi.