### PR TITLE
Up to VQSR training in combiner stage

### DIFF
--- a/configs/defaults/rd_post_combiner.toml
+++ b/configs/defaults/rd_post_combiner.toml
@@ -1,0 +1,3 @@
+[workflow]
+name = 'rd_post_combiner'
+status_reporter = 'metamist'

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -4,7 +4,6 @@ All jobs required to take a shard manifest (containing paths to VCF fragments) a
 
 from os.path import join
 
-import hail as hl
 import hailtop.batch as hb
 
 from cpg_utils import to_path
@@ -83,7 +82,7 @@ def gcloud_compose_vcf_from_manifest(
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [
-        join(manifest_directory, str(fragment).strip()) for fragment in hl.hadoop_open(manifest_path).readlines()
+        join(manifest_directory, str(fragment).strip()) for fragment in to_path(manifest_path).open().readlines()
     ]
 
     # rolling squash of the chunks, should enable infinite-ish scaling

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -6,7 +6,7 @@ from os.path import join
 
 import hailtop.batch as hb
 
-from cpg_utils import to_path, Path
+from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path
 from cpg_workflows.utils import chunks, get_logger
@@ -78,15 +78,11 @@ def gcloud_compose_vcf_from_manifest(
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
     """
-    get_logger().info(f'Using Manifest file path: {manifest_path}')
-    get_logger().info(f'Using Manifest parent: {manifest_path.parent}')
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [
         join(str(manifest_path.parent), fragment.strip()) for fragment in manifest_path.open().readlines()
     ]
-
-    get_logger().info(f'First fragment: {fragment_files[0]}')
 
     # rolling squash of the chunks, should enable infinite-ish scaling
     temp_chunk_prefix_num = 1

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -1,0 +1,122 @@
+"""
+All jobs required to take a shard manifest (containing paths to VCF fragments) and produce a single VCF file
+"""
+
+from os.path import join
+
+import hail as hl
+import hailtop.batch as hb
+
+from cpg_utils import to_path
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path
+from cpg_workflows.utils import chunks
+
+
+def get_gcloud_condense_command_string(fragment_list: list[str], output: str) -> str:
+    """
+    Generate a gcloud compose command string to concatenate a list of VCF fragments
+    write the product to the output path
+    Args:
+        fragment_list ():
+        output ():
+    Returns:
+    """
+
+    cat_string = 'gcloud storage objects compose '
+    for fragment in fragment_list:
+        cat_string += f'{fragment} '
+    cat_string += f'{output}'
+    return cat_string
+
+
+def compose_condense_fragments(
+    path_list: list[str],
+    temp_prefix: str,
+    chunk_size: int = 30,
+) -> tuple[list[str], hb.batch.job.Job]:
+    """
+    takes a list of things to condense, creates jobs to condense them. Returns a list of the result paths
+
+    Args:
+        path_list (list[str]): all the paths to condense
+        temp_prefix ():
+        chunk_size (): number of objects to condense at once
+    Returns:
+        list of paths to the condensed objects
+    """
+
+    chunk_job = get_batch().new_job(name=f'chunkbuster_{len(path_list)}')
+    chunk_job.image(config_retrieve(['workflow', 'driver_image']))
+    authenticate_cloud_credentials_in_job(chunk_job)
+
+    sub_chunks = []
+    for i, chunk in enumerate(chunks(path_list, chunk_size=chunk_size)):
+        # either the named file, or a temp location
+        chunk_output = join(temp_prefix, f'chunk_{i}.vcf.bgz')
+        chunk_job.command(get_gcloud_condense_command_string(chunk, chunk_output))
+        sub_chunks.append(chunk_output)
+    return sub_chunks, chunk_job
+
+
+def gcloud_compose_vcf_from_manifest(
+    manifest_path: str, intermediates_path: str, output_path: str,
+) -> list[hb.batch.job.Job]:
+    """
+    compose a series gcloud commands to condense a list of VCF fragments into a single VCF
+    gcloud compose has a limit on 32 separate inputs, so at higher input counts we need to do a rolling merge
+
+    compose can only run within a bucket, so we can't do all the intermediate generation in one bucket, and
+    then move to a permanent location
+
+    Args:
+        manifest_path (str): path to a file in GCP, one GCP file path per line
+        intermediates_path (str): path to a bucket, where intermediate files will be written
+        output_path (str): path to write the final file to. Must be in the same bucket as the manifest
+
+    Returns:
+        a list of the jobs which will generate a single output from the manifest of fragment paths
+    """
+    manifest_directory = to_path(intermediates_path).parent
+
+    # prefix these shard names to get full GCP path for each
+    fragment_files = [
+        join(manifest_directory, str(fragment).strip()) for fragment in hl.hadoop_open(manifest_path).readlines()
+    ]
+
+    # rolling squash of the chunks, should enable infinite-ish scaling
+    temp_chunk_prefix_num = 1
+    condense_jobs: list[hb.batch.job.Job] = []
+    while len(fragment_files) > 1:
+        condense_temp = join(intermediates_path, f'temp_chunk_{temp_chunk_prefix_num}')
+        temp_chunk_prefix_num += 1
+        fragment_files, condense_job = compose_condense_fragments(
+            fragment_files,
+            condense_temp,
+        )
+        if condense_jobs:
+            condense_job.depends_on(condense_jobs[-1])
+            condense_jobs.append(condense_job)
+
+    # one final job - read the final vcf in, index it, move the index, and write it out
+    input_vcf = get_batch().read_input(fragment_files[0])
+    final_job = get_batch().new_bash_job(name='index_final_vcf')
+
+    # if there were no jobs, there's no composing...
+    if condense_jobs:
+        final_job.depends_on(condense_jobs[-1])
+    condense_jobs.append(final_job)
+
+    final_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
+    final_job.image(image_path('bcftools'))
+    final_job.storage(config_retrieve(['gcloud_condense', 'storage'], '10Gi'))
+
+    # we specifically need block-gzipped output for some downstream tools
+    # otherwise a mv or a bcftools view with --write-index=tbi would be neater
+    final_job.command(f'bcftools view {input_vcf} | bgzip -c > {final_job.output["vcf.bgz"]}')
+    final_job.command(f'tabix {final_job.output["vcf.bgz"]}')
+
+    get_batch().write_output(final_job.output, output_path.removesuffix('.vcf.bgz'))
+
+    # don't start the batch straight away
+    return condense_jobs

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -95,7 +95,7 @@ def gcloud_compose_vcf_from_manifest(
             condense_temp,
         )
         if condense_jobs:
-            condense_job.depends_on(condense_jobs[-1])
+            condense_job.depends_on(*condense_jobs)
             condense_jobs.append(condense_job)
 
     # one final job - read the final vcf in, index it, move the index, and write it out

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -78,7 +78,7 @@ def gcloud_compose_vcf_from_manifest(
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
     """
-    manifest_directory = to_path(intermediates_path).parent
+    manifest_directory = to_path(manifest_path).parent
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -60,7 +60,9 @@ def compose_condense_fragments(
 
 
 def gcloud_compose_vcf_from_manifest(
-    manifest_path: str, intermediates_path: str, output_path: str,
+    manifest_path: str,
+    intermediates_path: str,
+    output_path: str,
 ) -> list[hb.batch.job.Job]:
     """
     compose a series gcloud commands to condense a list of VCF fragments into a single VCF

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -95,8 +95,9 @@ def gcloud_compose_vcf_from_manifest(
             condense_temp,
         )
         if condense_jobs:
-            condense_job.depends_on(*condense_jobs)
-            condense_jobs.append(condense_job)
+            condense_job.depends_on(condense_jobs[-1])
+
+        condense_jobs.append(condense_job)
 
     # one final job - read the final vcf in, index it, move the index, and write it out
     input_vcf = get_batch().read_input(fragment_files[0])

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -6,7 +6,7 @@ from os.path import join
 
 import hailtop.batch as hb
 
-from cpg_utils import to_path
+from cpg_utils import to_path, Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path
 from cpg_workflows.utils import chunks
@@ -59,7 +59,7 @@ def compose_condense_fragments(
 
 
 def gcloud_compose_vcf_from_manifest(
-    manifest_path: str,
+    manifest_path: Path,
     intermediates_path: str,
     output_path: str,
 ) -> list[hb.batch.job.Job]:
@@ -78,11 +78,11 @@ def gcloud_compose_vcf_from_manifest(
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
     """
-    manifest_directory = to_path(manifest_path).parent
+    print(f'Using Manifest file path: {manifest_path}')
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [
-        join(manifest_directory, str(fragment).strip()) for fragment in to_path(manifest_path).open().readlines()
+        join(manifest_path.parent, str(fragment).strip()) for fragment in to_path(manifest_path).open().readlines()
     ]
 
     # rolling squash of the chunks, should enable infinite-ish scaling

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -1,0 +1,91 @@
+"""
+Create and run jobs relating to VQSR for the RD combiner
+"""
+
+from cpg_utils.config import reference_path
+from cpg_utils.hail_batch import get_batch
+
+from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job
+
+
+def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str):
+    """
+    Train VQSR indels on the sites-only VCF
+    Args:
+        sites_only_vcf ():
+        indel_recal ():
+        indel_tranches ():
+    """
+    resources = {
+        key: get_batch().read_input_group(
+            base=reference_path(f'broad/{key}_vcf'),
+            index=reference_path(f'broad/{key}_vcf_index'),
+        )
+        for key in [
+            'dbsnp',
+            'mills',
+            'axiom_poly',
+        ]
+    }
+    siteonly_vcf = get_batch().read_input_group(
+        **{
+            'vcf.gz': str(sites_only_vcf),
+            'vcf.gz.tbi': str(sites_only_vcf) + '.tbi',
+        },
+    )
+
+    indel_recalibrator_j = indel_recalibrator_job(
+        b=get_batch(),
+        siteonly_vcf=siteonly_vcf,
+        mills_resource_vcf=resources['mills'],
+        axiom_poly_resource_vcf=resources['axiom_poly'],
+        dbsnp_resource_vcf=resources['dbsnp'],
+        disk_size=100,
+        use_as_annotations=True,
+        is_small_callset=False,
+    )
+
+    get_batch().write_output(indel_recalibrator_j.recalibration, indel_recal)
+    get_batch().write_output(indel_recalibrator_j.recalibration_idx, indel_recal + '.idx')
+    get_batch().write_output(indel_recalibrator_j.tranches, indel_tranches)
+    return indel_recalibrator_j
+def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
+    """
+    Train VQSR indels on the sites-only VCF
+    Args:
+        sites_only_vcf ():
+        snp_model ():
+    """
+    resources = {
+        key: get_batch().read_input_group(
+            base=reference_path(f'broad/{key}_vcf'),
+            index=reference_path(f'broad/{key}_vcf_index'),
+        )
+        for key in [
+            'dbsnp',
+            'hapmap',
+            'omni',
+            'one_thousand_genomes',
+        ]
+    }
+    siteonly_vcf = get_batch().read_input_group(
+        **{
+            'vcf.gz': str(sites_only_vcf),
+            'vcf.gz.tbi': str(sites_only_vcf) + '.tbi',
+        },
+    )
+
+    snp_recalibrator_j = snps_recalibrator_create_model_job(
+        b=get_batch(),
+        siteonly_vcf=siteonly_vcf,
+        hapmap_resource_vcf=resources['hapmap'],
+        omni_resource_vcf=resources['omni'],
+        one_thousand_genomes_resource_vcf=resources['one_thousand_genomes'],
+        dbsnp_resource_vcf=resources['dbsnp'],
+        disk_size=100,
+        use_as_annotations=True,
+        is_small_callset=False,
+    )
+
+    get_batch().write_output(snp_recalibrator_j.model_file, snp_model)
+    return snp_recalibrator_j

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -4,7 +4,6 @@ Create and run jobs relating to VQSR for the RD combiner
 
 from cpg_utils.config import reference_path
 from cpg_utils.hail_batch import get_batch
-
 from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job
 
 
@@ -49,6 +48,8 @@ def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str
     get_batch().write_output(indel_recalibrator_j.recalibration_idx, indel_recal + '.idx')
     get_batch().write_output(indel_recalibrator_j.tranches, indel_tranches)
     return indel_recalibrator_j
+
+
 def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
     """
     Train VQSR indels on the sites-only VCF

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -72,7 +72,7 @@ def main(
 
     mt.write(dense_mt_out, overwrite=True)
 
-    if not sites_only or separate_header:
+    if not (sites_only or separate_header):
         return
 
     # read the dense MT and obtain the sites-only HT

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -52,10 +52,10 @@ def main(
 
     vds = hl.vds.read_vds(vds_in)
 
-    get_logger(__file__).info('Splitting multiallelics')
+    get_logger().info('Splitting multiallelics')
     vds = hl.vds.split_multi(vds)
 
-    get_logger(__file__).info('Densifying data...')
+    get_logger().info('Densifying data...')
     mt = hl.vds.to_dense_mt(vds)
 
     # remove any monoallelic or non-ref-in-any-sample sites
@@ -81,12 +81,12 @@ def main(
 
     # write a directory containing all the per-partition VCF fragments, each with a VCF header
     if sites_only:
-        get_logger(__file__).info('Writing sites-only VCF, header-per-shard')
+        get_logger().info('Writing sites-only VCF, header-per-shard')
         hl.export_vcf(sites_only_ht, sites_only, tabix=True, parallel='header_per_shard')
 
     # write a directory containing all the per-partition VCF fragments, with a separate VCF header file
     if separate_header:
-        get_logger(__file__).info('Writing sites-only VCF, separate-header')
+        get_logger().info('Writing sites-only VCF, separate-header')
         hl.export_vcf(sites_only_ht, separate_header, tabix=True, parallel='separate_header')
 
 

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -57,7 +57,7 @@ def main(
 
     # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
     # remove any monoallelic or non-ref-in-any-sample sites
-    mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.GT.is_non_ref())))
+    mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.LGT.is_non_ref())))
 
     # annotate site-level DP to avoid name collision
     mt = mt.annotate_rows(

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -65,7 +65,7 @@ def main(
     # annotate site-level DP to avoid name collision
     mt = mt.annotate_rows(
         site_dp=hl.agg.sum(mt.DP),
-        ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
+        ANS=hl.agg.count_where(hl.is_defined(mt.GT)) * 2,
     )
 
     # content shared with large_cohort.site_only_vcf.py

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -18,13 +18,12 @@ from argparse import ArgumentParser
 
 import hail as hl
 
-from gnomad.utils.sparse_mt import default_compute_info
-from gnomad.utils.vcf import adjust_vcf_incompatible_types
-
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
 from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import get_logger
+from gnomad.utils.sparse_mt import default_compute_info
+from gnomad.utils.vcf import adjust_vcf_incompatible_types
 
 
 def main(

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -52,9 +52,6 @@ def main(
 
     vds = hl.vds.read_vds(vds_in)
 
-    get_logger().info('Splitting multiallelics')
-    vds = hl.vds.split_multi(vds)
-
     get_logger().info('Densifying data...')
     mt = hl.vds.to_dense_mt(vds)
 
@@ -65,7 +62,7 @@ def main(
     # annotate site-level DP to avoid name collision
     mt = mt.annotate_rows(
         site_dp=hl.agg.sum(mt.DP),
-        ANS=hl.agg.count_where(hl.is_defined(mt.GT)) * 2,
+        ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
     )
 
     # content shared with large_cohort.site_only_vcf.py
@@ -84,6 +81,9 @@ def main(
 
     # annotate this info back into the main MatrixTable
     mt = mt.annotate_rows(info=info_ht[mt.row_key])
+
+    get_logger().info('Splitting multiallelics')
+    mt = hl.split_multi_hts(mt)
 
     mt.write(dense_mt_out, overwrite=True)
 

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -82,6 +82,10 @@ def main(
     # annotate this info back into the main MatrixTable
     mt = mt.annotate_rows(info=info_ht[mt.row_key])
 
+    # unpack mt.info.info back into mt.info
+    mt = mt.transmute_rows(**mt.info)
+    mt = mt.drop('gvcf_info')
+
     get_logger().info('Splitting multiallelics')
     mt = hl.split_multi_hts(mt)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -8,6 +8,7 @@ from cpg_workflows.workflow import (
     MultiCohortStage,
     StageInput,
     StageOutput,
+    get_workflow,
     stage,
 )
 from metamist.graphql import gql, query
@@ -178,7 +179,7 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
         and the result will be a spec-compliant VCF
         """
 
-        manifest_file = self.prefix / f'{multicohort.name}_separate.vcf.bgz' / SHARD_MANIFEST
+        manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}_separate.vcf.bgz' / SHARD_MANIFEST
 
         if not manifest_file.exists():
             raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the previous workflow')
@@ -207,7 +208,7 @@ class VQSROnCombinerData(MultiCohortStage):
         This means the VQSR logic should be far simpler - we don't need to subdivide the input by regions
         """
 
-        _manifest_file = self.prefix / f'{multicohort.name}.vcf.bgz' / SHARD_MANIFEST
+        _manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}.vcf.bgz' / SHARD_MANIFEST
 
         outputs = self.expected_outputs(multicohort)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -195,7 +195,7 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
 
         jobs = gcloud_compose_vcf_from_manifest(
             manifest_path=manifest_file,
-            intermediates_path=str(self.tmp_prefix),
+            intermediates_path=str(self.prefix / 'temporary_compose_intermediates'),
             output_path=str(outputs['vcf']),
         )
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -129,8 +129,9 @@ class DenseMTFromVDS(MultiCohortStage):
         """
         the MT and both shard_manifest files are Paths, so this stage will rerun if any of those are missing
         the VCFs are written as a directory, rather than a single VCF, so we can't check its existence well
+
+        Needs a range of INFO fields to be present in the VCF
         """
-        # generate hashes once
         prefix = self.prefix
 
         return {

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -178,8 +178,14 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
         This means we can combine the VCF header and data fragments through concatenation
         and the result will be a spec-compliant VCF
         """
-
-        manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}_separate.vcf.bgz' / SHARD_MANIFEST
+        manifest_file = (
+            multicohort.analysis_dataset.prefix()
+            / 'rd_combiner'
+            / get_workflow().output_version
+            / 'DenseMTFromVDS'
+            / f'{multicohort.name}_separate.vcf.bgz'
+            / SHARD_MANIFEST
+        )
 
         if not manifest_file.exists():
             raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the previous workflow')
