### PR TITLE
Non pre-emptible gVCF combiner jobs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.32.12
+current_version = 1.32.13
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.32.12
+  VERSION: 1.32.13
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -49,6 +49,8 @@ driver_storage = "10Gi"
 driver_cores = 1
 # highem, standard, or a string, e.g. "4Gi"
 worker_memory = "standard"
+# if false, use non-preemptible VMs
+preemptible_vms = false
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -173,6 +173,10 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
         combiner_job.storage(config_retrieve(['combiner', 'driver_storage']))
         combiner_job.cpu(config_retrieve(['combiner', 'driver_cores'], 2))
 
+        # set this job to be non-spot (i.e. non-preemptible)
+        # previous issues with preemptible VMs led to multiple simultaneous QOB groups processing the same data
+        combiner_job.spot(config_retrieve(['combiner', 'preemptible_vms'], False))
+
         # Default to GRCh38 for reference if not specified
         combiner_job.call(
             combiner.run,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.32.12',
+    version='1.32.13',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
By default this makes the Combiner host job non-preemptible. This alters the scheduling behaviour, and prevents the top level job being preempted/replaced. The quirk is this:

- We start a combiner job
- The combiner job starts an open QOB batch which carries out all the underlying tasks
- If the combiner job is preempted, it restarts, generating a new QOB batch
- Hail doesn't have a mechanic to abort the original QOB batch, so now we have two ongoing QOB batches doing the same work, writing to the same locations (unless the original one is manually cancelled)

worst case scenario here: https://batch.hail.populationgenomics.org.au/batches/588549/jobs/1  - multiple sporadic preemptions and a really muddy job history. The final job didn't appear to get close to a conclusion.

This change makes the single host/driver job non-spot to prevent preemption, which doesn't stop QOB jobs being preempted, but does stop multiple versions of the same batch being started. This job is relatively low-resource, so even a non-spot instance should represent a negligible cost relative to the gVCF combining.

---

Tagging @katiedelange  and @Alexander-Stuckey  as an FYI - this preemption/combiner duplication has been pretty frequent lately, and could easily happen in the PA pipeline