### PR TITLE
Change py version in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10.0'
+        python-version: '3.10.9'
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10.9'
+        python-version: '3.10'
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11.0'
+        python-version: '3.10.0'
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt


### PR DESCRIPTION
This is to make it consistent with the versions defined in the pre-commit config and the rest of the codebase. Also stops the linting from failing.