### PR TITLE
Remove doubled printing during workflow planning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.33.2
+current_version = 1.33.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.33.2
+  VERSION: 1.33.3
 
 jobs:
   docker:

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -1382,7 +1382,6 @@ class CohortStage(Stage, ABC):
         output_by_target: dict[str, StageOutput | None] = dict()
         for cohort in multicohort.get_cohorts():
             action = self._get_action(cohort)
-            logging.info(f'{self.name}: {cohort} [{action.name}]')
             output_by_target[cohort.target_id] = self._queue_jobs_with_checks(cohort, action)
         return output_by_target
 

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -1344,9 +1344,8 @@ class DatasetStage(Stage, ABC):
         """
         output_by_target: dict[str, StageOutput | None] = dict()
         # iterate directly over the datasets in this multicohort
-        for dataset_i, dataset in enumerate(multicohort.get_datasets()):
+        for dataset in multicohort.get_datasets():
             action = self._get_action(dataset)
-            logging.info(f'{self.name}: #{dataset_i + 1}/{dataset} [{action.name}]')
             output_by_target[dataset.target_id] = self._queue_jobs_with_checks(dataset, action)
         return output_by_target
 
@@ -1413,6 +1412,5 @@ class MultiCohortStage(Stage, ABC):
         """
         output_by_target: dict[str, StageOutput | None] = dict()
         action = self._get_action(multicohort)
-        logging.info(f'{self.name}: {multicohort} [{action.name}]')
         output_by_target[multicohort.target_id] = self._queue_jobs_with_checks(multicohort, action)
         return output_by_target

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.33.2',
+    version='1.33.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
These lines are logged twice - once each for Dataset, Cohort, and MultiCohort Stages. These same lines are already printed in get_action, and make the logging during the driver job look a bit silly.

Should be fixed in cpg-flow, but why wait