### PR TITLE
RD: Resume from previous combiner

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.0
+current_version = 1.32.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.0
+  VERSION: 1.32.1
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -23,7 +23,7 @@ snps_recal_disc_size = 20
 
 # choices of jar specs to use for the various steps
 # without this setting we would default to matching the native Hail version in the container
-# currently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 133 + 400'retry + StreamConstraints patch
+# currently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 0.2.133 + 400'retry + StreamConstraints patch
 [rd_combiner.jar_spec_revision]
 annotate_cohort = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 annotate_dataset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -34,8 +34,14 @@ subset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 [combiner]
 # used to decide if we should resume from a previous combiner plan
 force_new_combiner = false
-memory = "8Gi"
-storage = "10Gi"
+# highem, standard, or a string, e.g. "4Gi"
+driver_memory = "standard"
+# string, e.g. "4Gi"
+driver_storage = "10Gi"
+# integer
+driver_cores = 1
+# highem, standard, or a string, e.g. "4Gi"
+worker_memory = "standard"
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -14,7 +14,6 @@ check_for_existing_vds = false
 ## Subsetting and AnnotateDataset will only run for these datasets
 #write_mt_for_datasets = ['test_dataset', ]
 
-[rd_combiner]
 # these are used when calculating how many fragments to send to each job
 vqsr_training_fragments_per_job = 100
 vqsr_apply_fragments_per_job = 60
@@ -23,20 +22,18 @@ snps_gather_disc_size = 10
 snps_recal_disc_size = 20
 
 # choices of jar specs to use for the various steps
-# by default we match the native Hail version in the container
-[rd_combiner.subset]
-jar_spec_revision = false
-
-[rd_combiner.annotate_cohort]
-jar_spec_revision = false
-
-[rd_combiner.annotate_dataset]
-jar_spec_revision = false
-
-[rd_combiner.densify]
-jar_spec_revision = false
+# without this setting we would default to matching the native Hail version in the container
+# currently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 133 + 400'retry + StreamConstraints patch
+[rd_combiner.jar_spec_revision]
+annotate_cohort = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
+annotate_dataset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
+combiner = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
+densify = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
+subset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 
 [combiner]
+# used to decide if we should resume from a previous combiner plan
+force_new_combiner = false
 memory = "8Gi"
 storage = "10Gi"
 

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -24,7 +24,7 @@ snps_recal_disc_size = 20
 # choices of jar specs to use for the various steps
 # without this setting we would default to matching the native Hail version in the container
 # currently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 0.2.133 + 400'retry + StreamConstraints patch
