### PR TITLE
Allow configurable flexibility in STRVCTVRE stage

### DIFF
--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -591,8 +591,9 @@ class AnnotateCNVVcfWithStrvctvre(MultiCohortStage):
         strv_job = get_batch().new_job('StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'})
 
         strv_job.image(image_path('strvctvre'))
-        strv_job.storage('20Gi')
-        strv_job.memory('8Gi')
+        strv_job.cpu(config_retrieve(['strvctvre_resources', 'cpu'], 2))
+        strv_job.memory(config_retrieve(['strvctvre_resources', 'memory'], '20Gi'))
+        strv_job.storage(config_retrieve(['strvctvre_resources', 'storage'], '20Gi'))
 
         strvctvre_phylop = get_references(['strvctvre_phylop'])['strvctvre_phylop']
         assert isinstance(strvctvre_phylop, str)


### PR DESCRIPTION
With great callsets comes great resourcing demands

https://batch.hail.populationgenomics.org.au/batches/530979/jobs/7

Clarifying that the default memory previously was 8GB, with `cpu` unaltered from the default of 2.0. Hail ignored the 8GB memory request, instead going with 6.5 (highmem) * 2 cpu, and the resulting 13GB wasn't enough. On that basis I'm raising the standard to 20Gi - it'll be configurable, but hopefully we won't need to override for a while.