### PR TITLE
Put partition command in correct method call

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.6
+current_version = 1.32.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.6
+  VERSION: 1.32.7
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -60,12 +60,12 @@ def main(
     # check here to see if we can reuse the dense MT
     if not can_reuse(dense_mt_out):
 
-        vds = hl.vds.read_vds(vds_in)
-
         get_logger().info(f'Densifying data, using {partitions} partitions')
 
         # providing n_partitions here gets Hail to calculate the intervals per partition on the VDS var and ref data
-        mt = hl.vds.to_dense_mt(vds, n_partitions=partitions)
+        vds = hl.vds.read_vds(vds_in, n_partitions=partitions)
+
+        mt = hl.vds.to_dense_mt(vds)
 
         # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
         # remove any monoallelic or non-ref-in-any-sample sites

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -49,7 +49,12 @@ def main(
         sites_only (str): optional, if used write a sites-only VCF directory to this location
         separate_header (str): optional, if used write a sites-only VCF directory with a separate header to this location
     """
-    init_batch()
+
+    init_batch(
+        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
+        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
+        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+    )
 
     get_logger().info(f'Partition strategy {partition_strategy} is not currently in use (see #1078)')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.6',
+    version='1.32.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Not sure why my local linter and the CI check both thought this was ok... The `n_partitions` argument was placed in the wrong method call
https://batch.hail.populationgenomics.org.au/batches/557481/jobs/3