### PR TITLE
Combiner workflow up to VQSR training

### DIFF
--- a/configs/defaults/rd_post_combiner.toml
+++ b/configs/defaults/rd_post_combiner.toml
@@ -1,0 +1,3 @@
+[workflow]
+name = 'rd_post_combiner'
+status_reporter = 'metamist'

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -4,7 +4,6 @@ All jobs required to take a shard manifest (containing paths to VCF fragments) a
 
 from os.path import join
 
-import hail as hl
 import hailtop.batch as hb
 
 from cpg_utils import to_path
@@ -83,7 +82,7 @@ def gcloud_compose_vcf_from_manifest(
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [
-        join(manifest_directory, str(fragment).strip()) for fragment in hl.hadoop_open(manifest_path).readlines()
+        join(manifest_directory, str(fragment).strip()) for fragment in to_path(manifest_path).open().readlines()
     ]
 
     # rolling squash of the chunks, should enable infinite-ish scaling

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -6,7 +6,7 @@ from os.path import join
 
 import hailtop.batch as hb
 
-from cpg_utils import to_path, Path
+from cpg_utils import Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path
 from cpg_workflows.utils import chunks, get_logger
@@ -78,15 +78,11 @@ def gcloud_compose_vcf_from_manifest(
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
     """
-    get_logger().info(f'Using Manifest file path: {manifest_path}')
-    get_logger().info(f'Using Manifest parent: {manifest_path.parent}')
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [
         join(str(manifest_path.parent), fragment.strip()) for fragment in manifest_path.open().readlines()
     ]
-
-    get_logger().info(f'First fragment: {fragment_files[0]}')
 
     # rolling squash of the chunks, should enable infinite-ish scaling
     temp_chunk_prefix_num = 1

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -33,6 +33,7 @@ def compose_condense_fragments(
     path_list: list[str],
     temp_prefix: str,
     chunk_size: int = 30,
+    job_name: str = 'ChunkBuster',
 ) -> tuple[list[str], hb.batch.job.Job]:
     """
     takes a list of things to condense, creates jobs to condense them. Returns a list of the result paths
@@ -41,11 +42,12 @@ def compose_condense_fragments(
         path_list (list[str]): all the paths to condense
         temp_prefix ():
         chunk_size (): number of objects to condense at once
+        job_name (str): name of the job
     Returns:
         list of paths to the condensed objects
     """
 
-    chunk_job = get_batch().new_job(name=f'chunkbuster_{len(path_list)}')
+    chunk_job = get_batch().new_job(name=f'{job_name}_{len(path_list)}')
     chunk_job.image(config_retrieve(['workflow', 'driver_image']))
     authenticate_cloud_credentials_in_job(chunk_job)
 
@@ -62,6 +64,7 @@ def gcloud_compose_vcf_from_manifest(
     manifest_path: Path,
     intermediates_path: str,
     output_path: str,
+    job_name: str,
 ) -> list[hb.batch.job.Job]:
     """
     compose a series gcloud commands to condense a list of VCF fragments into a single VCF
@@ -74,6 +77,7 @@ def gcloud_compose_vcf_from_manifest(
         manifest_path (Path): path to a file in GCP, one GCP file path per line
         intermediates_path (str): path to a bucket, where intermediate files will be written
         output_path (str): path to write the final file to. Must be in the same bucket as the manifest
+        job_name (str): name of the job
 
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
@@ -93,6 +97,7 @@ def gcloud_compose_vcf_from_manifest(
         fragment_files, condense_job = compose_condense_fragments(
             fragment_files,
             condense_temp,
+            job_name=job_name,
         )
         if condense_jobs:
             condense_job.depends_on(condense_jobs[-1])

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -1,0 +1,122 @@
+"""
+All jobs required to take a shard manifest (containing paths to VCF fragments) and produce a single VCF file
+"""
+
+from os.path import join
+
+import hail as hl
+import hailtop.batch as hb
+
+from cpg_utils import to_path
+from cpg_utils.config import config_retrieve
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path
+from cpg_workflows.utils import chunks
+
+
+def get_gcloud_condense_command_string(fragment_list: list[str], output: str) -> str:
+    """
+    Generate a gcloud compose command string to concatenate a list of VCF fragments
+    write the product to the output path
+    Args:
+        fragment_list ():
+        output ():
+    Returns:
+    """
+
+    cat_string = 'gcloud storage objects compose '
+    for fragment in fragment_list:
+        cat_string += f'{fragment} '
+    cat_string += f'{output}'
+    return cat_string
+
+
+def compose_condense_fragments(
+    path_list: list[str],
+    temp_prefix: str,
+    chunk_size: int = 30,
+) -> tuple[list[str], hb.batch.job.Job]:
+    """
+    takes a list of things to condense, creates jobs to condense them. Returns a list of the result paths
+
+    Args:
+        path_list (list[str]): all the paths to condense
+        temp_prefix ():
+        chunk_size (): number of objects to condense at once
+    Returns:
+        list of paths to the condensed objects
+    """
+
+    chunk_job = get_batch().new_job(name=f'chunkbuster_{len(path_list)}')
+    chunk_job.image(config_retrieve(['workflow', 'driver_image']))
+    authenticate_cloud_credentials_in_job(chunk_job)
+
+    sub_chunks = []
+    for i, chunk in enumerate(chunks(path_list, chunk_size=chunk_size)):
+        # either the named file, or a temp location
+        chunk_output = join(temp_prefix, f'chunk_{i}.vcf.bgz')
+        chunk_job.command(get_gcloud_condense_command_string(chunk, chunk_output))
+        sub_chunks.append(chunk_output)
+    return sub_chunks, chunk_job
+
+
+def gcloud_compose_vcf_from_manifest(
+    manifest_path: str, intermediates_path: str, output_path: str,
+) -> list[hb.batch.job.Job]:
+    """
+    compose a series gcloud commands to condense a list of VCF fragments into a single VCF
+    gcloud compose has a limit on 32 separate inputs, so at higher input counts we need to do a rolling merge
+
+    compose can only run within a bucket, so we can't do all the intermediate generation in one bucket, and
+    then move to a permanent location
+
+    Args:
+        manifest_path (str): path to a file in GCP, one GCP file path per line
+        intermediates_path (str): path to a bucket, where intermediate files will be written
+        output_path (str): path to write the final file to. Must be in the same bucket as the manifest
+
+    Returns:
+        a list of the jobs which will generate a single output from the manifest of fragment paths
+    """
+    manifest_directory = to_path(intermediates_path).parent
+
+    # prefix these shard names to get full GCP path for each
+    fragment_files = [
+        join(manifest_directory, str(fragment).strip()) for fragment in hl.hadoop_open(manifest_path).readlines()
+    ]
+
+    # rolling squash of the chunks, should enable infinite-ish scaling
+    temp_chunk_prefix_num = 1
+    condense_jobs: list[hb.batch.job.Job] = []
+    while len(fragment_files) > 1:
+        condense_temp = join(intermediates_path, f'temp_chunk_{temp_chunk_prefix_num}')
+        temp_chunk_prefix_num += 1
+        fragment_files, condense_job = compose_condense_fragments(
+            fragment_files,
+            condense_temp,
+        )
+        if condense_jobs:
+            condense_job.depends_on(condense_jobs[-1])
+            condense_jobs.append(condense_job)
+
+    # one final job - read the final vcf in, index it, move the index, and write it out
+    input_vcf = get_batch().read_input(fragment_files[0])
+    final_job = get_batch().new_bash_job(name='index_final_vcf')
+
+    # if there were no jobs, there's no composing...
+    if condense_jobs:
+        final_job.depends_on(condense_jobs[-1])
+    condense_jobs.append(final_job)
+
+    final_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
+    final_job.image(image_path('bcftools'))
+    final_job.storage(config_retrieve(['gcloud_condense', 'storage'], '10Gi'))
+
+    # we specifically need block-gzipped output for some downstream tools
+    # otherwise a mv or a bcftools view with --write-index=tbi would be neater
+    final_job.command(f'bcftools view {input_vcf} | bgzip -c > {final_job.output["vcf.bgz"]}')
+    final_job.command(f'tabix {final_job.output["vcf.bgz"]}')
+
+    get_batch().write_output(final_job.output, output_path.removesuffix('.vcf.bgz'))
+
+    # don't start the batch straight away
+    return condense_jobs

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -95,7 +95,7 @@ def gcloud_compose_vcf_from_manifest(
             condense_temp,
         )
         if condense_jobs:
-            condense_job.depends_on(condense_jobs[-1])
+            condense_job.depends_on(*condense_jobs)
             condense_jobs.append(condense_job)
 
     # one final job - read the final vcf in, index it, move the index, and write it out

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -95,8 +95,8 @@ def gcloud_compose_vcf_from_manifest(
         condense_temp = join(intermediates_path, f'temp_chunk_{temp_chunk_prefix_num}')
         temp_chunk_prefix_num += 1
         fragment_files, condense_job = compose_condense_fragments(
-            fragment_files,
-            condense_temp,
+            path_list=fragment_files,
+            temp_prefix=condense_temp,
             job_name=job_name,
         )
         if condense_jobs:

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -78,7 +78,7 @@ def gcloud_compose_vcf_from_manifest(
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
     """
-    manifest_directory = to_path(intermediates_path).parent
+    manifest_directory = to_path(manifest_path).parent
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -60,7 +60,9 @@ def compose_condense_fragments(
 
 
 def gcloud_compose_vcf_from_manifest(
-    manifest_path: str, intermediates_path: str, output_path: str,
+    manifest_path: str,
+    intermediates_path: str,
+    output_path: str,
 ) -> list[hb.batch.job.Job]:
     """
     compose a series gcloud commands to condense a list of VCF fragments into a single VCF

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -95,8 +95,9 @@ def gcloud_compose_vcf_from_manifest(
             condense_temp,
         )
         if condense_jobs:
-            condense_job.depends_on(*condense_jobs)
-            condense_jobs.append(condense_job)
+            condense_job.depends_on(condense_jobs[-1])
+
+        condense_jobs.append(condense_job)
 
     # one final job - read the final vcf in, index it, move the index, and write it out
     input_vcf = get_batch().read_input(fragment_files[0])

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -6,7 +6,7 @@ from os.path import join
 
 import hailtop.batch as hb
 
-from cpg_utils import to_path
+from cpg_utils import to_path, Path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch, image_path
 from cpg_workflows.utils import chunks
@@ -59,7 +59,7 @@ def compose_condense_fragments(
 
 
 def gcloud_compose_vcf_from_manifest(
-    manifest_path: str,
+    manifest_path: Path,
     intermediates_path: str,
     output_path: str,
 ) -> list[hb.batch.job.Job]:
@@ -78,11 +78,11 @@ def gcloud_compose_vcf_from_manifest(
     Returns:
         a list of the jobs which will generate a single output from the manifest of fragment paths
     """
-    manifest_directory = to_path(manifest_path).parent
+    print(f'Using Manifest file path: {manifest_path}')
 
     # prefix these shard names to get full GCP path for each
     fragment_files = [
-        join(manifest_directory, str(fragment).strip()) for fragment in to_path(manifest_path).open().readlines()
+        join(manifest_path.parent, str(fragment).strip()) for fragment in to_path(manifest_path).open().readlines()
     ]
 
     # rolling squash of the chunks, should enable infinite-ish scaling

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -11,7 +11,7 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import image_path, reference_path
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job, snps_recalibrator_scattered, snps_gather_tranches_job, SNP_RECALIBRATION_TRANCHE_VALUES, SNP_ALLELE_SPECIFIC_FEATURES
-from cpg_workflows.resources import HIGHMEM, STANDARD, joint_calling_scatter_count
+from cpg_workflows.resources import HIGHMEM, joint_calling_scatter_count
 from cpg_workflows.utils import can_reuse
 
 

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -191,8 +191,8 @@ def train_vqsr_snp_tranches(
           "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
           VariantRecalibrator \\
           -V input.vcf.bgz \\
-          -O {snps_recal_path} \\
-          --tranches-file {snps_tranche_path} \\
+          -O {snps_recal_j.recalibration} \\
+          --tranches-file {snps_recal_j.tranches} \\
           --trust-all-polymorphic \\
           {tranche_cmdl} \\
           {an_cmdl} \\

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -2,9 +2,65 @@
 Create and run jobs relating to VQSR for the RD combiner
 """
 
+from functools import lru_cache
+
+from hailtop.batch.resource import ResourceGroup
+from hailtop.batch.job import Job
+
+from cpg_utils import Path, to_path
 from cpg_utils.config import reference_path
 from cpg_utils.hail_batch import get_batch
-from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job
+from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job, snps_recalibrator_scattered, snps_gather_tranches_job
+from cpg_workflows.utils import can_reuse
+
+
+@lru_cache(100)
+def get_all_fragments_from_manifest(manifest_file: Path) -> list[ResourceGroup]:
+    """
+    read the manifest file, and return all the fragment resources as an ordered list
+    this is a cached method as we don't want to localise every fragment once per task
+
+    Args:
+        manifest_file ():
+
+    Returns:
+        an ordered list of all the fragment VCFs and corresponding indices
+    """
+
+    resource_objects: list[ResourceGroup] = []
+    manifest_folder: Path = manifest_file.parent
+    with manifest_file.open() as f:
+        for line in f:
+            vcf_path = manifest_folder / line.strip()
+            resource_objects.append(
+                get_batch().read_input_group(**{'vcf.bgz': vcf_path, 'vcf.bgz.tbi': f'{vcf_path}.tbi'}),
+            )
+
+    return resource_objects
+
+
+@lru_cache(1)
+def get_localised_resources_for_vqsr() -> dict[str, ResourceGroup]:
+    """
+    get the resources required for VQSR, once per run
+    Returns:
+        the dictionary of resources and their names
+    """
+
+    return {
+        key: get_batch().read_input_group(
+            base=reference_path(f'broad/{key}_vcf'),
+            index=reference_path(f'broad/{key}_vcf_index'),
+        )
+        for key in [
+            'axiom_poly',
+            'dbsnp',
+            'hapmap',
+            'mills',
+            'omni',
+            'one_thousand_genomes',
+        ]
+    }
 
 
 def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str):
@@ -15,17 +71,7 @@ def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str
         indel_recal ():
         indel_tranches ():
     """
-    resources = {
-        key: get_batch().read_input_group(
-            base=reference_path(f'broad/{key}_vcf'),
-            index=reference_path(f'broad/{key}_vcf_index'),
-        )
-        for key in [
-            'dbsnp',
-            'mills',
-            'axiom_poly',
-        ]
-    }
+    resources = get_localised_resources_for_vqsr()
     siteonly_vcf = get_batch().read_input_group(
         **{
             'vcf.gz': str(sites_only_vcf),
@@ -39,7 +85,7 @@ def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str
         mills_resource_vcf=resources['mills'],
         axiom_poly_resource_vcf=resources['axiom_poly'],
         dbsnp_resource_vcf=resources['dbsnp'],
-        disk_size=100,
+        disk_size=20,
         use_as_annotations=True,
         is_small_callset=False,
     )
@@ -57,18 +103,7 @@ def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
         sites_only_vcf ():
         snp_model ():
     """
-    resources = {
-        key: get_batch().read_input_group(
-            base=reference_path(f'broad/{key}_vcf'),
-            index=reference_path(f'broad/{key}_vcf_index'),
-        )
-        for key in [
-            'dbsnp',
-            'hapmap',
-            'omni',
-            'one_thousand_genomes',
-        ]
-    }
+    resources = get_localised_resources_for_vqsr()
     siteonly_vcf = get_batch().read_input_group(
         **{
             'vcf.gz': str(sites_only_vcf),
@@ -83,10 +118,83 @@ def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
         omni_resource_vcf=resources['omni'],
         one_thousand_genomes_resource_vcf=resources['one_thousand_genomes'],
         dbsnp_resource_vcf=resources['dbsnp'],
-        disk_size=100,
+        disk_size=20,
         use_as_annotations=True,
         is_small_callset=False,
     )
 
     get_batch().write_output(snp_recalibrator_j.model_file, snp_model)
     return snp_recalibrator_j
+
+
+def train_vqsr_snp_tranches(
+    manifest_file:Path,
+    snp_model_path:str,
+    output_path:str,
+    temp_path:Path,
+) -> list[Job]:
+    """
+    train vqsr tranches for SNPs, in a scattered manner
+    Args:
+        manifest_file (Path): Path object to the manifest file
+        snp_model_path ():
+        output_path ():
+        temp_path ():
+
+    Returns:
+        all jobs required to get where we're going
+    """
+
+    vcf_resources = get_all_fragments_from_manifest(manifest_file)
+
+    fragment_count = len(vcf_resources)
+    snps_recal_paths = [temp_path / f'snp_recalibrations_{i}' for i in range(fragment_count)]
+    snps_tranches_paths = [temp_path / f'snp_tranches_{i}' for i in range(fragment_count)]
+
+    snp_model_in_batch = get_batch().read_input(snp_model_path)
+
+    resources = get_localised_resources_for_vqsr()
+
+    # the list of all jobs (per-fragment, and the summary)
+    scatter_jobs: list[Job] = []
+
+    # to hold the resulting parts, as ResourceFiles
+    snp_tranche_fragments = []
+
+    # iterate over all fragments, make
+    for idx in range(fragment_count):
+        snps_recal_path = snps_recal_paths[idx]
+        snps_tranche_path = snps_tranches_paths[idx]
+
+        if can_reuse(snps_recal_path) and can_reuse(snps_tranche_path):
+            snp_tranche_fragments.append(get_batch().read_input(str(snps_tranche_path)))
+            continue
+
+        snps_recal_j = snps_recalibrator_scattered(
+            get_batch(),
+            siteonly_vcf=vcf_resources[idx],
+            model_file=snp_model_in_batch,
+            hapmap_resource_vcf=resources['hapmap'],
+            omni_resource_vcf=resources['omni'],
+            one_thousand_genomes_resource_vcf=resources['one_thousand_genomes'],
+            dbsnp_resource_vcf=resources['dbsnp'],
+            disk_size=50,
+            use_as_annotations=True,
+            job_attrs={'part': f'{idx + 1}/{fragment_count}'},
+        )
+        scatter_jobs.append(snps_recal_j)
+
+        # write the results out to GCP
+        get_batch().write_output(snps_recal_j.recalibration, str(snps_recal_paths[idx]))
+        get_batch().write_output(snps_recal_j.recalibration_idx, str(snps_recal_paths[idx]) + '.idx')
+        get_batch().write_output(snps_recal_j.tranches, str(snps_tranches_paths[idx]))
+
+    gather_tranches_j = snps_gather_tranches_job(
+        get_batch(),
+        tranches=snp_tranche_fragments,
+        disk_size=100,
+    )
+    gather_tranches_j.depends_on(*scatter_jobs)
+    scatter_jobs.append(gather_tranches_j)
+    get_batch().write_output(gather_tranches_j.out_tranches, output_path)
+    return scatter_jobs

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -1,0 +1,91 @@
+"""
+Create and run jobs relating to VQSR for the RD combiner
+"""
+
+from cpg_utils.config import reference_path
+from cpg_utils.hail_batch import get_batch
+
+from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job
+
+
+def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str):
+    """
+    Train VQSR indels on the sites-only VCF
+    Args:
+        sites_only_vcf ():
+        indel_recal ():
+        indel_tranches ():
+    """
+    resources = {
+        key: get_batch().read_input_group(
+            base=reference_path(f'broad/{key}_vcf'),
+            index=reference_path(f'broad/{key}_vcf_index'),
+        )
+        for key in [
+            'dbsnp',
+            'mills',
+            'axiom_poly',
+        ]
+    }
+    siteonly_vcf = get_batch().read_input_group(
+        **{
+            'vcf.gz': str(sites_only_vcf),
+            'vcf.gz.tbi': str(sites_only_vcf) + '.tbi',
+        },
+    )
+
+    indel_recalibrator_j = indel_recalibrator_job(
+        b=get_batch(),
+        siteonly_vcf=siteonly_vcf,
+        mills_resource_vcf=resources['mills'],
+        axiom_poly_resource_vcf=resources['axiom_poly'],
+        dbsnp_resource_vcf=resources['dbsnp'],
+        disk_size=100,
+        use_as_annotations=True,
+        is_small_callset=False,
+    )
+
+    get_batch().write_output(indel_recalibrator_j.recalibration, indel_recal)
+    get_batch().write_output(indel_recalibrator_j.recalibration_idx, indel_recal + '.idx')
+    get_batch().write_output(indel_recalibrator_j.tranches, indel_tranches)
+    return indel_recalibrator_j
+def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
+    """
+    Train VQSR indels on the sites-only VCF
+    Args:
+        sites_only_vcf ():
+        snp_model ():
+    """
+    resources = {
+        key: get_batch().read_input_group(
+            base=reference_path(f'broad/{key}_vcf'),
+            index=reference_path(f'broad/{key}_vcf_index'),
+        )
+        for key in [
+            'dbsnp',
+            'hapmap',
+            'omni',
+            'one_thousand_genomes',
+        ]
+    }
+    siteonly_vcf = get_batch().read_input_group(
+        **{
+            'vcf.gz': str(sites_only_vcf),
+            'vcf.gz.tbi': str(sites_only_vcf) + '.tbi',
+        },
+    )
+
+    snp_recalibrator_j = snps_recalibrator_create_model_job(
+        b=get_batch(),
+        siteonly_vcf=siteonly_vcf,
+        hapmap_resource_vcf=resources['hapmap'],
+        omni_resource_vcf=resources['omni'],
+        one_thousand_genomes_resource_vcf=resources['one_thousand_genomes'],
+        dbsnp_resource_vcf=resources['dbsnp'],
+        disk_size=100,
+        use_as_annotations=True,
+        is_small_callset=False,
+    )
+
+    get_batch().write_output(snp_recalibrator_j.model_file, snp_model)
+    return snp_recalibrator_j

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -219,6 +219,7 @@ def train_vqsr_snp_tranches(
                     counter_string: {
                         'recal': '{root}',
                         'recal_idx': '{root}.idx',
+                        'tranches': '{root}.tranches',
                     },
                 },
             )
@@ -235,7 +236,7 @@ def train_vqsr_snp_tranches(
                   VariantRecalibrator \\
                   -V input.vcf.bgz \\
                   -O {one_job_to_rule_them_all[counter_string].recal} \\
-                  --tranches-file {one_job_to_rule_them_all.tranches} \\
+                  --tranches-file {one_job_to_rule_them_all[counter_string].tranches} \\
                   --trust-all-polymorphic \\
                   {tranche_cmdl} \\
                   {an_cmdl} \\
@@ -256,10 +257,14 @@ def train_vqsr_snp_tranches(
                 str(snps_recal_paths[top_level_counter]),
             )
             get_batch().write_output(
-                one_job_to_rule_them_all.tranches,
+                one_job_to_rule_them_all[counter_string].recal_idx,
+                str(snps_recal_paths[top_level_counter]) + '.idx',
+            )
+            get_batch().write_output(
+                one_job_to_rule_them_all[counter_string].tranches,
                 str(snps_tranches_paths[top_level_counter]),
             )
-            snp_tranche_fragments.append(one_job_to_rule_them_all.tranches)
+            snp_tranche_fragments.append(one_job_to_rule_them_all[counter_string].tranches)
 
     gather_tranches_j = snps_gather_tranches_job(
         get_batch(),

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -222,6 +222,7 @@ def train_vqsr_snp_tranches(
         get_batch().write_output(snps_recal_j.recalibration, str(snps_recal_paths[idx]))
         get_batch().write_output(snps_recal_j.recalibration_idx, str(snps_recal_paths[idx]) + '.idx')  # tidy this up
         get_batch().write_output(snps_recal_j.tranches, str(snps_tranches_paths[idx]))
+        snp_tranche_fragments.append(snps_recal_j.tranches)
 
     gather_tranches_j = snps_gather_tranches_job(
         get_batch(),

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -20,7 +20,7 @@ from cpg_workflows.jobs.vqsr import (
 from cpg_workflows.resources import HIGHMEM
 from cpg_workflows.utils import VCF_GZ, VCF_GZ_TBI, can_reuse, chunks
 
-FRAGMENTS_PER_JOB: int = 100
+FRAGMENTS_PER_JOB: int = 80
 
 
 @lru_cache(2)

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -235,8 +235,8 @@ def train_vqsr_snp_tranches(
                   "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
                   VariantRecalibrator \\
                   -V input.vcf.bgz \\
-                  -O {one_job_to_rule_them_all[counter_string].recal} \\
-                  --tranches-file {one_job_to_rule_them_all[counter_string].tranches} \\
+                  -O {one_job_to_rule_them_all[counter_string]['recal']} \\
+                  --tranches-file {one_job_to_rule_them_all[counter_string]['tranches']} \\
                   --trust-all-polymorphic \\
                   {tranche_cmdl} \\
                   {an_cmdl} \\
@@ -253,15 +253,15 @@ def train_vqsr_snp_tranches(
 
             # write the results out to GCP
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string].recal,
+                one_job_to_rule_them_all[counter_string]['recal'],
                 str(snps_recal_paths[top_level_counter]),
             )
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string].recal_idx,
+                one_job_to_rule_them_all[counter_string]['recal_idx'],
                 str(snps_recal_paths[top_level_counter]) + '.idx',
             )
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string].tranches,
+                one_job_to_rule_them_all[counter_string]['tranches'],
                 str(snps_tranches_paths[top_level_counter]),
             )
             snp_tranche_fragments.append(one_job_to_rule_them_all[counter_string].tranches)

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -249,10 +249,12 @@ def train_vqsr_snp_tranches(
                   -resource:omni,known=false,training=true,truth=true,prior=12 {resources['omni'].base} \\
                   -resource:1000G,known=false,training=true,truth=false,prior=10 {resources['one_thousand_genomes'].base} \\
                   -resource:dbsnp,known=true,training=false,truth=false,prior=7 {resources['dbsnp'].base}
+                touch {one_job_to_rule_them_all[counter_string]['recal_idx']}
                 """,
             )
 
             # write the results out to GCP
+            print(one_job_to_rule_them_all[counter_string])
             get_batch().write_output(
                 one_job_to_rule_them_all[counter_string].recal,
                 str(snps_recal_paths[top_level_counter]),

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -20,7 +20,7 @@ from cpg_workflows.jobs.vqsr import (
 from cpg_workflows.resources import HIGHMEM
 from cpg_workflows.utils import VCF_GZ, VCF_GZ_TBI, can_reuse, chunks
 
-FRAGMENTS_PER_JOB: int = 80
+FRAGMENTS_PER_JOB: int = 100
 
 
 @lru_cache(2)

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -4,7 +4,6 @@ Create and run jobs relating to VQSR for the RD combiner
 
 from cpg_utils.config import reference_path
 from cpg_utils.hail_batch import get_batch
-
 from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job
 
 
@@ -49,6 +48,8 @@ def train_vqsr_indels(sites_only_vcf: str, indel_recal: str, indel_tranches: str
     get_batch().write_output(indel_recalibrator_j.recalibration_idx, indel_recal + '.idx')
     get_batch().write_output(indel_recalibrator_j.tranches, indel_tranches)
     return indel_recalibrator_j
+
+
 def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
     """
     Train VQSR indels on the sites-only VCF

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -10,7 +10,13 @@ from hailtop.batch.job import Job
 from cpg_utils import Path, to_path
 from cpg_utils.config import image_path, reference_path
 from cpg_utils.hail_batch import get_batch
-from cpg_workflows.jobs.vqsr import indel_recalibrator_job, snps_recalibrator_create_model_job, snps_recalibrator_scattered, snps_gather_tranches_job, SNP_RECALIBRATION_TRANCHE_VALUES, SNP_ALLELE_SPECIFIC_FEATURES
+from cpg_workflows.jobs.vqsr import (
+    indel_recalibrator_job,
+    snps_recalibrator_create_model_job,
+    snps_gather_tranches_job,
+    SNP_RECALIBRATION_TRANCHE_VALUES,
+    SNP_ALLELE_SPECIFIC_FEATURES,
+)
 from cpg_workflows.resources import HIGHMEM
 from cpg_workflows.utils import can_reuse
 
@@ -184,7 +190,7 @@ def train_vqsr_snp_tranches(
             f"""set -euo pipefail
 
         MODEL_REPORT={snp_model_in_batch}
-        
+
         mv {vcf_resources[idx]['vcf.gz']} input.vcf.bgz
         mv {vcf_resources[idx]['vcf.gz.tbi']} input.vcf.bgz.tbi
 
@@ -210,18 +216,6 @@ def train_vqsr_snp_tranches(
         """,
         )
 
-        # snps_recal_j = snps_recalibrator_scattered(
-        #     get_batch(),
-        #     siteonly_vcf=vcf_resources[idx],
-        #     model_file=snp_model_in_batch,
-        #     hapmap_resource_vcf=resources['hapmap'],
-        #     omni_resource_vcf=resources['omni'],
-        #     one_thousand_genomes_resource_vcf=resources['one_thousand_genomes'],
-        #     dbsnp_resource_vcf=resources['dbsnp'],
-        #     disk_size=50,
-        #     use_as_annotations=True,
-        #     job_attrs={'part': f'{idx + 1}/{fragment_count}'},
-        # )
         scatter_jobs.append(snps_recal_j)
 
         # write the results out to GCP

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -173,6 +173,8 @@ def train_vqsr_snp_tranches(
     # if we start this as -1, we can increment at the start of the loop, making the index counting easier to track
     top_level_counter = -1
 
+    chunk_counter = 0
+
     # iterate over all fragments, but in chunks of FRAGMENTS_PER_JOB
     for fragment_chunk in chunks(vcf_resources, FRAGMENTS_PER_JOB):
         # NB this VQSR training stage is scattered, and we have a high number of very small VCF fragments
@@ -181,7 +183,10 @@ def train_vqsr_snp_tranches(
         # we can batch fragments into fewer jobs, each stacking multiple fragments together but only requiring
         # one block of reference data to be loaded.
         # candidate splitting is 100-fragments-per-job, for a ~99% cost saving
-        one_job_to_rule_them_all = get_batch().new_job(f'{job_name}, Chunk 1')
+
+        chunk_counter += 1
+
+        one_job_to_rule_them_all = get_batch().new_job(f'{job_name}, Chunk {chunk_counter}')
         one_job_to_rule_them_all.image(image_path('gatk'))
 
         # add this job to the list of scatter jobs

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -18,7 +18,7 @@ from cpg_workflows.jobs.vqsr import (
     snps_recalibrator_create_model_job,
 )
 from cpg_workflows.resources import HIGHMEM
-from cpg_workflows.utils import can_reuse, chunks, VCF_GZ, VCF_GZ_TBI
+from cpg_workflows.utils import VCF_GZ, VCF_GZ_TBI, can_reuse, chunks
 
 FRAGMENTS_PER_JOB: int = 100
 

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -234,6 +234,8 @@ def train_vqsr_snp_tranches(
                 gatk --java-options \
                   "{res.java_mem_options()} {res.java_gc_thread_options()}" \\
                   VariantRecalibrator \\
+                  --verbosity WARNING \\
+                  --QUIET \\
                   -V input.vcf.bgz \\
                   -O {chunk_job[counter_string]['recal']} \\
                   --tranches-file {chunk_job[counter_string]['tranches']} \\

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -242,7 +242,8 @@ def train_vqsr_snp_tranches(
                   {an_cmdl} \\
                   -mode SNP \\
                   --use-allele-specific-annotations \\
-                  --input-model {snp_model_in_batch} --output-tranches-for-scatter \\
+                  --input-model {snp_model_in_batch} \\
+                  --output-tranches-for-scatter \\
                   --max-gaussians 6 \\
                   -resource:hapmap,known=false,training=true,truth=true,prior=15 {resources['hapmap'].base} \\
                   -resource:omni,known=false,training=true,truth=true,prior=12 {resources['omni'].base} \\
@@ -253,15 +254,15 @@ def train_vqsr_snp_tranches(
 
             # write the results out to GCP
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string]['recal'],
+                one_job_to_rule_them_all[counter_string].recal,
                 str(snps_recal_paths[top_level_counter]),
             )
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string]['recal_idx'],
+                one_job_to_rule_them_all[counter_string].recal_idx,
                 str(snps_recal_paths[top_level_counter]) + '.idx',
             )
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string]['tranches'],
+                one_job_to_rule_them_all[counter_string].tranches,
                 str(snps_tranches_paths[top_level_counter]),
             )
             snp_tranche_fragments.append(one_job_to_rule_them_all[counter_string].tranches)

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -33,7 +33,7 @@ def get_all_fragments_from_manifest(manifest_file: Path) -> list[ResourceGroup]:
         for line in f:
             vcf_path = manifest_folder / line.strip()
             resource_objects.append(
-                get_batch().read_input_group(**{'vcf.bgz': vcf_path, 'vcf.bgz.tbi': f'{vcf_path}.tbi'}),
+                get_batch().read_input_group(**{'vcf.gz': vcf_path, 'vcf.gz.tbi': f'{vcf_path}.tbi'}),
             )
 
     return resource_objects

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -235,7 +235,7 @@ def train_vqsr_snp_tranches(
                   VariantRecalibrator \\
                   -V input.vcf.bgz \\
                   -O {one_job_to_rule_them_all[counter_string].recal} \\
-                  --tranches-file {one_job_to_rule_them_all[counter_string].tranches} \\
+                  --tranches-file {one_job_to_rule_them_all.tranches} \\
                   --trust-all-polymorphic \\
                   {tranche_cmdl} \\
                   {an_cmdl} \\
@@ -256,7 +256,7 @@ def train_vqsr_snp_tranches(
                 str(snps_recal_paths[top_level_counter]),
             )
             get_batch().write_output(
-                one_job_to_rule_them_all[counter_string].tranches,
+                one_job_to_rule_them_all.tranches,
                 str(snps_tranches_paths[top_level_counter]),
             )
             snp_tranche_fragments.append(one_job_to_rule_them_all.tranches)

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -128,10 +128,11 @@ def train_vqsr_snps(sites_only_vcf: str, snp_model: str):
 
 
 def train_vqsr_snp_tranches(
-    manifest_file:Path,
-    snp_model_path:str,
-    output_path:str,
-    temp_path:Path,
+    manifest_file: Path,
+    snp_model_path: str,
+    output_path: str,
+    temp_path: Path,
+    job_name: str = 'TrainVqsrSnpTranches',
 ) -> list[Job]:
     """
     train vqsr tranches for SNPs, in a scattered manner
@@ -170,7 +171,7 @@ def train_vqsr_snp_tranches(
             snp_tranche_fragments.append(get_batch().read_input(str(snps_tranche_path)))
             continue
 
-        snps_recal_j = get_batch().new_job('VQSR: SNPsVariantRecalibratorScattered', {'part': f'{idx + 1}/{fragment_count}'})
+        snps_recal_j = get_batch().new_job(job_name, {'part': f'{idx + 1}/{fragment_count}'})
         snps_recal_j.image(image_path('gatk'))
 
         res = HIGHMEM.set_resources(snps_recal_j, ncpu=4, storage_gb=50)

--- a/cpg_workflows/jobs/rd_combiner/vqsr.py
+++ b/cpg_workflows/jobs/rd_combiner/vqsr.py
@@ -8,7 +8,7 @@ from hailtop.batch.job import Job
 from hailtop.batch.resource import ResourceFile, ResourceGroup
 
 from cpg_utils import Path
-from cpg_utils.config import image_path, reference_path
+from cpg_utils.config import config_retrieve, image_path, reference_path
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.vqsr import (
     SNP_ALLELE_SPECIFIC_FEATURES,
@@ -227,7 +227,6 @@ def train_vqsr_snp_tranches(
             chunk_job.command(
                 f"""
                 set -euo pipefail
-
                 MODEL_REPORT={snp_model_in_batch}
                 mv {vcf_resource[VCF_GZ]} input.vcf.bgz
                 mv {vcf_resource[VCF_GZ_TBI]} input.vcf.bgz.tbi
@@ -263,6 +262,7 @@ def train_vqsr_snp_tranches(
 
     # one final job to write the success indicator
     final_job = get_batch().new_bash_job('Completion message')
+    final_job.image(config_retrieve(['workflow', 'driver_image']))
     final_job.command(f'echo "All tranches trained" > {final_job.output}')
     final_job.depends_on(*scatter_jobs)
     scatter_jobs.append(final_job)

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -72,7 +72,7 @@ def main(
 
     mt.write(dense_mt_out, overwrite=True)
 
-    if not sites_only or separate_header:
+    if not (sites_only or separate_header):
         return
 
     # read the dense MT and obtain the sites-only HT

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -52,10 +52,10 @@ def main(
 
     vds = hl.vds.read_vds(vds_in)
 
-    get_logger(__file__).info('Splitting multiallelics')
+    get_logger().info('Splitting multiallelics')
     vds = hl.vds.split_multi(vds)
 
-    get_logger(__file__).info('Densifying data...')
+    get_logger().info('Densifying data...')
     mt = hl.vds.to_dense_mt(vds)
 
     # remove any monoallelic or non-ref-in-any-sample sites
@@ -81,12 +81,12 @@ def main(
 
     # write a directory containing all the per-partition VCF fragments, each with a VCF header
     if sites_only:
-        get_logger(__file__).info('Writing sites-only VCF, header-per-shard')
+        get_logger().info('Writing sites-only VCF, header-per-shard')
         hl.export_vcf(sites_only_ht, sites_only, tabix=True, parallel='header_per_shard')
 
     # write a directory containing all the per-partition VCF fragments, with a separate VCF header file
     if separate_header:
-        get_logger(__file__).info('Writing sites-only VCF, separate-header')
+        get_logger().info('Writing sites-only VCF, separate-header')
         hl.export_vcf(sites_only_ht, separate_header, tabix=True, parallel='separate_header')
 
 

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -57,7 +57,7 @@ def main(
 
     # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
     # remove any monoallelic or non-ref-in-any-sample sites
-    mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.GT.is_non_ref())))
+    mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.LGT.is_non_ref())))
 
     # annotate site-level DP to avoid name collision
     mt = mt.annotate_rows(

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -65,7 +65,7 @@ def main(
     # annotate site-level DP to avoid name collision
     mt = mt.annotate_rows(
         site_dp=hl.agg.sum(mt.DP),
-        ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
+        ANS=hl.agg.count_where(hl.is_defined(mt.GT)) * 2,
     )
 
     # content shared with large_cohort.site_only_vcf.py

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -18,13 +18,12 @@ from argparse import ArgumentParser
 
 import hail as hl
 
-from gnomad.utils.sparse_mt import default_compute_info
-from gnomad.utils.vcf import adjust_vcf_incompatible_types
-
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
 from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import get_logger
+from gnomad.utils.sparse_mt import default_compute_info
+from gnomad.utils.vcf import adjust_vcf_incompatible_types
 
 
 def main(

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -52,9 +52,6 @@ def main(
 
     vds = hl.vds.read_vds(vds_in)
 
-    get_logger().info('Splitting multiallelics')
-    vds = hl.vds.split_multi(vds)
-
     get_logger().info('Densifying data...')
     mt = hl.vds.to_dense_mt(vds)
 
@@ -65,7 +62,7 @@ def main(
     # annotate site-level DP to avoid name collision
     mt = mt.annotate_rows(
         site_dp=hl.agg.sum(mt.DP),
-        ANS=hl.agg.count_where(hl.is_defined(mt.GT)) * 2,
+        ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
     )
 
     # content shared with large_cohort.site_only_vcf.py
@@ -84,6 +81,9 @@ def main(
 
     # annotate this info back into the main MatrixTable
     mt = mt.annotate_rows(info=info_ht[mt.row_key])
+
+    get_logger().info('Splitting multiallelics')
+    mt = hl.split_multi_hts(mt)
 
     mt.write(dense_mt_out, overwrite=True)
 

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -82,6 +82,10 @@ def main(
     # annotate this info back into the main MatrixTable
     mt = mt.annotate_rows(info=info_ht[mt.row_key])
 
+    # unpack mt.info.info back into mt.info
+    mt = mt.transmute_rows(**mt.info)
+    mt = mt.drop('gvcf_info')
+
     get_logger().info('Splitting multiallelics')
     mt = hl.split_multi_hts(mt)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -103,7 +103,7 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
             get_logger(__file__).info(f'Checking if VDS exists: {outputs["vds"]}: {outputs["vds"].exists()}')  # type: ignore
             return self.make_outputs(multicohort, outputs)
 
-        j = get_batch().new_python_job('Combiner', self.get_job_attrs())
+        j = get_batch().new_python_job('CreateVdsFromGvcfsWithHailCombiner', self.get_job_attrs())
         j.image(config_retrieve(['workflow', 'driver_image']))
         j.memory(config_retrieve(['combiner', 'memory']))
         j.storage(config_retrieve(['combiner', 'storage']))
@@ -150,7 +150,7 @@ class CreateDenseMtFromVdsWithHail(MultiCohortStage):
 
         output = self.expected_outputs(multicohort)
 
-        j = get_batch().new_job('Dense Subset')
+        j = get_batch().new_job('CreateDenseMtFromVdsWithHail')
         j.image(config_retrieve(['workflow', 'driver_image']))
         j.command(
             'mt_from_vds '
@@ -198,6 +198,7 @@ class ConcatenateVcfFragmentsWithGcloud(MultiCohortStage):
             manifest_path=manifest_file,
             intermediates_path=str(self.prefix / 'temporary_compose_intermediates'),
             output_path=str(outputs['vcf']),
+            job_name=self.name,
         )
 
         return self.make_outputs(multicohort, data=outputs, jobs=jobs)

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -124,7 +124,7 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
 
 @stage(required_stages=[CreateVdsFromGvcfsWithHailCombiner], analysis_type='matrixtable', analysis_keys=['mt'])
-class CreateDenseMtFromVdsWithHail(MultiCohortStage):
+class CreateCreateDenseMtFromVdsWithHailWithHail(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict:
         """
         the MT and both shard_manifest files are Paths, so this stage will rerun if any of those are missing
@@ -184,7 +184,7 @@ class ConcatenateVcfFragmentsWithGcloud(MultiCohortStage):
             multicohort.analysis_dataset.prefix()
             / 'rd_combiner'
             / get_workflow().output_version
-            / 'DenseMTFromVDS'
+            / 'CreateDenseMtFromVdsWithHail'
             / f'{multicohort.name}_separate.vcf.bgz'
             / SHARD_MANIFEST
         )
@@ -207,7 +207,7 @@ class ConcatenateVcfFragmentsWithGcloud(MultiCohortStage):
 class TrainVqsrIndelModelOnCombinerData(MultiCohortStage):
     """
     Train VQSR Indel model on the combiner data
-    This is disconnected from the DenseMTFromVDS stage, but requires it to be run first
+    This is disconnected from the CreateDenseMtFromVdsWithHail stage, but requires it to be run first
     """
 
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
@@ -235,7 +235,7 @@ class TrainVqsrIndelModelOnCombinerData(MultiCohortStage):
 class TrainVqsrSnpModelOnCombinerData(MultiCohortStage):
     """
     Train VQSR SNP model on the combiner data
-    This is disconnected from the DenseMTFromVDS stage, but requires it to be run first
+    This is disconnected from the CreateDenseMtFromVdsWithHail stage, but requires it to be run first
     """
 
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
@@ -273,7 +273,7 @@ class TrainVqsrSnpTranches(MultiCohortStage):
             multicohort.analysis_dataset.prefix()
             / 'rd_combiner'
             / get_workflow().output_version
-            / 'DenseMTFromVDS'
+            / 'CreateDenseMtFromVdsWithHail'
             / f'{multicohort.name}_separate.vcf.bgz'
             / SHARD_MANIFEST
         )
@@ -306,7 +306,7 @@ class RunTrainedVqsrOnCombinerFragments(MultiCohortStage):
             multicohort.analysis_dataset.prefix()
             / 'rd_combiner'
             / get_workflow().output_version
-            / 'DenseMTFromVDS'
+            / 'CreateDenseMtFromVdsWithHail'
             / f'{multicohort.name}.vcf.bgz'
             / SHARD_MANIFEST
         )

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -2,7 +2,7 @@ from cpg_utils import Path
 from cpg_utils.config import config_retrieve, genome_build
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.gcloud_composer import gcloud_compose_vcf_from_manifest
-from cpg_workflows.jobs.rd_combiner.vqsr import train_vqsr_indels, train_vqsr_snps
+from cpg_workflows.jobs.rd_combiner.vqsr import train_vqsr_indels, train_vqsr_snp_tranches, train_vqsr_snps
 from cpg_workflows.targets import MultiCohort
 from cpg_workflows.utils import get_logger
 from cpg_workflows.workflow import (
@@ -255,3 +255,62 @@ class TrainVQSRSNPModelOnCombinerData(MultiCohortStage):
             snp_model=str(outputs['snp_model']),
         )
         return self.make_outputs(multicohort, data=outputs, jobs=snp_calibration_job)
+
+
+@stage(required_stages=TrainVQSRSNPModelOnCombinerData)
+class TrainVqsrSnpTranches(MultiCohortStage):
+    """
+    Scattered training of VQSR tranches for SNPs
+    """
+
+    def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
+
+        return {'tranches': self.prefix / 'snp_tranches'}
+
+    def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
+
+        manifest_file = (
+            multicohort.analysis_dataset.prefix()
+            / 'rd_combiner'
+            / get_workflow().output_version
+            / 'DenseMTFromVDS'
+            / f'{multicohort.name}_separate.vcf.bgz'
+            / SHARD_MANIFEST
+        )
+
+        if not manifest_file.exists():
+            raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the rd_combiner workflow')
+
+        outputs = self.expected_outputs(multicohort)
+        snp_model_path = inputs.as_path(target=multicohort, stage=TrainVQSRSNPModelOnCombinerData, key='snp_model')
+        temp_path = self.tmp_prefix / 'vqsr_snp_tranches'
+
+        jobs = train_vqsr_snp_tranches(
+            manifest_file=manifest_file,
+            snp_model_path=str(snp_model_path),
+            output_path=str(outputs['tranches']),
+            temp_path=temp_path,
+        )
+        return self.make_outputs(multicohort, data=outputs, jobs=jobs)
+
+
+@stage(analysis_keys=['vcf'], analysis_type='qc', required_stages=TrainVQSRIndelModelOnCombinerData)
+class RunVQSROnCombinerData(MultiCohortStage):
+    def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
+        # should this be one per fragment?
+        return {'vcf': self.prefix / 'vqsr.vcf.bgz'}
+
+    def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
+
+        manifest_file = (
+            multicohort.analysis_dataset.prefix()
+            / 'rd_combiner'
+            / get_workflow().output_version
+            / 'DenseMTFromVDS'
+            / f'{multicohort.name}.vcf.bgz'
+            / SHARD_MANIFEST
+        )
+
+        if not manifest_file.exists():
+            raise ValueError(f'Manifest file {manifest_file} does not exist, run the rd_combiner workflow')
+        ...

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -8,6 +8,7 @@ from cpg_workflows.workflow import (
     MultiCohortStage,
     StageInput,
     StageOutput,
+    get_workflow,
     stage,
 )
 from metamist.graphql import gql, query
@@ -178,7 +179,7 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
         and the result will be a spec-compliant VCF
         """
 
-        manifest_file = self.prefix / f'{multicohort.name}_separate.vcf.bgz' / SHARD_MANIFEST
+        manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}_separate.vcf.bgz' / SHARD_MANIFEST
 
         if not manifest_file.exists():
             raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the previous workflow')
@@ -207,7 +208,7 @@ class VQSROnCombinerData(MultiCohortStage):
         This means the VQSR logic should be far simpler - we don't need to subdivide the input by regions
         """
 
-        _manifest_file = self.prefix / f'{multicohort.name}.vcf.bgz' / SHARD_MANIFEST
+        _manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}.vcf.bgz' / SHARD_MANIFEST
 
         outputs = self.expected_outputs(multicohort)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -275,7 +275,7 @@ class TrainVqsrSnpTranches(MultiCohortStage):
             / 'rd_combiner'
             / get_workflow().output_version
             / 'CreateDenseMtFromVdsWithHail'
-            / f'{multicohort.name}_separate.vcf.bgz'
+            / f'{multicohort.name}.vcf.bgz'
             / SHARD_MANIFEST
         )
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -195,7 +195,7 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
 
         jobs = gcloud_compose_vcf_from_manifest(
             manifest_path=manifest_file,
-            intermediates_path=str(self.tmp_prefix),
+            intermediates_path=str(self.prefix / 'temporary_compose_intermediates'),
             output_path=str(outputs['vcf']),
         )
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -129,8 +129,9 @@ class DenseMTFromVDS(MultiCohortStage):
         """
         the MT and both shard_manifest files are Paths, so this stage will rerun if any of those are missing
         the VCFs are written as a directory, rather than a single VCF, so we can't check its existence well
+
+        Needs a range of INFO fields to be present in the VCF
         """
-        # generate hashes once
         prefix = self.prefix
 
         return {

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -178,8 +178,14 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
         This means we can combine the VCF header and data fragments through concatenation
         and the result will be a spec-compliant VCF
         """
-
-        manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}_separate.vcf.bgz' / SHARD_MANIFEST
+        manifest_file = (
+            multicohort.analysis_dataset.prefix()
+            / 'rd_combiner'
+            / get_workflow().output_version
+            / 'DenseMTFromVDS'
+            / f'{multicohort.name}_separate.vcf.bgz'
+            / SHARD_MANIFEST
+        )
 
         if not manifest_file.exists():
             raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the previous workflow')
@@ -208,7 +214,14 @@ class VQSROnCombinerData(MultiCohortStage):
         This means the VQSR logic should be far simpler - we don't need to subdivide the input by regions
         """
 
-        _manifest_file = get_workflow().prefix / 'rd_combiner' / f'{multicohort.name}.vcf.bgz' / SHARD_MANIFEST
+        _manifest_file = (
+            multicohort.analysis_dataset.prefix()
+            / 'rd_combiner'
+            / get_workflow().output_version
+            / 'DenseMTFromVDS'
+            / f'{multicohort.name}.vcf.bgz'
+            / SHARD_MANIFEST
+        )
 
         outputs = self.expected_outputs(multicohort)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -29,7 +29,7 @@ LATEST_ANALYSIS_QUERY = gql(
     }
 """,
 )
-SHARD_MANIFEST = 'shard_manifest.txt'
+SHARD_MANIFEST = 'shard-manifest.txt'
 
 
 def query_for_latest_vds(dataset: str, entry_type: str = 'combiner') -> dict | None:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -255,25 +255,3 @@ class TrainVQSRSNPModelOnCombinerData(MultiCohortStage):
             snp_model=str(outputs['snp_model']),
         )
         return self.make_outputs(multicohort, data=outputs, jobs=snp_calibration_job)
-
-
-# @stage(analysis_keys=['vcf'], analysis_type='qc', required_stages=TrainVQSRIndelModelOnCombinerData)
-# class RunVQSROnCombinerData(MultiCohortStage):
-#     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
-#         # should this be one per fragment?
-#         return {'vcf': self.prefix / 'vqsr.vcf.bgz'}
-#
-#     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
-#
-#         manifest_file = (
-#             multicohort.analysis_dataset.prefix()
-#             / 'rd_combiner'
-#             / get_workflow().output_version
-#             / 'DenseMTFromVDS'
-#             / f'{multicohort.name}.vcf.bgz'
-#             / SHARD_MANIFEST
-#         )
-#
-#         if not manifest_file.exists():
-#             raise ValueError(f'Manifest file {manifest_file} does not exist, run the rd_combiner workflow')
-#         ...

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -193,7 +193,11 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
 
         outputs = self.expected_outputs(multicohort)
 
-        jobs = gcloud_compose_vcf_from_manifest(str(manifest_file), str(self.tmp_prefix), str(outputs['vcf']))
+        jobs = gcloud_compose_vcf_from_manifest(
+            manifest_path=manifest_file,
+            intermediates_path=str(self.tmp_prefix),
+            output_path=str(outputs['vcf']),
+        )
 
         return self.make_outputs(multicohort, data=outputs, jobs=jobs)
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -124,7 +124,7 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
 
 @stage(required_stages=[CreateVdsFromGvcfsWithHailCombiner], analysis_type='matrixtable', analysis_keys=['mt'])
-class CreateCreateDenseMtFromVdsWithHailWithHail(MultiCohortStage):
+class CreateDenseMtFromVdsWithHail(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict:
         """
         the MT and both shard_manifest files are Paths, so this stage will rerun if any of those are missing

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -188,7 +188,7 @@ class ComposeFragmentsToSingleVCF(MultiCohortStage):
         )
 
         if not manifest_file.exists():
-            raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the previous workflow')
+            raise ValueError(f'Manifest file {str(manifest_file)} does not exist, run the rd_combiner workflow')
 
         outputs = self.expected_outputs(multicohort)
 
@@ -214,7 +214,7 @@ class VQSROnCombinerData(MultiCohortStage):
         This means the VQSR logic should be far simpler - we don't need to subdivide the input by regions
         """
 
-        _manifest_file = (
+        manifest_file = (
             multicohort.analysis_dataset.prefix()
             / 'rd_combiner'
             / get_workflow().output_version
@@ -222,6 +222,9 @@ class VQSROnCombinerData(MultiCohortStage):
             / f'{multicohort.name}.vcf.bgz'
             / SHARD_MANIFEST
         )
+
+        if not manifest_file.exists():
+            raise ValueError(f'Manifest file {manifest_file} does not exist, run the rd_combiner workflow')
 
         outputs = self.expected_outputs(multicohort)
 

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -53,7 +53,6 @@ def get_logger(
 
         # create a named logger
         new_logger = logging.getLogger(logger_name)
-        new_logger.setLevel(log_level)
 
         # unless otherwise specified, use coloredlogs
         if config_retrieve(['workflow', 'logger', logger_name, 'use_colored_logs'], True):

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -35,7 +35,6 @@ VCF_GZ = 'vcf.gz'
 VCF_GZ_TBI = 'vcf.gz.tbi'
 
 
-
 def get_logger(
     logger_name: str = 'cpg_workflows',
     log_level: int = logging.INFO,

--- a/cpg_workflows/utils.py
+++ b/cpg_workflows/utils.py
@@ -29,6 +29,12 @@ DEFAULT_LOG_FORMAT = config_retrieve(
 )
 LOGGERS: dict[str, logging.Logger] = {}
 
+VCF_BGZ = 'vcf.bgz'
+VCF_GZ_TBI = 'vcf.bgz.tbi'
+VCF_GZ = 'vcf.gz'
+VCF_GZ_TBI = 'vcf.gz.tbi'
+
+
 
 def get_logger(
     logger_name: str = 'cpg_workflows',

--- a/main.py
+++ b/main.py
@@ -27,8 +27,8 @@ from cpg_workflows.stages.outrider import Outrider
 from cpg_workflows.stages.rd_combiner import (
     CreateDenseMtFromVdsWithHail,
     CreateVdsFromGvcfsWithHailCombiner,
-    TrainVqsrIndelModelOnCombinerData,
     GatherTrainedVqsrSnpTranches,
+    TrainVqsrIndelModelOnCombinerData,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram

--- a/main.py
+++ b/main.py
@@ -24,7 +24,12 @@ from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, Validati
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.rd_combiner import ComposeFragmentsToSingleVCF, DenseMTFromVDS, GVCFCombiner
+from cpg_workflows.stages.rd_combiner import (
+    ComposeFragmentsToSingleVCF,
+    DenseMTFromVDS,
+    GVCFCombiner,
+    TrainVQSRIndelModelOnCombinerData,
+)
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels
@@ -41,7 +46,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
-    'rd_post_combiner': [ComposeFragmentsToSingleVCF],
+    'rd_post_combiner': [ComposeFragmentsToSingleVCF, TrainVQSRIndelModelOnCombinerData],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -25,10 +25,10 @@ from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVq
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
 from cpg_workflows.stages.rd_combiner import (
-    DenseMTFromVDS,
-    GVCFCombiner,
-    TrainVQSRIndelModelOnCombinerData,
-    TrainVQSRSNPModelOnCombinerData,
+    CreateVdsFromGvcfsWithHailCombiner,
+    CreateDenseMtFromVdsWithHail,
+    TrainVqsrIndelModelOnCombinerData,
+    TrainVqsrSnpTranches,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
@@ -45,8 +45,8 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_snps_indels_annotation': [MtToEsLrSNPsIndels],
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
-    'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
-    'rd_post_combiner': [TrainVQSRIndelModelOnCombinerData, TrainVQSRSNPModelOnCombinerData],
+    'rd_combiner': [CreateVdsFromGvcfsWithHailCombiner, CreateDenseMtFromVdsWithHail],
+    'rd_post_combiner': [TrainVqsrIndelModelOnCombinerData, TrainVqsrSnpTranches],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, Validati
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.rd_combiner import DenseMTFromVDS, GVCFCombiner
+from cpg_workflows.stages.rd_combiner import DenseMTFromVDS, GVCFCombiner, ComposeFragmentsToSingleVCF
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels
@@ -41,6 +41,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
+    'rd_post_combiner': [ComposeFragmentsToSingleVCF],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from cpg_workflows.stages.rd_combiner import (
     CreateDenseMtFromVdsWithHail,
     CreateVdsFromGvcfsWithHailCombiner,
     TrainVqsrIndelModelOnCombinerData,
-    TrainVqsrSnpTranches,
+    GatherTrainedVqsrSnpTranches,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
@@ -46,7 +46,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [CreateVdsFromGvcfsWithHailCombiner, CreateDenseMtFromVdsWithHail],
-    'rd_post_combiner': [TrainVqsrIndelModelOnCombinerData, TrainVqsrSnpTranches],
+    'rd_post_combiner': [TrainVqsrIndelModelOnCombinerData, GatherTrainedVqsrSnpTranches],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, Validati
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
-from cpg_workflows.stages.rd_combiner import DenseMTFromVDS, GVCFCombiner, ComposeFragmentsToSingleVCF
+from cpg_workflows.stages.rd_combiner import ComposeFragmentsToSingleVCF, DenseMTFromVDS, GVCFCombiner
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels

--- a/main.py
+++ b/main.py
@@ -25,10 +25,10 @@ from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVq
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
 from cpg_workflows.stages.rd_combiner import (
-    ComposeFragmentsToSingleVCF,
     DenseMTFromVDS,
     GVCFCombiner,
     TrainVQSRIndelModelOnCombinerData,
+    TrainVQSRSNPModelOnCombinerData,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
 from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
@@ -46,7 +46,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],
     'rd_combiner': [GVCFCombiner, DenseMTFromVDS],
-    'rd_post_combiner': [ComposeFragmentsToSingleVCF, TrainVQSRIndelModelOnCombinerData],
+    'rd_post_combiner': [TrainVQSRIndelModelOnCombinerData, TrainVQSRSNPModelOnCombinerData],
     'seqr_loader': [
         DatasetVCF,
         AnnotateDataset,

--- a/main.py
+++ b/main.py
@@ -25,8 +25,8 @@ from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVq
 from cpg_workflows.stages.mito import MitoReport
 from cpg_workflows.stages.outrider import Outrider
 from cpg_workflows.stages.rd_combiner import (
-    CreateVdsFromGvcfsWithHailCombiner,
     CreateDenseMtFromVdsWithHail,
+    CreateVdsFromGvcfsWithHailCombiner,
     TrainVqsrIndelModelOnCombinerData,
     TrainVqsrSnpTranches,
 )


### PR DESCRIPTION
This is an expansion/replacement of #1022

See https://batch.hail.populationgenomics.org.au/batches/531195
https://batch.hail.populationgenomics.org.au/batches/531646 for VQSR training (prior to current batching process)
https://batch.hail.populationgenomics.org.au/batches/531737 for VQSR training with 80 VCF fragments per job. This change drops the price of VQSR training from $54 to $1.30

This makes a lot of changes to the RD combiner process (which wasn't fit for purpose... The sites-only VCFs it generated had no INFO content. That's fine for VEP, very not fine for VQSR), renames previous steps and adds three more:

New names: `CreateVdsFromGvcfsWithHailCombiner` & `CreateDenseMtFromVdsWithHail` 

1. `ConcatenateVcfFragmentsWithGcloud` - uses `gcloud storage compose` to build a single sites-only VCF from the per-partition fragments, to be used in training the VQSR model
2. `TrainVqsrIndelModelOnCombinerData` - trains the VQSR indel model on the whole-genome sites-only VCF
3. `TrainVqsrSnpModelOnCombinerData` - trains the VQSR SNP model on the whole-genome sites-only VCF
4. `TrainVqsrSnpTranches` - scattered per-fragment training of VQSR on VCF fragments to get SNP tranches
5. `GatherTrainedVqsrSnpTranches` - gather the separate Tranche files into a single file. This needed to be a separate job for dodgy hail reasons. 

2, 3, 4, & 5 there were previously part of the single VQSR Stage (training, generating intervals, splitting, running VQSR, joining into a single VCF), but IMO that's an unmaintainable spaghetti code nightmare, so I'm rewriting the whole workflow as discrete sections