### PR TITLE
Add option to write sorted bam to temp and reuse it for markdups

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.12
+current_version = 1.32.13
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.14
+current_version = 1.32.15
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.33.1
+current_version = 1.33.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.33.1
+  VERSION: 1.33.2
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.12
+  VERSION: 1.32.13
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.14
+  VERSION: 1.32.15
 
 jobs:
   docker:

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -12,10 +12,7 @@ highmem_workers = true
 #realign_from_cram_version = 'v0'
 
 # Write the sorted BAM file to the temp bucket after alignment and before MarkDuplicates
-# checkpoint_sorted_bam = false
-
-# Re-use the sorted BAM file from the temp bucket after alignment and before MarkDuplicates
-# reuse_sorted_bam = false
+checkpoint_sorted_bam = false
 
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -11,6 +11,12 @@ highmem_workers = true
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPGaaa.cram
 #realign_from_cram_version = 'v0'
 
+# Write the sorted BAM file to the temp bucket after alignment and before MarkDuplicates
+# checkpoint_sorted_bam = false
+
+# Re-use the sorted BAM file from the temp bucket after alignment and before MarkDuplicates
+# reuse_sorted_bam = false
+
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -17,10 +17,7 @@ vep_version = '110'
 #realign_from_cram_version = 'v0'
 
 # Write the sorted BAM file to the temp bucket after alignment and before MarkDuplicates
-# checkpoint_sorted_bam = false
-
-# Re-use the sorted BAM file from the temp bucket after alignment and before MarkDuplicates
-# reuse_sorted_bam = false
+checkpoint_sorted_bam = false
 
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -16,6 +16,12 @@ vep_version = '110'
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPGaaa.cram
 #realign_from_cram_version = 'v0'
 
