### PR TITLE
Add the ability to update the storage and memory requirements via config

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -334,6 +334,8 @@ class MakeSiteOnlyVcf(CohortStage):
             (self.get_job_attrs() or {}) | {'tool': HAIL_QUERY},
         )
         j.image(image_path('cpg_workflows'))
+        j.memory(config_retrieve('sitesvcf').get('memory', "4Gi"))
+        j.storage(config_retrieve('sitesvcf').get('storage', "5Gi"))
 
         j.command(
             query_command(


### PR DESCRIPTION
MakeSiteOnlyVcf requires more storage, as per: https://batch.hail.populationgenomics.org.au/batches/532410/jobs/124630