### PR TITLE
Second attempt at -test correction

### DIFF
--- a/cpg_workflows/metamist.py
+++ b/cpg_workflows/metamist.py
@@ -250,7 +250,12 @@ def sort_sgs_by_project(response_data) -> dict:
     result_dict: dict[str, list[str]] = {}
 
     for sequencing_group in response_data:
+
         project_id = sequencing_group['sample']['project']['name']
+
+        # RE: PR #1063 - we need to strip the '-test' suffix from the project_id to match configs
+        if project_id.endswith('-test'):
+            project_id = project_id[:-5]
 
         if project_id not in result_dict:
             result_dict[project_id] = []


### PR DESCRIPTION
We also need to drop the -test suffix in this dictionary structure to match the later `-test` trimming.

The creation of the `SGs per project` dictionary uses the project name in the metamistresults: `SG.Sample.project`. In test projects, this project string also has `-test` in.

This behaviour won't be required in cpg-flow as we've already scrapped this structure