-[rd_combiner.jar_spec_revision]
+[workflow.jar_spec_revisions]
 annotate_cohort = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 annotate_dataset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 combiner = 'a8be268326b2ac168035b629a78465c9d94fc7b9'

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -42,7 +42,7 @@ def run(
     logging.basicConfig(level=logging.INFO)
 
     init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
-    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision', 'combiner'], False):
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'combiner'], False):
         override_jar_spec(jar_spec)
 
     # Load from save, if supplied (log correctly depending on force_new_combiner)

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -41,7 +41,11 @@ def run(
     # set up a quick logger inside the job
     logging.basicConfig(level=logging.INFO)
 
-    init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
+    init_batch(
+        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
+        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
+        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+    )
     if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'combiner'], False):
         override_jar_spec(jar_spec)
 

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -1,0 +1,77 @@
+"""
+Runs the hail combiner
+This is copied from the large_cohort implementation, as RD needs to alter some defaults
+Specifically we need to drop/modify the Force argument to resume from previous Combiner plan/runs
+"""
+
+
+def run(
+    output_vds_path: str,
+    sequencing_type: str,
+    tmp_prefix: str,
+    genome_build: str,
+    save_path: str | None,
+    gvcf_paths: list[str] | None = None,
+    vds_paths: list[str] | None = None,
+    specific_intervals: list[str] | None = None,
+    force_new_combiner: bool = False,
+) -> None:
+    """
+    Runs the combiner
+
+    Args:
+        output_vds_path (str): eventual output path for the VDS
+        sequencing_type (str): genome/exome, relevant in selecting defaults
+        tmp_prefix (str): where to store temporary combiner intermediates
+        genome_build (str): GRCh38
+        save_path (str | None): where to store the combiner plan, or where to resume from
+        gvcf_paths (list[str] | None): list of paths to GVCFs
+        vds_paths (list[str] | None): list of paths to VDSs
+        specific_intervals (list[str] | None): list of intervals to use for the combiner, if using non-standard
+        force_new_combiner (bool): whether to force a new combiner run, or permit resume from a previous one
+    """
+    import logging
+
+    import hail as hl
+
+    from cpg_utils.config import config_retrieve
+    from cpg_utils.hail_batch import init_batch
+    from cpg_workflows.batch import override_jar_spec
+
+    # set up a quick logger inside the job
+    logging.basicConfig(level=logging.INFO)
+
+    init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revision', 'combiner'], False):
+        override_jar_spec(jar_spec)
+
+    # Load from save, if supplied (log correctly depending on force_new_combiner)
+    if save_path:
+        if force_new_combiner:
+            logging.info(f'Combiner plan {save_path} will be ignored/written new')
+        else:
+            logging.info(f'Resuming combiner plan from {save_path}')
+
+    if specific_intervals:
+        logging.info(f'Using specific intervals: {specific_intervals}')
+        intervals = hl.eval(
+            [hl.parse_locus_interval(interval, reference_genome=genome_build) for interval in specific_intervals],
+        )
+
+    else:
+        intervals = None
+
+    combiner = hl.vds.new_combiner(
+        output_path=output_vds_path,
+        save_path=save_path,
+        gvcf_paths=gvcf_paths,
+        vds_paths=vds_paths,
+        reference_genome=genome_build,
+        temp_path=tmp_prefix,
+        use_exome_default_intervals=sequencing_type == 'exome',
+        use_genome_default_intervals=sequencing_type == 'genome',
+        intervals=intervals,
+        force=force_new_combiner,
+    )
+
+    combiner.run()

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -123,7 +123,7 @@ def annotate_cohort(
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods
     # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
-    if jar_spec := config_retrieve(['rd_combiner', 'annotate_cohort', 'jar_spec_revision'], False):
+    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'annotate_cohort'], False):
         override_jar_spec(jar_spec)
 
     # hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/permissions.20issues/near/398711114

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -123,7 +123,7 @@ def annotate_cohort(
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods
     # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
-    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'annotate_cohort'], False):
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'annotate_cohort'], False):
         override_jar_spec(jar_spec)
 
     # hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/permissions.20issues/near/398711114

--- a/cpg_workflows/scripts/annotate_dataset_small_vars.py
+++ b/cpg_workflows/scripts/annotate_dataset_small_vars.py
@@ -21,7 +21,7 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
 
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods
-    if jar_spec := config_retrieve(['rd_combiner', 'annotate_dataset', 'jar_spec_revision'], False):
+    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'annotate_dataset'], False):
         override_jar_spec(jar_spec)
 
     mt = hl.read_matrix_table(mt_path)

--- a/cpg_workflows/scripts/annotate_dataset_small_vars.py
+++ b/cpg_workflows/scripts/annotate_dataset_small_vars.py
@@ -21,7 +21,7 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
 
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods
-    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'annotate_dataset'], False):
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'annotate_dataset'], False):
         override_jar_spec(jar_spec)
 
     mt = hl.read_matrix_table(mt_path)

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -46,7 +46,7 @@ def main(
     init_batch()
 
     # if we need to manually specify a non-standard Hail QoB JAR file
-    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'densify'], False):
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'densify'], False):
         override_jar_spec(jar_spec)
 
     vds = hl.vds.read_vds(vds_in)

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -46,7 +46,7 @@ def main(
     init_batch()
 
     # if we need to manually specify a non-standard Hail QoB JAR file
-    if jar_spec := config_retrieve(['rd_combiner', 'densify', 'jar_spec_revision'], False):
+    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'densify'], False):
         override_jar_spec(jar_spec)
 
     vds = hl.vds.read_vds(vds_in)

--- a/cpg_workflows/scripts/subset_mt_to_dataset.py
+++ b/cpg_workflows/scripts/subset_mt_to_dataset.py
@@ -28,7 +28,7 @@ def subset_mt_to_samples(input_mt: str, sg_id_file: str, output: str):
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods
     # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
