### PR TITLE
Removing test suffix from dataset names for multicohorts.

### DIFF
--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -105,7 +105,7 @@ def _populate_cohort(cohort: Cohort, sgs_by_dataset_for_cohort, read_pedigree: b
     TODO (mwelland): so we can lose a layer of the structure here
     """
     for dataset_name in sgs_by_dataset_for_cohort.keys():
-        dataset = cohort.create_dataset(dataset_name)
+        dataset = cohort.create_dataset(dataset_name[:-5] if dataset_name.endswith('-test') else dataset_name)
         sgs = sgs_by_dataset_for_cohort[dataset_name]
 
         for entry in sgs:

--- a/cpg_workflows/inputs.py
+++ b/cpg_workflows/inputs.py
@@ -105,7 +105,7 @@ def _populate_cohort(cohort: Cohort, sgs_by_dataset_for_cohort, read_pedigree: b
     TODO (mwelland): so we can lose a layer of the structure here
     """
     for dataset_name in sgs_by_dataset_for_cohort.keys():
-        dataset = cohort.create_dataset(dataset_name[:-5] if dataset_name.endswith('-test') else dataset_name)
+        dataset = cohort.create_dataset(dataset_name.removesuffix('-test'))
         sgs = sgs_by_dataset_for_cohort[dataset_name]
 
         for entry in sgs:

--- a/test/test_multicohort.py
+++ b/test/test_multicohort.py
@@ -184,6 +184,152 @@ def mock_get_sgs_by_cohort_project_b(*args, **kwargs) -> list[dict]:
     ]
 
 
