### PR TITLE
Allow n_per_split flexibility

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.7
+current_version = 1.31.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.31.7
+  VERSION: 1.31.8
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample.toml
+++ b/configs/defaults/gatk_sv_multisample.toml
@@ -37,6 +37,8 @@ run_module_metrics = false
 
 [resource_overrides.GenotypeBatch]
 run_module_metrics = false
+n_per_split = 5001
+n_gt_bins = 100000
 
 [resource_overrides.MakeCohortVcf]
 run_module_metrics = false

--- a/configs/defaults/gatk_sv_multisample.toml
+++ b/configs/defaults/gatk_sv_multisample.toml
@@ -37,6 +37,7 @@ run_module_metrics = false
 
 [resource_overrides.GenotypeBatch]
 run_module_metrics = false
+# If we run into silent failures in integrateGQ.sh, modify the number of splits (affecting number of shards)
 n_per_split = 5001
 n_gt_bins = 100000
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -689,8 +689,8 @@ class GenotypeBatch(CohortStage):
 
         input_dict: dict[str, Any] = {
             'batch': cohort.id,
-            'n_per_split': config_retrieve(['workflow', 'n_per_split'], 5000),
-            'n_RD_genotype_bins': config_retrieve(['workflow', 'n_RD_genotype_bins'], 100000),
+            'n_per_split': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_per_split'], 5000),
+            'n_RD_genotype_bins': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_gt_bins'], 100000),
             'coveragefile': batchevidence_d['merged_bincov'],
             'coveragefile_index': batchevidence_d['merged_bincov_index'],
             'discfile': batchevidence_d['merged_PE'],

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -689,8 +689,8 @@ class GenotypeBatch(CohortStage):
 
         input_dict: dict[str, Any] = {
             'batch': cohort.id,
-            'n_per_split': 5000,
-            'n_RD_genotype_bins': 100000,
+            'n_per_split': config_retrieve(['workflow', 'n_per_split'], 5000),
+            'n_RD_genotype_bins': config_retrieve(['workflow', 'n_RD_genotype_bins'], 100000),
             'coveragefile': batchevidence_d['merged_bincov'],
             'coveragefile_index': batchevidence_d['merged_bincov_index'],
             'discfile': batchevidence_d['merged_PE'],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.31.7',
+    version='1.31.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Mitigation for https://github.com/broadinstitute/gatk-sv/issues/759

Allows us to flexibly alter the number of variants per shard in GenotypeBatch.