### PR TITLE
Mitocram markduplicates job rename

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.10
+current_version = 1.32.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.10
+  VERSION: 1.32.11
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -139,7 +139,8 @@ def markdup(
     Make job that runs Picard MarkDuplicates and converts the result to CRAM.
     """
     job_attrs = (job_attrs or {}) | dict(tool='picard_MarkDuplicates')
-    j = b.new_job('MarkDuplicates', job_attrs)
+    job_name = 'MarkDuplicates' + (' mito' if 'mito' in str(output_path) else '')
+    j = b.new_job(job_name, job_attrs)
     if can_reuse(output_path, overwrite):
         return None
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.10',
+    version='1.32.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
A very minor change to the Markduplicates job to append `' mito'` to the job name, to more easily distinguish the jobs during runs involving both the `Align` and `RealignMito` stages.

E.g. It would be very useful to know how many of these jobs failed at Markduplicates from Align vs Markduplicates from RealignMito, but since they all have the same name it's difficult to tell - and this has cost implications when thinking about rerunning the cohort.
https://batch.hail.populationgenomics.org.au/batches/588491?q=state%3Dbad