### PR TITLE
Override exomiser MT contig

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.11
+current_version = 1.32.12
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.11
+  VERSION: 1.32.12
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.11',
+    version='1.32.12',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I tried to be nice and work around Exomiser's erroneous use of MT as the GRCh38 Mitochondrial contig name... then stepped firmly on the Hail rake

https://batch.hail.populationgenomics.org.au/batches/588576/jobs/1