### PR TITLE
Don't always force a new combiner to run

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -14,6 +14,17 @@ highmem_workers = true
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 
+# Override for QoB JAR to fix teh StreamConstraints issue
+jar_spec_revision = 'f5b65edb8f1ed8e431f1799546a8e96d0ddff7d9'
+
+[combiner]
+force_new_combiner = false
+vds_version = "0.1"
+memory = "8Gi"
+storage = "10Gi"
+vds_analysis_ids = []
+merge_only_vds = false
+
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level
 # sensitivities. The tool matches them internally to a VQSLOD score cutoff

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -31,7 +31,22 @@ def run(
     gvcf_paths: list[str] | None = None,
     vds_paths: list[str] | None = None,
     specific_intervals: list[str] | None = None,
+    force_new_combiner: bool = False,
 ) -> None:
+    """
+    Runs the combiner
+
+    Args:
+        output_vds_path (str): eventual output path for the VDS
+        sequencing_type (str): genome/exome, relevant in selecting defaults
+        tmp_prefix (str): where to store temporary combiner intermediates
+        genome_build (str): GRCh38
+        save_path (str | None): where to store the combiner plan, or where to resume from
+        gvcf_paths (list[str] | None): list of paths to GVCFs
+        vds_paths (list[str] | None): list of paths to VDSs
+        specific_intervals (list[str] | None): list of intervals to use for the combiner, if using non-standard
+        force_new_combiner (bool): whether to force a new combiner run, or permit resume from a previous one
+    """
     import logging
 
     import hail as hl
@@ -41,12 +56,16 @@ def run(
 
     if not can_reuse(to_path(output_vds_path)):
         init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
+
         if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
             override_jar_spec(jar_spec)
 
         # Load from save, if supplied
         if save_path:
-            logging.info(f'Loading combiner plan from {save_path}')
+            if force_new_combiner:
+                logging.info(f'Combiner plan {save_path} will be ignored/written new')
+            else:
+                logging.info(f'Resuming combiner plan from {save_path}')
 
         if specific_intervals:
             logging.info(f'Using specific intervals: {specific_intervals}')
@@ -68,7 +87,7 @@ def run(
             use_exome_default_intervals=sequencing_type == 'exome',
             use_genome_default_intervals=sequencing_type == 'genome',
             intervals=intervals,
-            force=True,
+            force=force_new_combiner,
         )
 
         combiner.run()

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -96,8 +96,8 @@ class Combiner(CohortStage):
 
         j: PythonJob = get_batch().new_python_job('Combiner', (self.get_job_attrs() or {}) | {'tool': HAIL_QUERY})
         j.image(image_path('cpg_workflows'))
-        j.memory(combiner_config.get('memory', "4Gi"))
-        j.storage(combiner_config.get('storage', "5Gi"))
+        j.memory(combiner_config.get('memory', '4Gi'))
+        j.storage(combiner_config.get('storage', '5Gi'))
 
         # Default to GRCh38 for reference if not specified
         j.call(
@@ -109,6 +109,7 @@ class Combiner(CohortStage):
             gvcf_paths=new_sg_gvcfs,
             vds_paths=vds_paths,
             save_path=output_paths['combiner_plan'],
+            force_new_combiner=config_retrieve(['combiner', 'force_new_combiner'], False),
         )
 
         return self.make_outputs(cohort, output_paths, [j])
@@ -337,8 +338,8 @@ class MakeSiteOnlyVcf(CohortStage):
         sitesvcf_config = config_retrieve('sitesvcf')
 
         j.image(image_path('cpg_workflows'))
-        j.memory(sitesvcf_config.get('memory', "4Gi"))
-        j.storage(sitesvcf_config.get('storage', "5Gi"))
+        j.memory(sitesvcf_config.get('memory', '4Gi'))
+        j.storage(sitesvcf_config.get('storage', '5Gi'))
 
         init_batch_args: dict[str, str | int] = {}
         for config_key, batch_key in [('highmem_workers', 'worker_memory'), ('highmem_drivers', 'driver_memory')]:


### PR DESCRIPTION
As done in the RD combiner, don't always force a new combiner to run from scratch, if a plan exists for it already.