### PR TITLE
Override JAR spec for the ancestry PCA stage.

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -9,7 +9,8 @@ from attr import dataclass
 import hail as hl
 
 from cpg_utils import Path, to_path
-from cpg_utils.config import get_config, reference_path
+from cpg_utils.config import config_retrieve, get_config, reference_path
+from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import can_reuse
 from gnomad.sample_qc.ancestry import assign_population_pcs, run_pca_with_relateds
 
@@ -130,6 +131,10 @@ def run(
         'pop': str
         'prob_<pop>': float64 (for each population label)
     """
+
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
+        override_jar_spec(jar_spec)
+
     min_pop_prob = get_config()['large_cohort']['min_pop_prob']
     n_pcs = get_config()['large_cohort']['n_pcs']
     dense_mt = hl.read_matrix_table(str(dense_mt_path))


### PR DESCRIPTION
As per https://github.com/populationgenomics/production-pipelines/pull/1015, we need to be able to override the JAR spec to get around transient hail issues.