### PR TITLE
Reorganise densification steps

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.2
+current_version = 1.32.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.2
+  VERSION: 1.32.3
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.2',
+    version='1.32.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Another PR that looks a bit brutal, but it's really simple.

Hail normally operates lazily, which means we can call all the filter/annotate methods, but if we don't write the result to file the computation never happens. Quick, cheap.

In the VDS -> Densify script we plan all the annotation, then at the end we only write the MT to disc if it doesn't already exist. Unfortunately the methods here (computing the info fields) write some temporary data, meaning that even if we don't use them, the steps will be executed. It's probably only a few dollars, but it's wasted compute.

This change indents the whole `VDS -> Annotation -> MT` phase inside the `can_reuse` check. If the MT already exists, we properly skip all the steps involved in creating it.