@@ -208,7 +214,14 @@ class VQSROnCombinerData(MultiCohortStage):
         This means the VQSR logic should be far simpler - we don't need to subdivide the input by regions
         """
 
-        _manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}.vcf.bgz' / SHARD_MANIFEST
+        _manifest_file = (
+            multicohort.analysis_dataset.prefix()
+            / 'rd_combiner'
+            / get_workflow().output_version
+            / 'DenseMTFromVDS'
+            / f'{multicohort.name}.vcf.bgz'
+            / SHARD_MANIFEST
+        )
 
         outputs = self.expected_outputs(multicohort)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -29,7 +29,7 @@ LATEST_ANALYSIS_QUERY = gql(
     }
 """,
 )
-SHARD_MANIFEST = 'shard_manifest.txt'
+SHARD_MANIFEST = 'shard-manifest.txt'
 
 
 def query_for_latest_vds(dataset: str, entry_type: str = 'combiner') -> dict | None:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -255,25 +255,3 @@ class TrainVQSRSNPModelOnCombinerData(MultiCohortStage):
             snp_model=str(outputs['snp_model']),
         )
         return self.make_outputs(multicohort, data=outputs, jobs=snp_calibration_job)
-
-
-# @stage(analysis_keys=['vcf'], analysis_type='qc', required_stages=TrainVQSRIndelModelOnCombinerData)
-# class RunVQSROnCombinerData(MultiCohortStage):
-#     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
-#         # should this be one per fragment?
-#         return {'vcf': self.prefix / 'vqsr.vcf.bgz'}
-#
-#     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
-#
-#         manifest_file = (
-#             multicohort.analysis_dataset.prefix()
-#             / 'rd_combiner'
-#             / get_workflow().output_version
-#             / 'DenseMTFromVDS'
-#             / f'{multicohort.name}.vcf.bgz'
-#             / SHARD_MANIFEST
-#         )
-#
-#         if not manifest_file.exists():
-#             raise ValueError(f'Manifest file {manifest_file} does not exist, run the rd_combiner workflow')
-#         ...

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -193,7 +193,11 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
 
         outputs = self.expected_outputs(multicohort)
 