+# Write the sorted BAM file to the temp bucket after alignment and before MarkDuplicates
+# checkpoint_sorted_bam = false
+
+# Re-use the sorted BAM file from the temp bucket after alignment and before MarkDuplicates
+# reuse_sorted_bam = false
+
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -172,7 +172,7 @@ def align(
     sharded_align_jobs = []
     sorted_bams = []
 
-    if can_reuse(sorted_bam_path, overwrite):
+    if can_reuse(sorted_bam_path):
         # If the sorted BAM can be reused, skip the alignment job(s) and go straight to markdup.
         logging.info(f'{sequencing_group.id} :: Re-using sorted BAM: {sorted_bam_path}')
         # Its necessary to create this merge_or_align_j object to pass it to finalise_alignment,
@@ -621,7 +621,7 @@ def finalise_alignment(
             align_cmd += f' {sort_cmd(nthreads)}'
         align_cmd += f' > {j.sorted_bam}'
 
-    if not can_reuse(sorted_bam_path, overwrite):
+    if not can_reuse(sorted_bam_path):
         # Submit the alignment job(s) if we're not reusing the sorted BAM
         j.command(command(align_cmd, monitor_space=True))  # type: ignore
 

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -177,6 +177,7 @@ def align(
         merge_or_align_j = b.new_job('Reusing sorted bam', job_attrs or {})
         merge_or_align_j.sorted_bam = b.read_input(str(sorted_bam_path))
         jobs.append(merge_or_align_j)
+        align_cmd = ''
 
     elif not sharded:  # Just running one alignment job
         if isinstance(alignment_input, FastqPairs):

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -617,14 +617,16 @@ def finalise_alignment(
     # If sorted_bam_path is provided, skip to markdup if it exists and reuse_sorted_bam is true
     reusing_sorted_bam = False
     if sorted_bam_path:
-        if sorted_bam_path.exists() and config_retrieve('workflow', 'reuse_sorted_bam', False):
+        if sorted_bam_path.exists() and config_retrieve(['workflow', 'reuse_sorted_bam'], False):
             logging.info(f'Skipping alignment job, {sorted_bam_path} already exists')
             j.sorted_bam = b.read_input(str(sorted_bam_path))
             reusing_sorted_bam = True
-        elif not sorted_bam_path.exists() and config_retrieve('workflow', 'checkpoint_sorted_bam', False):
+        elif not sorted_bam_path.exists() and config_retrieve(['workflow', 'checkpoint_sorted_bam'], False):
             logging.info(f'Will write sorted bam to checkpoint: {sorted_bam_path}')
             j.command(command(align_cmd, monitor_space=True))  # type: ignore
             b.write_output(j.sorted_bam, str(sorted_bam_path))
+        else:
+            j.command(command(align_cmd, monitor_space=True))  # type: ignore
     else:
         j.command(command(align_cmd, monitor_space=True))  # type: ignore
 

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -176,7 +176,9 @@ def align(
         logging.info(f'{sequencing_group.id} :: Re-using sorted BAM: {sorted_bam_path}')
         # Its necessary to create this merge_or_align_j object to pass it to finalise_alignment,
         # and to declare the sorted_bam_path as a resource, so it can be written to the checkpoint.
+        job_attrs = (job_attrs or {}) | dict(label='Reusing sorted bam', tool='Reusing sorted bam')
         merge_or_align_j = b.new_job('Reusing sorted bam', job_attrs or {})
+        merge_or_align_j.image(config_retrieve(['workflow', 'driver_image']))
         merge_or_align_j.sorted_bam = b.read_input(str(sorted_bam_path))
         jobs.append(merge_or_align_j)
         # The align_cmd and other parameters are not used but are necessary to pass to finalise_alignment.

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -178,6 +178,8 @@ def align(
         merge_or_align_j.sorted_bam = b.read_input(str(sorted_bam_path))
         jobs.append(merge_or_align_j)
         align_cmd = ''
+        stdout_is_sorted = True
+        output_fmt = 'bam'
 
     elif not sharded:  # Just running one alignment job
         if isinstance(alignment_input, FastqPairs):

--- a/cpg_workflows/stages/align.py
+++ b/cpg_workflows/stages/align.py
@@ -55,6 +55,9 @@ class Align(SequencingGroupStage):
             / 'markduplicates_metrics'
             / f'{sequencing_group.id}.markduplicates-metrics'
         )
+        sorted_bam_path = (
+            sequencing_group.dataset.prefix(category='tmp') / 'align' / f'{sequencing_group.id}.sorted.bam'
+        )
 
         try:
             jobs = align.align(
@@ -63,6 +66,7 @@ class Align(SequencingGroupStage):
                 output_path=sequencing_group.make_cram_path(),
                 job_attrs=self.get_job_attrs(sequencing_group),
                 overwrite=sequencing_group.forced,
+                sorted_bam_path=sorted_bam_path,
                 out_markdup_metrics_path=markdup_metrics_path,
             )
             return self.make_outputs(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.12',
+    version='1.32.13',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.14',
+    version='1.32.15',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.33.1',
+    version='1.33.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Addresses #1092 

Adds some logic that modifies the align job so that the sorted BAM created by the align / merge jobs can be re used by MarkDuplicates if MarkDuplicates fails or is cancelled.
 
- **NEW CONFIG OPTION**: `workflow.checkpoint_sorted_bam` - If this is set and the file does not already exist, write the sorted BAM to temp storage prior to MarkDuplicates. 
  - The sorted BAMs are large and it would be expensive to store them in temp for all sequencing groups being aligned. Therefore, it's best to keep this as a config option to be toggled on for runs with expensive align jobs, where checkpointing the BAMs would be wise. 

- **NEW LOGIC**: Re-use the sorted BAM in temp storage as input to MarkDuplicates (if it exists), skipping the align / merge jobs. The config option `workflow.check_intermediates` must be set to allow reuse.

---

This works by adding a new path arg to the `Align` stage & jobs - `sorted_bam_path`, which is a path in the dataset's temp bucket. 

Then, if set in the config, the sorted BAM output by the align / merge jobs will be written to this temp path. This will allow MarkDuplicates to read the sorted BAM from the temp storage if the MarkDuplicates job needs to be re-attempted (which is not uncommon, due to memory requirements & transient errors). 

If the sorted BAM exists in the temp path on a rerun can be reused, the align jobs will be skipped, and only the MarkDuplicates job will be executed. A "dummy job" will be created in place of the align / merge job which usually creates the sorted BAM. This is required due to the structure of the `finalise_alignment` function in the align job module. 

---

### Test run

1. Sorted BAM is checkpointed by aligning fastqs and writing the merged and sorted BAM to tmp storage
[Driver](https://batch.hail.populationgenomics.org.au/batches/588601/jobs/1) and [Batch](https://batch.hail.populationgenomics.org.au/batches/588602?q=&last_job_id=50)
2. Sorted BAM is re-used to skip straight to MarkDuplicates, which reads the sorted BAM from temp
[Driver](https://batch.hail.populationgenomics.org.au/batches/588626/jobs/1) and [Batch](https://batch.hail.populationgenomics.org.au/batches/588627)
3. Genotype jobs are correctly queued after sorted BAM reuse
[Driver](https://batch.hail.populationgenomics.org.au/batches/588628/jobs/1) and [Batch](https://batch.hail.populationgenomics.org.au/batches/588629)