-    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'subset'], False):
+    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'subset'], False):
         override_jar_spec(jar_spec)
 
     mt = hl.read_matrix_table(input_mt)

--- a/cpg_workflows/scripts/subset_mt_to_dataset.py
+++ b/cpg_workflows/scripts/subset_mt_to_dataset.py
@@ -28,7 +28,7 @@ def subset_mt_to_samples(input_mt: str, sg_id_file: str, output: str):
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods
     # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
-    if jar_spec := config_retrieve(['rd_combiner', 'subset', 'jar_spec_revision'], False):
+    if jar_spec := config_retrieve(['rd_combiner', 'jar_spec_revision', 'subset'], False):
         override_jar_spec(jar_spec)
 
     mt = hl.read_matrix_table(input_mt)

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -169,8 +169,9 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
         combiner_job = get_batch().new_python_job('CreateVdsFromGvcfsWithHailCombiner', {'stage': self.name})
         combiner_job.image(config_retrieve(['workflow', 'driver_image']))
-        combiner_job.memory(config_retrieve(['combiner', 'memory']))
-        combiner_job.storage(config_retrieve(['combiner', 'storage']))
+        combiner_job.memory(config_retrieve(['combiner', 'driver_memory'], 'highmem'))
+        combiner_job.storage(config_retrieve(['combiner', 'driver_storage']))
+        combiner_job.cpu(config_retrieve(['combiner', 'driver_cores'], 2))
 
         # Default to GRCh38 for reference if not specified
         combiner_job.call(

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -6,6 +6,7 @@ use the gVCF combiner instead of joint-calling.
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, genome_build
 from cpg_utils.hail_batch import get_batch
+from cpg_workflows.jobs.rd_combiner import combiner
 from cpg_workflows.jobs.gcloud_composer import gcloud_compose_vcf_from_manifest
 from cpg_workflows.jobs.rd_combiner.vep import add_vep_jobs
 from cpg_workflows.jobs.rd_combiner.vqsr import (
@@ -129,7 +130,6 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
         }
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
-        from cpg_workflows.large_cohort import combiner
 
         outputs: dict[str, str | Path] = self.expected_outputs(multicohort)
 
@@ -182,6 +182,7 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
             genome_build=genome_build(),
             gvcf_paths=new_sg_gvcfs,
             vds_paths=[vds_path] if vds_path else None,
+            force_new_combiner=config_retrieve(['combiner', 'force_new_combiner'], False),
         )
 
         return self.make_outputs(multicohort, outputs, combiner_job)

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -6,8 +6,8 @@ use the gVCF combiner instead of joint-calling.
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, genome_build
 from cpg_utils.hail_batch import get_batch
-from cpg_workflows.jobs.rd_combiner import combiner
 from cpg_workflows.jobs.gcloud_composer import gcloud_compose_vcf_from_manifest
+from cpg_workflows.jobs.rd_combiner import combiner
 from cpg_workflows.jobs.rd_combiner.vep import add_vep_jobs
 from cpg_workflows.jobs.rd_combiner.vqsr import (
     apply_recalibration_indels,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.0',
+    version='1.32.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR looks pretty chunky, but it's actually quite minor

- In the shift from Joint-calling to gVCF combining we need the ability to cost-effectively resume from a previous partial run failure
- Hail permits this by providing the combiner plan from an initial attempt
- The currently Combiner implementation is being shared with PA, and in that the `force=True` argument to the Combiner is hard coded
- The force argument prevents hail from reusing the combiner plan, and instead guarantees a from-scratch attempt with each run

The solution here is to duplicate the combiner.py code into an `rd_combiner` folder, and modify the force argument to be modifiable from config (defaulting instead to being False).

The only substantive change being made is the addition of a separate configurable parameter for `force`, and the logging to clarify both if a save_path was provided, and if Hail will be able to use it. To keep the changes separate from PA's usage it's been duplicated away.

---

Now that there are 5 different stages where we might want to override the Hail JAR file I've re-ordered the config parameters. Instead of the config having `rd_combiner.STAGE. jar_spec_revision` I've swapped it around to `workflow. jar_spec_revisions.STAGE`, which means that all the 5 config entries are at the same level in the hierarchy, which to me reads much better.

I've also set these defaults to be the latest prod-ready fix containing the two patches we're interested in.