### PR TITLE
grubby little hack

### DIFF
--- a/cpg_workflows/stages/dragen_ica/monitor_align_genotype_with_dragen.py
+++ b/cpg_workflows/stages/dragen_ica/monitor_align_genotype_with_dragen.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 from random import randint
@@ -19,7 +18,7 @@ def run(
     """Monitor a pipeline running in ICA
 
     Args:
-        ica_pipeline_id_path (str): The path to the JSON file holding the pipeline ID
+        ica_pipeline_id_path (str): The path to the file holding the pipeline ID
         api_root (str): The root API endpoint for ICA
 
     Raises:
@@ -39,7 +38,7 @@ def run(
     configuration.api_key['ApiKeyAuth'] = api_key
 
     with open(cpg_utils.to_path(ica_pipeline_id_path), 'rt') as pipeline_fid_handle:
-        ica_pipeline_id: str = json.load(pipeline_fid_handle)['pipeline_id']
+        ica_pipeline_id: str = pipeline_fid_handle.read().rstrip()
 
     with icasdk.ApiClient(configuration=configuration) as api_client:
         api_instance = project_analysis_api.ProjectAnalysisApi(api_client)
@@ -58,7 +57,7 @@ def run(
             )
         if pipeline_status == 'SUCCEEDED':
             logging.info(f'Pipeline run {ica_pipeline_id} has succeeded')
-            return {'pipeline': 'success'}
+            return {'pipeline': ica_pipeline_id, 'status': 'success'}
         elif pipeline_status in ['ABORTING', 'ABORTED']:
             raise Exception(f'Pipeline run {ica_pipeline_id} has been cancelled.')
         else:

--- a/cpg_workflows/stages/dragen_ica/run_align_genotype_with_dragen.py
+++ b/cpg_workflows/stages/dragen_ica/run_align_genotype_with_dragen.py
@@ -88,7 +88,8 @@ def run(
     reference_tags: list[str],
     user_reference: str,
     api_root: str,
-) -> dict[str, str]:
+    output_path: str,
+):
     """_summary_
 
     Args:
@@ -102,10 +103,9 @@ def run(
         reference_tags (list[str]): List of reference tags for the analysis (optional, can be empty)
         user_reference (str): A reference name for the pipeline run
         api_root (str): The ICA API root
-
-    Returns:
-        dict[str, str]: A dict holding the pipeline ID
+        output_path (str): The path to write the pipeline ID to
     """
+
     SECRETS: dict[Literal['projectID', 'apiKey'], str] = ica_utils.get_ica_secrets()
     project_id: str = SECRETS['projectID']
     api_key: str = SECRETS['apiKey']
@@ -139,4 +139,5 @@ def run(
         )
 
         logging.info(f'Submitted ICA run with pipeline ID: {analysis_run_id}')
-        return {'pipeline_id': analysis_run_id}
+        with cpg_utils.to_path(output_path).open('w') as f:
+            f.write(analysis_run_id)

--- a/cpg_workflows/stages/realign_genotype_with_dragen.py
+++ b/cpg_workflows/stages/realign_genotype_with_dragen.py
@@ -149,7 +149,11 @@ class AlignGenotypeWithDragen(SequencingGroupStage):
         sg_bucket: cpg_utils.Path = sequencing_group.dataset.prefix()
         return {
             'output': sg_bucket / GCP_FOLDER_FOR_RUNNING_PIPELINE / f'{sequencing_group.name}_pipeline_concluded.json',
-            'pipeline_id': str(sequencing_group.dataset.prefix(test=True) / GCP_FOLDER_FOR_RUNNING_PIPELINE / f'{sequencing_group.name}_pipeline_id.json'),
+            'pipeline_id': str(
+                sequencing_group.dataset.prefix(test=True)
+                / GCP_FOLDER_FOR_RUNNING_PIPELINE
+                / f'{sequencing_group.name}_pipeline_id.json',
+            ),
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
@@ -159,10 +163,9 @@ class AlignGenotypeWithDragen(SequencingGroupStage):
         stage_jobs: list[BashJob | PythonJob] = []
 
         # test if a previous pipeline should be re-monitored
-        if (
-                (resume := config_retrieve(['ica', 'pipelines', 'monitor_previous'], False))
-                and cpg_utils.to_path(outputs['pipeline_id']).exists()
-        ):
+        if (resume := config_retrieve(['ica', 'pipelines', 'monitor_previous'], False)) and cpg_utils.to_path(
+            outputs['pipeline_id'],
+        ).exists():
             logging.info(f'Previous pipeline found for {sequencing_group.name}, not setting off a new one')
         elif resume:
             logging.warning(f'No previous pipeline found for {sequencing_group.name}, but resume flag set.')
@@ -294,7 +297,7 @@ class CancelIcaPipelineRun(SequencingGroupStage):
 
 @stage(
     analysis_type='ica_data_download',
-    required_stages=[PrepareIcaForDragenAnalysis, MonitorAlignGenotypeWithDragen, GvcfMlrWithDragen],
+    required_stages=[PrepareIcaForDragenAnalysis, GvcfMlrWithDragen],
 )
 class DownloadDataFromIca(SequencingGroupStage):
     def expected_outputs(


### PR DESCRIPTION
A bluesky thinking branch trying to model a few situations within a single stage:
- what if the ICA pipeline fails, and a new one needs to be submitted
- what if the watcher job fails, and we need to keep watching the same pipeline ID
- if this is the first attempt, we need to submit and watch 
- if the whole process succeeds, never repeat the stage

We can do this in the current format by manually deleting the stage outputs from the Align & Monitor stages, forcing the submission & watching jobs to repeat. It's not clear at this time whether blindly restarting a new ICA pipeline is a good idea, or whether each failure should be manually investigated.

This probably won't work for all scenarios (e.g. 2 consecutive failures), and in those situations it's really not clear if we should be automating restarts

Changes
- Combines starting the pipeline and monitoring into one stage
- pipeline ID written into temp storage as a file with a single string in it
- If the `monitor_previous` arg is used in config, and the pipeline ID file exists, it will go straight to monitoring
- if `monitor_previous` but no file, warning message
- if not monitor_previous, the stage resubmits an ICA job
- only writes proper output file if successful, containing both ID and status