### PR TITLE
Add non-preemptible vm option for es-index creating job

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.8
+current_version = 1.31.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.8
+  VERSION: 1.31.9
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -39,6 +39,10 @@ write_vcf = ["udn-aus"]
 # [workflow.gvcf_multiqc.extra_config]
 # plots_force_interactive = true
 
+# By default, run the es-index generating jobs on spot (preemptible) instances
+[workflow.es_index]
+spot_instance = true
+
 [resource_overrides]
 # Override default resource requirements for unusually large seq data without
 # demanding higher resources for all operations as standard. Examples below

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -226,7 +226,7 @@ class MtToEs(DatasetStage):
 
         job = get_batch().new_bash_job(f'Generate {index_name} from {mt_path}')
         if not config_retrieve(['workflow', 'es_index', 'spot_instance'], default=True):
-            job = job.spot(is_spot = False)
+            job = job.spot(is_spot=False)
 
         req_storage = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -225,6 +225,8 @@ class MtToEs(DatasetStage):
         flag_name = str(outputs['done_flag'])
 
         job = get_batch().new_bash_job(f'Generate {index_name} from {mt_path}')
+        if not config_retrieve(['workflow', 'es_index', 'spot_instance'], default=True):
+            job = job.spot(is_spot = False)
 
         req_storage = tshirt_mt_sizing(
             sequencing_type=config_retrieve(['workflow', 'sequencing_type']),

--- a/cpg_workflows/stages/seqr_loader.py
+++ b/cpg_workflows/stages/seqr_loader.py
@@ -225,7 +225,8 @@ class MtToEs(DatasetStage):
         flag_name = str(outputs['done_flag'])
 
         job = get_batch().new_bash_job(f'Generate {index_name} from {mt_path}')
-        if not config_retrieve(['workflow', 'es_index', 'spot_instance'], default=True):
+        if config_retrieve(['workflow', 'es_index', 'spot_instance'], default=True) is False:
+            # Use a non-preemptible instance if spot_instance is False in the config
             job = job.spot(is_spot=False)
 
         req_storage = tshirt_mt_sizing(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.8',
+    version='1.31.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Allow the elasticsearch index export job to run on non-preemptible (or "not spot") VMs, to stop them getting preempted and cancelling the index. Should only be used for when time is of the essence and multiple days worth of preemptions is not worth the savings.

Non-preemtible VM cost to export a 22GB index over 1hr 25m: [$0.4062](https://batch.hail.populationgenomics.org.au/batches/532710/jobs/163) - according to Hail Batch

Preemptible VM cost in the same time: [~$0.20](https://batch.hail.populationgenomics.org.au/batches/532774/jobs/1) (it got preempted 😆  so this is a guesstimate) 