### PR TITLE
Revert cpg_workflows pin to Hail 132 now that issues are understood

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,7 @@ setup(
         'cpg-utils>=5.1.1',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        # Pin Hail to the release prior to 0.2.133
-        # see https://centrepopgen.slack.com/archives/C018KFBCR1C/p1731047651300539
-        'hail==0.2.132',
+        'hail>=0.2.133',
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
         'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'cpg-utils>=5.1.1',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        'hail>=0.2.133',
+        'hail==0.2.133',  # Pin Hail at CPG's installed version
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
         'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking


### PR DESCRIPTION
After the roller-coaster of Hail JAR iteration, we now understand the underlying cause of the inflated expense issues - there is no "expensive version of Hail", per se, so we can release this pin to an earlier formal release version.

This is relevant for VDS work - it appears that even if the QOB JAR file is an earlier hail version, the codecs used to write data (VDSs) are determined by this version. By pinning to this earlier version we write VDSs which natively have an older specification, and would have less efficient interval queries.

This is evident if you read any of the recently written VDSs with Hail 133+, you get a logging notice suggesting that your VDSs be patched in place to gain the improved functionality.