### PR TITLE
Couple of exomiser tweaks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.7
+current_version = 1.32.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.7
+  VERSION: 1.32.8
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -11,7 +11,6 @@ from hailtop.batch.job import Job
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve, get_config, image_path, reference_path
 from cpg_utils.hail_batch import get_batch
-from cpg_workflows.scripts import collect_dataset_tsvs
 from cpg_workflows.targets import SequencingGroup
 from cpg_workflows.utils import chunks, exists
 
@@ -396,27 +395,3 @@ def run_exomiser_14(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
                     str(content_dict[family]['output']).removesuffix('.tsv'),
                 )
     return all_jobs
-
-
-def generate_seqr_summary(tsv_dict: dict[str, Path], project: str, output: str):
-    """
-    Generate the summary TSV for Seqr by combining all per-family TSVs
-
-    Args:
-        tsv_dict (dict[str, Path]):
-        project ():
-        output ():
-    """
-
-    # path to the python script
-    script_path = collect_dataset_tsvs.__file__.removeprefix('/production-pipelines')
-
-    # read all the input files in
-    files_read_in = [get_batch().read_input(str(tsv)) for tsv in tsv_dict.values()]
-
-    job = get_batch().new_bash_job(f'Aggregate TSVs for {project}')
-    job.storage('10Gi')
-    job.image(get_config()['workflow']['driver_image'])
-    job.command(f'python3 {script_path} --project {project} --input {" ".join(files_read_in)} --output {job.output} ')
-    get_batch().write_output(job.output, output)
-    return [job]

--- a/cpg_workflows/scripts/collect_dataset_tsvs.py
+++ b/cpg_workflows/scripts/collect_dataset_tsvs.py
@@ -112,7 +112,7 @@ def main(project: str, input_files: list[str], p_threshold: float = 0.05):
     return output_lines
 
 
-if __name__ == '__main__':
+def cli_main():
 
     parser = ArgumentParser()
     parser.add_argument('--project', help='Name of Seqr Project')
@@ -127,3 +127,7 @@ if __name__ == '__main__':
     with open(args.output, 'w') as handle:
         for line in data_lines:
             handle.write('\t'.join(line) + '\n')
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -16,9 +16,7 @@ from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.exomiser import (
     create_gvcf_to_vcf_jobs,
     extract_mini_ped_files,
-    generate_seqr_summary,
     make_phenopackets,
-    run_exomiser_13,
     run_exomiser_14,
 )
 from cpg_workflows.utils import get_logger
@@ -206,43 +204,56 @@ class RunExomiser(DatasetStage):
             if '_variants' not in family
         }
 
-        if exomiser_version == 14:
-            jobs = run_exomiser_14(single_dict)
-        elif exomiser_version == 13:
-            jobs = run_exomiser_13(single_dict)
-        else:
+        # commenting out the 13 version as it's not maintained anymore
+        if exomiser_version != 14:
             raise ValueError(f'Exomiser version {exomiser_version} not supported')
+
+        jobs = run_exomiser_14(single_dict)
 
         return self.make_outputs(dataset, data=output_dict, jobs=jobs)
 
 
-@stage(required_stages=[RunExomiser], analysis_type='exomiser', analysis_keys=['tsv'])
+@stage(required_stages=[RunExomiser], analysis_type='exomiser')
 class ExomiserSeqrTSV(DatasetStage):
     """
     Parse the Exomiser results into a TSV for Seqr
     """
 
-    def expected_outputs(self, dataset: Dataset):
+    def expected_outputs(self, dataset: Dataset) -> Path:
         exomiser_version = config_retrieve(['workflow', 'exomiser_version'], 14)
-
-        return {
-            'tsv': dataset.analysis_prefix()
-            / get_workflow().output_version
-            / f'exomiser_{exomiser_version}_results.tsv',
-        }
+        return dataset.analysis_prefix() / get_workflow().output_version / f'exomiser_{exomiser_version}_results.tsv'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
+
+        output = self.expected_outputs(dataset)
+
         # is there a seqr project?
         projects = find_seqr_projects()
+
         if dataset.name not in projects:
             get_logger(__file__).info(f'No Seqr project found for {dataset.name}, skipping')
             return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=[], skipped=True)
 
         results = inputs.as_dict(target=dataset, stage=RunExomiser)
 
-        jobs = generate_seqr_summary(results, projects[dataset.name], str(self.expected_outputs(dataset)['tsv']))
+        # just collect the per-family gene-level TSVs
+        local_files: list = []
+        for family, file in results.items():
+            if family.endswith('_variants'):
+                continue
 
-        return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=jobs)
+            local_files.append(get_batch().read_input(file))
+
+        # assign the project name to a variable
+        project = projects[dataset.name]
+
+        job = get_batch().new_bash_job(f'Aggregate gene-level TSVs for {project}')
+        job.storage('10Gi')
+        job.image(config_retrieve(['workflow', 'driver_image']))
+        job.command(f'combine_exomiser_genes --project {project} --input {" ".join(local_files)} --output {job.output}')
+        get_batch().write_output(job.output, str(output))
+
+        return self.make_outputs(dataset, data=output, jobs=job)
 
 
 @stage(required_stages=[RunExomiser], analysis_type='exomiser', analysis_keys=['json', 'ht'])

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -281,9 +281,7 @@ class ExomiserVariantsTSV(DatasetStage):
         job.image(config_retrieve(['workflow', 'driver_image']))
 
         job.declare_resource_group(output={'json': '{root}.json', 'ht': '{root}.ht'})
-        job.command(
-            f'combine_exomiser_variants ' f'--input {" ".join(family_files)} ' f'--output {job.output} ' f'--as_hail ',
-        )
+        job.command(f'combine_exomiser_variants --input {" ".join(family_files)} --output {job.output}')
 
         # recursive copy of the HT
         job.command(f'gcloud storage cp -r {job.output["ht"]} {str(outputs["ht"])}')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.7',
+    version='1.32.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,9 @@ setup(
             # Reconfigure annotations for Seqr Export
             'annotate_dataset_small = cpg_workflows.scripts.annotate_dataset_small_vars:cli_main',
             # script for combining multiple per-family exomiser Variant-level TSVs into a single JSON & Hail Table
-            'combine_exomiser_variants = cpg_workflows.scripts.combine_exomiser_variant_tsvs:cli_main',
+            'combine_exomiser_variants = cpg_workflows.scripts.combine_dataset_tsvs:cli_main',
+            # script for combining multiple per-family exomiser Gene-level TSVs into a single JSON
+            'combine_exomiser_genes = cpg_workflows.scripts.combine_exomiser_variant_tsvs:cli_main',
         ],
     },
 )


### PR DESCRIPTION
I needed to adjust a behaviour in the gene-level aggregation Stage - the gene-level aggregation ignores all '-variants' files, the variant aggregation only uses '-variants' files. 

This felt like a decent opportunity to change the way this Stage works in general, to make it behave the same as the other stages (use an entrypoint instead of finding a script by guessing the path to it)