### PR TITLE
Overwrite incomplete tempfiles

### DIFF
--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -119,7 +119,8 @@ def impute_sex(
                     keep=False,
                 )
                 vds = VariantDataset(reference_data=vds.reference_data, variant_data=tmp_variant_data).checkpoint(
-                    str(vds_tmp_path),overwrite=True
+                    str(vds_tmp_path),
+                    overwrite=True,
                 )
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -119,7 +119,7 @@ def impute_sex(
                     keep=False,
                 )
                 vds = VariantDataset(reference_data=vds.reference_data, variant_data=tmp_variant_data).checkpoint(
-                    str(vds_tmp_path),
+                    str(vds_tmp_path),overwrite=True
                 )
             logging.info(f'count post {name} filter:{vds.variant_data.count()}')
 


### PR DESCRIPTION
If we cannot reuse the existing VDS tempfile (e.g. because it failed to write out completely), then overwrite it.