### PR TITLE
Update n_gt_bins to n_RD_genotype_bins in gatk sv multisample config

### DIFF
--- a/configs/defaults/gatk_sv_multisample.toml
+++ b/configs/defaults/gatk_sv_multisample.toml
@@ -39,7 +39,7 @@ run_module_metrics = false
 run_module_metrics = false
 # If we run into silent failures in integrateGQ.sh, modify the number of splits (affecting number of shards)
 n_per_split = 5001
-n_gt_bins = 100000
+n_RD_genotype_bins = 100000
 
 [resource_overrides.MakeCohortVcf]
 run_module_metrics = false

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -690,7 +690,10 @@ class GenotypeBatch(CohortStage):
         input_dict: dict[str, Any] = {
             'batch': cohort.id,
             'n_per_split': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_per_split'], 5000),
-            'n_RD_genotype_bins': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_RD_genotype_bins'], 100000),
+            'n_RD_genotype_bins': config_retrieve(
+                ['resource_overrides', 'GenotypeBatch', 'n_RD_genotype_bins'],
+                100000,
+            ),
             'coveragefile': batchevidence_d['merged_bincov'],
             'coveragefile_index': batchevidence_d['merged_bincov_index'],
             'discfile': batchevidence_d['merged_PE'],

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -690,7 +690,7 @@ class GenotypeBatch(CohortStage):
         input_dict: dict[str, Any] = {
             'batch': cohort.id,
             'n_per_split': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_per_split'], 5000),
-            'n_RD_genotype_bins': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_gt_bins'], 100000),
+            'n_RD_genotype_bins': config_retrieve(['resource_overrides', 'GenotypeBatch', 'n_RD_genotype_bins'], 100000),
             'coveragefile': batchevidence_d['merged_bincov'],
             'coveragefile_index': batchevidence_d['merged_bincov_index'],
             'discfile': batchevidence_d['merged_PE'],


### PR DESCRIPTION
Looks like this variable needs to be renamed to match what GATK expects. Not exactly sure how its happening, but the whole `[resource_overrides.GenotypeBatch]` is being passed through to the cromwell workflow attributes? edit: [here](https://github.com/populationgenomics/production-pipelines/blob/57e4797edc095cec0291f863c59cf9ee2ed02ebc/cpg_workflows/stages/gatk_sv/gatk_sv_common.py#L147-L148)

As we can see in the submit job:
https://batch.hail.populationgenomics.org.au/batches/532761/jobs/1

The config has `"GenotypeBatch.n_RD_genotype_bins": 100000,` as well as `"GenotypeBatch.n_gt_bins": 100000`.

This is leading to the error:
```
"WARNING: Unexpected input provided: GenotypeBatch.n_gt_bins 
(expected inputs: [GenotypeBatch.runtime_attr_split_vcf, GenotypeBatch.baseline_genotyped_pesr_vcf, GenotypeBatch.GenotypeBatchMetrics.runtime_attr_depth_metrics, GenotypeBatch.runtime_attr_index_vcf, GenotypeBatch.discfile_index, GenotypeBatch.GenotypeBatchMetrics.runtime_attr_cutoff_metrics, GenotypeBatch.runtime_attr_merge_counts, GenotypeBatch.genotype_depth_pesr_sepcutoff, GenotypeBatch.runtime_attr_genotype_pesr_concat_vcfs, GenotypeBatch.reference_build, GenotypeBatch.rf_cutoffs, GenotypeBatch.PE_metrics, GenotypeBatch.batch_pesr_vcf, GenotypeBatch.runtime_attr_merge_regeno_cov_med, GenotypeBatch.coveragefile_index, GenotypeBatch.coveragefile, GenotypeBatch.runtime_attr_update_cutoff, GenotypeBatch.n_per_split, GenotypeBatch.ref_dict, GenotypeBatch.runtime_attr_make_subset_vcf, GenotypeBatch.runtime_attr_merge_genotypes, GenotypeBatch.runtime_attr_add_batch, GenotypeBatch.GenotypeBatchMetrics.runtime_attr_id_list_metrics, GenotypeBatch.runtime_attr_training_bed, GenotypeBatch.splitfile, GenotypeBatch.runtime_attr_sr_genotype, GenotypeBatch.runtime_attr_make_batch_bed, GenotypeBatch.medianfile, GenotypeBatch.runtime_attr_integrate_pesr_gq, GenotypeBatch.runtime_attr_genotype_sr, GenotypeBatch.batch, GenotypeBatch.genotype_pesr_pesr_sepcutoff, GenotypeBatch.runtime_attr_ids_from_vcf, GenotypeBatch.GenotypeBatchMetrics.runtime_attr_cat_metrics, GenotypeBatch.n_RD_genotype_bins, GenotypeBatch.runtime_attr_integrate_depth_gq, GenotypeBatch.runtime_attr_generate_cutoff, GenotypeBatch.discfile, GenotypeBatch.batch_depth_vcf, GenotypeBatch.linux_docker, GenotypeBatch.splitfile_index, GenotypeBatch.bin_exclude, GenotypeBatch.runtime_attr_triple_stream_cat, GenotypeBatch.seed_cutoffs, GenotypeBatch.cohort_depth_vcf, GenotypeBatch.cohort_pesr_vcf, GenotypeBatch.runtime_attr_genotype_depths_concat_vcfs, GenotypeBatch.runtime_attr_genotype_train, GenotypeBatch.runtime_attr_count_sr, GenotypeBatch.runtime_attr_genotype_pe, GenotypeBatch.runtime_attr_count_pe, GenotypeBatch.sv_pipeline_rdtest_docker, GenotypeBatch.sr_hom_cutoff_multiplier, GenotypeBatch.runtime_attr_pe_genotype, GenotypeBatch.sv_pipeline_base_docker, GenotypeBatch.baseline_genotyped_depth_vcf, GenotypeBatch.runtime_attr_rdtest_genotype, GenotypeBatch.sr_median_hom_ins, GenotypeBatch.sv_pipeline_docker, GenotypeBatch.primary_contigs_list, GenotypeBatch.genotype_pesr_depth_sepcutoff, GenotypeBatch.runtime_attr_add_genotypes, GenotypeBatch.genotype_depth_depth_sepcutoff, GenotypeBatch.SR_metrics, GenotypeBatch.sv_base_mini_docker, GenotypeBatch.runtime_attr_subset_ped, GenotypeBatch.pesr_exclude_list, GenotypeBatch.GenotypeBatchMetrics.runtime_attr_pesr_metrics, GenotypeBatch.run_module_metrics, GenotypeBatch.runtime_attr_integrate_gq, GenotypeBatch.runtime_attr_split_variants])"
```