+def mock_get_sgs_by_cohort_project_a_test_suffix(*args, **kwargs) -> list[dict]:
+    return [
+        {
+            'id': 'CPGXXXX',
+            'meta': {'sg_meta': 'is_fun'},
+            'platform': 'illumina',
+            'technology': 'short-read',
+            'type': 'genome',
+            'sample': {
+                'project': {
+                    'name': 'projecta-test',
+                },
+                'externalId': 'NA12340',
+                'participant': {
+                    'id': 1,
+                    'externalId': '8',
+                    'reportedSex': 'Male',
+                    'meta': {'participant_meta': 'is_here'},
+                },
+            },
+            'assays': [
+                {
+                    'id': 1,
+                    'meta': {
+                        'platform': '30x Illumina PCR-Free',
+                        'concentration': '25',
+                        'fluid_x_tube_id': '220405_FS28',
+                        'reference_genome': 'Homo sapiens (b37d5)',
+                        'volume': '100',
+                        'reads_type': 'fastq',
+                        'batch': '1',
+                    },
+                    'type': 'sequencing',
+                },
+            ],
+        },
+        {
+            'id': 'CPGAAAA',
+            'meta': {'sg_meta': 'is_fun'},
+            'platform': 'illumina',
+            'technology': 'short-read',
+            'type': 'genome',
+            'sample': {
+                'project': {
+                    'name': 'projecta-test',
+                },
+                'externalId': 'NA12489',
+                'participant': {
+                    'id': 2,
+                    'externalId': '14',
+                    'reportedSex': None,
+                    'meta': {'participant_metadata': 'number_fourteen'},
+                },
+            },
+            'assays': [
+                {
+                    'id': 2,
+                    'meta': {
+                        'platform': '30x Illumina PCR-Free',
+                        'concentration': '25',
+                        'fluid_x_tube_id': '220405_FS29',
+                        'reference_genome': 'Homo sapiens (b37d5)',
+                        'volume': '100',
+                        'reads_type': 'fastq',
+                        'batch': '1',
+                    },
+                    'type': 'sequencing',
+                },
+            ],
+        },
+    ]
+
+
+def mock_get_sgs_by_cohort_project_b_test_suffix(*args, **kwargs) -> list[dict]:
+    return [
+        {
+            'id': 'CPGCCCCCC',
+            'meta': {'sg_meta': 'is_awesome'},
+            'platform': 'illumina',
+            'technology': 'short-read',
+            'type': 'genome',
+            'sample': {
+                'project': {
+                    'name': 'projectb-test',
+                },
+                'externalId': 'NA111111',
+                'participant': {
+                    'id': 1,
+                    'externalId': '10',
+                    'reportedSex': 'Male',
+                    'meta': {'participant_meta': 'is_here'},
+                },
+            },
+            'assays': [
+                {
+                    'id': 1,
+                    'meta': {
+                        'platform': '30x Illumina PCR-Free',
+                        'concentration': '25',
+                        'fluid_x_tube_id': '220405_FS28',
+                        'reference_genome': 'Homo sapiens (b37d5)',
+                        'volume': '100',
+                        'reads_type': 'fastq',
+                        'batch': '1',
+                    },
+                    'type': 'sequencing',
+                },
+            ],
+        },
+        {
+            'id': 'CPGDDDDDD',
+            'meta': {'sg_meta': 'is_fun'},
+            'platform': 'illumina',
+            'technology': 'short-read',
+            'type': 'genome',
+            'sample': {
+                'project': {
+                    'name': 'projectb-test',
+                },
+                'externalId': 'NA12489',
+                'participant': {
+                    'id': 2,
+                    'externalId': '14',
+                    'reportedSex': None,
+                    'meta': {'participant_metadata': 'number_fourteen'},
+                },
+            },
+            'assays': [
+                {
+                    'id': 2,
+                    'meta': {
+                        'platform': '30x Illumina PCR-Free',
+                        'concentration': '25',
+                        'fluid_x_tube_id': '220405_FS29',
+                        'reference_genome': 'Homo sapiens (b37d5)',
+                        'volume': '100',
+                        'reads_type': 'fastq',
+                        'batch': '1',
+                    },
+                    'type': 'sequencing',
+                },
+            ],
+        },
+    ]
+
+
 def mock_get_cohorts(*args, **kwargs) -> dict:
     return {
         'COH123': {
@@ -212,6 +358,23 @@ def mock_get_overlapping_cohorts(*args, **kwargs) -> dict:
         'COH456': {
             "sequencing_groups": {
                 'projecta': [mock_get_sgs_by_cohort_project_a()[1]],
+            },
+            "name": "CohortB",
+        },
+    }
+
+
+def mock_get_cohorts_with_test_suffix(*args, **kwargs) -> dict:
+    return {
+        'COH123': {
+            "sequencing_groups": {
+                'projecta-test': mock_get_sgs_by_cohort_project_a_test_suffix(),
+            },
+            "name": "CohortA",
+        },
+        'COH456': {
+            "sequencing_groups": {
+                'projectb-test': mock_get_sgs_by_cohort_project_b_test_suffix(),
             },
             "name": "CohortB",
         },
@@ -337,3 +500,40 @@ def test_overlapping_multicohort(mocker: MockFixture, tmp_path):
 
     for cohort in multicohort.get_cohorts():
         assert len(cohort.get_sequencing_group_ids()) == 1
+
+
+def test_multicohort_dataset_config(mocker: MockFixture, tmp_path):
+    """
+    This test is to ensure that the dataset name is stripped of the '-test' suffix.
+    """
+    set_config(_multicohort_config(tmp_path), tmp_path / 'config.toml')
+
+    mocker.patch('cpg_workflows.utils.exists_not_cached', lambda *args: False)
+
+    mocker.patch('cpg_workflows.metamist.Metamist.get_ped_entries', mock_get_pedigree)
+    mocker.patch('cpg_workflows.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
+    # mockup the cohort data with '-test' suffix
+    mocker.patch('cpg_workflows.metamist.Metamist.get_sgs_for_cohorts', mock_get_cohorts_with_test_suffix)
+
+    from cpg_workflows.inputs import get_multicohort
+
+    multicohort = get_multicohort()
+
+    assert multicohort
+    assert isinstance(multicohort, MultiCohort)
+
+    # Testing Cohort Information
+    cohorts = multicohort.get_cohorts()
+    assert len(cohorts) == 2
+    assert cohorts[0].name == "CohortA"
+    assert cohorts[1].name == "CohortB"
+
+    assert len(multicohort.get_sequencing_groups()) == 4
+    assert sorted(multicohort.get_sequencing_group_ids()) == ['CPGAAAA', 'CPGCCCCCC', 'CPGDDDDDD', 'CPGXXXX']
+
+    # Test the projects they belong to
+    # Datasets name should be without '-test' suffix
+    assert multicohort.get_sequencing_groups()[0].dataset.name == 'projecta'
+    assert multicohort.get_sequencing_groups()[1].dataset.name == 'projecta'
+    assert multicohort.get_sequencing_groups()[2].dataset.name == 'projectb'
+    assert multicohort.get_sequencing_groups()[3].dataset.name == 'projectb'


### PR DESCRIPTION
Datasets name gets populated from metamist project name for multicohorts, the old way was from the config file.
Metamist contain suffix for test projects. 
This PR removes them when creating relevant Dataset by name.