### PR TITLE
Exomiser uses the wrong contig?

### DIFF
--- a/cpg_workflows/scripts/combine_exomiser_variant_tsvs.py
+++ b/cpg_workflows/scripts/combine_exomiser_variant_tsvs.py
@@ -12,7 +12,7 @@ import hail as hl
 
 from cpg_utils import to_path
 
-ORDERED_ALLELES: list[str] = [f'chr{x}' for x in list(range(1, 23))] + ['chrX', 'chrY', 'chrM']
+ORDERED_ALLELES: list[str] = [f'chr{x}' for x in list(range(1, 23))] + ['chrX', 'chrY', 'chrM', 'chrMT']
 FAM_DICT = dict[str, dict[str, list[dict]]]
 VAR_DICT = dict[str, list[str]]
 


### PR DESCRIPTION
Yet another little issue with Exomiser

Mitochondrial variants (which we are incidentally calling in our standard small variant pipeline) are appearing in Exomiser reports as `MT`, not `M` as we would expect given the genome build