### PR TITLE
Checkpoint, then log

### DIFF
--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -28,6 +28,7 @@ def run(vds_path: str, out_dense_mt_path: str) -> hl.MatrixTable:
     logging.info('Densifying data...')
     mt = hl.vds.to_dense_mt(vds)
     mt = mt.select_entries('GT', 'GQ', 'DP', 'AD')
-    logging.info(f'Number of predetermined QC variants found in the VDS: {mt.count_rows()}')
     mt = mt.naive_coalesce(5000)
-    return mt.checkpoint(out_dense_mt_path, overwrite=True)
+    mt = mt.checkpoint(out_dense_mt_path, overwrite=True)
+    logging.info(f'Number of predetermined QC variants found in the VDS: {mt.count_rows()}')
+    return mt


### PR DESCRIPTION
- Hail lazy-loads operations
- by logging `mt.count_rows()` we force resolution of all operations, without storing the result
- By printing a logging statement, then writing a checkpoint, every operation after the VDS load is duplicated (AFAIK)
- By checkpointing first, the logging statement can do a no-op calculation of current rows on the checkpoint data

I'm pretty this is old code so this has been here a while. The MT doesn't need to be returned in current usage, not sure if that really affects anything.

Docs reference: https://populationgenomics.readthedocs.io/en/latest/hail.html#hail-query-pro-tips