### PR TITLE
Setting force_new_combiner to have a default value of False

### DIFF
--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -28,7 +28,7 @@ def run(
     tmp_prefix: str,
     genome_build: str,
     save_path: str | None,
-    force_new_combiner: bool,
+    force_new_combiner: bool = False,
     gvcf_paths: list[str] | None = None,
     vds_paths: list[str] | None = None,
     specific_intervals: list[str] | None = None,


### PR DESCRIPTION
Getting a `TypeError: run() got an unexpected keyword argument 'force_new_combiner'` [here](https://batch.hail.populationgenomics.org.au/batches/588842/jobs/1) because of position of argument in the `combiner.run()` function.

Changing `force_new_combiner` to have default value of `False`