### PR TITLE
Update VDS schema to drop data

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.5
+current_version = 1.32.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.5
+  VERSION: 1.32.6
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/drop_vds_entry_fields_and_overwrite.py
+++ b/cpg_workflows/scripts/drop_vds_entry_fields_and_overwrite.py
@@ -28,7 +28,6 @@ import hail as hl
 
 from cpg_utils.hail_batch import init_batch
 
-
 if __name__ == '__main__':
 
     logging.basicConfig(level=logging.INFO)
@@ -39,20 +38,16 @@ if __name__ == '__main__':
         help='Path to input VDS',
         required=True,
     )
-    parser.add_argument(
-        '--temp_location',
-        help='Path to temporary location',
-        required=True
-    )
+    parser.add_argument('--temp_location', help='Path to temporary location', required=True)
     parser.add_argument(
         '--fields',
         help='List of strings, fields to remove. So far only DRAGstr issues have been observed',
         nargs='+',
-        default=['DRAGstrInfo', 'DRAGstrParams']
+        default=['DRAGstrInfo', 'DRAGstrParams'],
     )
     args = parser.parse_args()
 
-    logging.info(f'Starting VDS entry field drop and overwrite')
+    logging.info('Starting VDS entry field drop and overwrite')
     logging.info(f'Input VDS: {args.input}')
     logging.info(f'Temp location: {args.temp_location}')
     logging.info(f'Fields to drop: {args.fields}')
@@ -68,7 +63,7 @@ if __name__ == '__main__':
     vds.variant_data = vds.variant_data.annotate_entries(
         gvcf_info=vds.variant_data.gvcf_info.drop(
             *args.fields,
-        )
+        ),
     )
     logging.info(f'Dropped fields: {args.fields}')
     vds.variant_data.describe()

--- a/cpg_workflows/scripts/drop_vds_entry_fields_and_overwrite.py
+++ b/cpg_workflows/scripts/drop_vds_entry_fields_and_overwrite.py
@@ -1,0 +1,82 @@
+"""
+See https://batch.hail.populationgenomics.org.au/batches/556897/jobs/1
+
+This script is used to drop fields from the entries of a VDS, and then
+overwrite the original VDS with the new entries.
+
+This aims to solve an issue with Hail gVCF Combining, where we do hierarchical merge of
+
+gVCFs -> VDSs
+
+then
+
+VDSs -> single VDS
+
+The gVCFs -> VDS stage takes a union of all entry fields across all component gVCFs, so if a single
+gVCF has an unusual field, the VDS will have that field in the schema. Combining VDS intermediates
+requires all input VDSs to have an identical schema, so we have to groom out the dodgy entry fields.
+Due to the way data is combined, the entries will always be in the `entry.gvcf_info` field.
+
+Due to hail's read-from-file processing, we can't patch in place, we have to write out a new VDS, then
+overwrite the original VDS with the new one.
+"""
+
+import logging
+from argparse import ArgumentParser
+
+import hail as hl
+
+from cpg_utils.hail_batch import init_batch
+
+
+if __name__ == '__main__':
+
+    logging.basicConfig(level=logging.INFO)
+
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--input',
+        help='Path to input VDS',
+        required=True,
+    )
+    parser.add_argument(
+        '--temp_location',
+        help='Path to temporary location',
+        required=True
+    )
+    parser.add_argument(
+        '--fields',
+        help='List of strings, fields to remove. So far only DRAGstr issues have been observed',
+        nargs='+',
+        default=['DRAGstrInfo', 'DRAGstrParams']
+    )
+    args = parser.parse_args()
+
+    logging.info(f'Starting VDS entry field drop and overwrite')
+    logging.info(f'Input VDS: {args.input}')
+    logging.info(f'Temp location: {args.temp_location}')
+    logging.info(f'Fields to drop: {args.fields}')
+
+    if not args.fields:
+        raise ValueError('No fields to drop')
+
+    init_batch()
+
+    # read in the input VDS
+    vds = hl.vds.read_vds(args.input)
+    vds.variant_data.describe()
+    vds.variant_data = vds.variant_data.annotate_entries(
+        gvcf_info=vds.variant_data.gvcf_info.drop(
+            *args.fields,
+        )
+    )
+    logging.info(f'Dropped fields: {args.fields}')
+    vds.variant_data.describe()
+
+    logging.info(f'Checkpointing VDS to {args.temp_location}')
+    vds = vds.checkpoint(args.temp_location)
+
+    logging.info(f'Checkpointed VDS to {args.temp_location}, writing back to {args.input}')
+    vds.write(args.input, overwrite=True)
+
+    logging.info('Done')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.5',
+    version='1.32.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add a script to do a VDS-editing 2-step

- take a VDS, and the list of `entry.gvcf_info` fields to remove
- remove fields from schema and write to a new location
- read back in, and overwrite original location

This is a pretty invasive operation, but AFAIK the data we have issues with is not currently recoverable, and there's no way to provide parameters during combining to remove specific fields, so we need to either edit the VDSs or gVCFs in-place to save our joint-call.