-        jobs = gcloud_compose_vcf_from_manifest(str(manifest_file), str(self.tmp_prefix), str(outputs['vcf']))
+        jobs = gcloud_compose_vcf_from_manifest(
+            manifest_path=manifest_file,
+            intermediates_path=str(self.tmp_prefix),
+            output_path=str(outputs['vcf']),
+        )
 
         return self.make_outputs(multicohort, data=outputs, jobs=jobs)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -188,7 +188,7 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
         )
 
         if not manifest_file.exists():
-            raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the previous workflow')
+            raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the rd_combiner workflow')
 
         outputs = self.expected_outputs(multicohort)
 
@@ -214,7 +214,7 @@ class VQSROnCombinerData(MultiCohortStage):
         This means the VQSR logic should be far simpler - we don't need to subdivide the input by regions
         """
 
-        _manifest_file = (
+        manifest_file = (
             multicohort.analysis_dataset.prefix()
             / 'rd_combiner'
             / get_workflow().output_version
@@ -222,6 +222,9 @@ class VQSROnCombinerData(MultiCohortStage):
             / f'{multicohort.name}.vcf.bgz'
             / SHARD_MANIFEST
         )
+
+        if not manifest_file.exists():
+            raise ValueError(f'Manifest file {manifest_file} does not exist, run the rd_combiner workflow')
 
         outputs = self.expected_outputs(multicohort)
 

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -53,7 +53,6 @@ def get_logger(
 
         # create a named logger
         new_logger = logging.getLogger(logger_name)
-        new_logger.setLevel(log_level)
 
         # unless otherwise specified, use coloredlogs
         if config_retrieve(['workflow', 'logger', logger_name, 'use_colored_logs'], True):

--- a/main.py
+++ b/main.py
@@ -24,7 +24,12 @@ from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, Validati
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.rd_combiner import ComposeFragmentsToSingleVCF, DenseMTFromVDS, GVCFCombiner
+from cpg_workflows.stages.rd_combiner import (
+    ComposeFragmentsToSingleVCF,
+    DenseMTFromVDS,
+    GVCFCombiner,
+    TrainVQSRIndelModelOnCombinerData,
+)
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels
@@ -41,7 +46,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
-    'rd_post_combiner': [ComposeFragmentsToSingleVCF],
+    'rd_post_combiner': [ComposeFragmentsToSingleVCF, TrainVQSRIndelModelOnCombinerData],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, Validati
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.rd_combiner import DenseMTFromVDS, GVCFCombiner
+from cpg_workflows.stages.rd_combiner import DenseMTFromVDS, GVCFCombiner, ComposeFragmentsToSingleVCF
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels
@@ -41,6 +41,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
+    'rd_post_combiner': [ComposeFragmentsToSingleVCF],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, Validati
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.rd_combiner import DenseMTFromVDS, GVCFCombiner, ComposeFragmentsToSingleVCF
+from cpg_workflows.stages.rd_combiner import ComposeFragmentsToSingleVCF, DenseMTFromVDS, GVCFCombiner
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels

--- a/main.py
+++ b/main.py
@@ -25,10 +25,10 @@ from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVq
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
 from cpg_workflows.stages.rd_combiner import (
-    ComposeFragmentsToSingleVCF,
     DenseMTFromVDS,
     GVCFCombiner,
     TrainVQSRIndelModelOnCombinerData,
+    TrainVQSRSNPModelOnCombinerData,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
@@ -46,7 +46,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
-    'rd_post_combiner': [ComposeFragmentsToSingleVCF, TrainVQSRIndelModelOnCombinerData],
+    'rd_post_combiner': [TrainVQSRIndelModelOnCombinerData, TrainVQSRSNPModelOnCombinerData],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,


### PR DESCRIPTION
See https://batch.hail.populationgenomics.org.au/batches/531175

This makes a lot of changes to the RD combiner process (which wasn't fit for purpose... The sites-only VCFs it generated had no INFO content. That's fine for VEP, very not fine for VQSR), and adds three additional steps:

1. ComposeFragmentsToSingleVCF - uses `gcloud storage compose` to build a single sites-only VCF from the per-partition fragments, to be used in training the VQSR model
2. TrainVQSRIndelModelOnCombinerData - trains the VQSR indel model on the whole-genome sites-only VCF
3. TrainVQSRSNPModelOnCombinerData - trains the VQSR SNP model on the whole-genome sites-only VCF

2 & 3 there were previously part of the single VQSR Stage (training, generating intervals, splitting, running VQSR, joining into a single VCF), but IMO that's an unmaintainable spaghetti code nightmare, so I'm rewriting the whole workflow as discrete sections


