### PR TITLE
Correction to rd combiner ac indexing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.4
+current_version = 1.32.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.4
+  VERSION: 1.32.5
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -48,7 +48,8 @@ def checkpoint_hail(
     if can_reuse(path) and allow_reuse:
         get_logger().info(f'Re-using {path}')
         method = hl.read_table if path.rstrip('/').endswith('.ht') else hl.read_matrix_table
-        method(path)
+        # return here instead of continuing to write the checkpoint anyway
+        return method(path)
 
     get_logger().info(f'Checkpointing {path}')
     return t.checkpoint(path, overwrite=True)
@@ -173,15 +174,13 @@ def annotate_cohort(
     mt = mt.drop('variant_qc')
 
     # split the AC/AF attributes into separate entries, overwriting the array in INFO
-    # these elements become a 1-element array
+    # these elements become a 1-element array for [ALT] instead [REF, ALT]
     mt = mt.annotate_rows(
         info=mt.info.annotate(
-            AF=[mt.info.AF[mt.a_index - 1]],
-            AC=[mt.info.AC[mt.a_index - 1]],
+            AF=[mt.info.AF[1]],
+            AC=[mt.info.AC[1]],
         ),
     )
-
-    get_logger().info('Annotating with seqr-loader fields: round 1')
 
     get_logger().info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(
@@ -269,7 +268,7 @@ def annotate_cohort(
             }.get(sequencing_type, ''),
         )
 
-    get_logger().info('Done:')
+    get_logger().info('Final Structure:')
     mt.describe()
     mt.write(out_mt_path, overwrite=True)
     get_logger().info(f'Written final matrix table into {out_mt_path}')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.4',
+    version='1.32.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Thanks @EddieLF!

Original issue: I forgot to include the bit of code which extracts the variant AC into `info.AC`

Next issue: I copied too much code from seqr_loader, and forgot that multiallelic variants were already split out before reaching this point, so `a_index` is irrelevant. Trying access the 3rd value in a 2-length array caused Hail Batch to explode

This PR: Knowing that data at this point is biallelic only, we always take the 2nd value (corresponding to the alt), and don't use `a_index`

Also - the checkpointing method was buggy, and would generate a checkpoint even if it could resume from a previous checkpoint (and had already logged a message to say it was going to do that)