### PR TITLE
Split usage of two output types

### DIFF
--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -202,7 +202,7 @@ class RunExomiser(DatasetStage):
                 'ped': ped_inputs[family],
                 'pheno': ppk_files[family],
             }
-            for family in output_dict.keys()
+            for family in output_dict.keys() if '_variants' not in family
         }
 
         if exomiser_version == 14:

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -263,6 +263,10 @@ class ExomiserVariantsTSV(DatasetStage):
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
 
+        if not find_families(dataset):
+            get_logger().info('No families found, skipping exomiser')
+            return self.make_outputs(dataset, jobs=None, skipped=True)
+
         outputs = self.expected_outputs(dataset)
 
         results = inputs.as_dict(target=dataset, stage=RunExomiser)

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -202,7 +202,8 @@ class RunExomiser(DatasetStage):
                 'ped': ped_inputs[family],
                 'pheno': ppk_files[family],
             }
-            for family in output_dict.keys() if '_variants' not in family
+            for family in output_dict.keys()
+            if '_variants' not in family
         }
 
         if exomiser_version == 14:


### PR DESCRIPTION
I'm now tracking the exomiser Variant-level and Gene-level outputs from the same stage. Each type of output is directed exclusively to one downstream stage, so I just need to add some specificity.

This condition ensures that the `FAMILY_variants` output is only directed to the `variants` aggregator, not the gene-level aggregator.

Example error: 
```
    'vcf': vcf_inputs[family],
KeyError: 'A1_variants'
```