### PR TITLE
Fix force new combiner param

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -24,6 +24,8 @@ memory = "8Gi"
 storage = "10Gi"
 vds_analysis_ids = []
 merge_only_vds = false
+# if false, use non-preemptible VMs
+preemptible_vms = false
 
 [vqsr]
 # VQSR, when applying model, targets indel_filter_level and snp_filter_level

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -42,10 +42,10 @@ def run(
         tmp_prefix (str): where to store temporary combiner intermediates
         genome_build (str): GRCh38
         save_path (str | None): where to store the combiner plan, or where to resume from
+        force_new_combiner (bool): whether to force a new combiner run, or permit resume from a previous one
         gvcf_paths (list[str] | None): list of paths to GVCFs
         vds_paths (list[str] | None): list of paths to VDSs
         specific_intervals (list[str] | None): list of intervals to use for the combiner, if using non-standard
-        force_new_combiner (bool): whether to force a new combiner run, or permit resume from a previous one
     """
     import logging
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -95,7 +95,7 @@ class Combiner(CohortStage):
             return self.make_outputs(cohort, output_paths)
 
         j: PythonJob = get_batch().new_python_job('Combiner', (self.get_job_attrs() or {}) | {'tool': HAIL_QUERY})
-        j.image(image_path('cpg_workflows'))
+        j.image(config_retrieve(['workflow', 'driver_image']))
         j.memory(combiner_config.get('memory'))
         j.storage(combiner_config.get('storage'))
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -107,9 +107,9 @@ class Combiner(CohortStage):
             tmp_prefix=tmp_prefix,
             genome_build=genome_build(),
             save_path=output_paths['combiner_plan'],
+            force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),
             gvcf_paths=new_sg_gvcfs,
             vds_paths=vds_paths,
-            force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),
         )
 
         return self.make_outputs(cohort, output_paths, [j])

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -99,6 +99,10 @@ class Combiner(CohortStage):
         j.memory(combiner_config.get('memory'))
         j.storage(combiner_config.get('storage'))
 
+        # set this job to be non-spot (i.e. non-preemptible)
+        # previous issues with preemptible VMs led to multiple simultaneous QOB groups processing the same data
+        j.spot(config_retrieve(['combiner', 'preemptible_vms'], False))
+
         # Default to GRCh38 for reference if not specified
         j.call(
             combiner.run,

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -106,9 +106,9 @@ class Combiner(CohortStage):
             sequencing_type=workflow_config['sequencing_type'],
             tmp_prefix=tmp_prefix,
             genome_build=genome_build(),
+            save_path=output_paths['combiner_plan'],
             gvcf_paths=new_sg_gvcfs,
             vds_paths=vds_paths,
-            save_path=output_paths['combiner_plan'],
             force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),
         )
 


### PR DESCRIPTION
Updating the image has worked.

The was `Combiner` stage using a `cpg_workflows` image from the config `australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:1.32.1` which was over a month old, that image was built December 17th, the `force_new_combiner` argument was added on the 20th. 

Updating the code so that the Combiner job runs inside the more recently built `driver_image` that contains the new parameter works.

Also noting that, the code printed out in the Combiner driver job itself was not the code being run by the Combiner workers. Which is why, despite the `force_new_combiner` parameter being visible in the print out in [this](https://batch.hail.populationgenomics.org.au/batches/588883/jobs/1) job, it didn't actually exist in the job that was doing the work.

So because the driver and worker jobs are using different images, they actually have a different `combiner.run` method description, but both are using the same arguments (from the driver job).

Shoutout to @MattWellie for providing context