### PR TITLE
Implement post-densification coalesce

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.1
+current_version = 1.32.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.1
+  VERSION: 1.32.2
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -14,6 +14,11 @@ check_for_existing_vds = false
 ## Subsetting and AnnotateDataset will only run for these datasets
 #write_mt_for_datasets = ['test_dataset', ]
 
+## number of partitions to coalesce the data into
+densify_partitions = 2500
+## strategy to use for partitioning the data [none, naive, shuffle]
+partition_strategy = 'naive'
+
 # these are used when calculating how many fragments to send to each job
 vqsr_training_fragments_per_job = 100
 vqsr_apply_fragments_per_job = 60

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -217,12 +217,18 @@ class CreateDenseMtFromVdsWithHail(MultiCohortStage):
 
         output = self.expected_outputs(multicohort)
 
+        # partitions to coalesce the data into
+        partitions = config_retrieve(['workflow', 'densify_partitions'], 2000)
+        partition_strategy = config_retrieve(['workflow', 'partition_strategy'], 'naive')
+
         densify_job = get_batch().new_job('CreateDenseMtFromVdsWithHail')
         densify_job.image(config_retrieve(['workflow', 'driver_image']))
         densify_job.command(
             'mt_from_vds '
             f'--input {str(inputs.as_dict(multicohort, CreateVdsFromGvcfsWithHailCombiner)["vds"])} '
             f'--output {str(output["mt"])} '
+            f'--partitions {partitions} '
+            f'--partition_strategy {partition_strategy} '
             f'--sites_only {output["hps_vcf_dir"]} '
             f'--separate_header {output["separate_header_vcf_dir"]} ',
         )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.1',
+    version='1.32.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bring down the number of exported VCFs, without altering the MT's partitions on disc.

2 arguments - `partition_strategy` and `partitions`

`partition_strategy`:
- `none`: don't
- `naive`: [naive_coalesce](https://hail.is/docs/0.2/hail.Table.html#hail.Table.naive_coalesce)
- `shuffle`: [repartition](https://hail.is/docs/0.2/hail.Table.html#hail.Table.repartition) (more expensive, but guaranteed balanced)

If a non-none strategy is selected, repartition into `partitions` partitions