### PR TITLE
Correction to AC/AF in Combiner AnnotateCohort

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.3
+current_version = 1.32.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.3
+  VERSION: 1.32.4
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -170,6 +170,16 @@ def annotate_cohort(
         ),
         vep=vep_ht[mt.locus].vep,
     )
+    mt = mt.drop('variant_qc')
+
+    # split the AC/AF attributes into separate entries, overwriting the array in INFO
+    # these elements become a 1-element array
+    mt = mt.annotate_rows(
+        info=mt.info.annotate(
+            AF=[mt.info.AF[mt.a_index - 1]],
+            AC=[mt.info.AC[mt.a_index - 1]],
+        ),
+    )
 
     get_logger().info('Annotating with seqr-loader fields: round 1')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.3',
+    version='1.32.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I missed out this part of the seqr_loader.annotate_cohort

This means that the default AC of `[num_ref, num_alt]` is kept. 

In Talos we then do variant frequency tests based on `AC[0]`, which is the number of WT alleles, not the number of variant alleles - meaning that everything fails frequency tests, and all we're left with is ClinVar variants (which evade the filter)