### PR TITLE
Re-work exomiser stages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.33.2
+current_version = 1.34.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.33.2
+  VERSION: 1.34.0
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -79,12 +79,13 @@ def family_vcf_from_gvcf(family_members: list[SequencingGroup], out_path: str) -
     return job
 
 
-def create_gvcf_to_vcf_jobs(proband_dict: dict[str, list[SequencingGroup]], out_paths: dict[str, Path]) -> list[Job]:
+def create_gvcf_to_vcf_jobs(proband_dict: dict[str, list[SequencingGroup]], previous_completions: set[str], out_paths: dict[str, Path],) -> list[Job]:
     """
     Create Joint VCFs for families of SG IDs
 
     Args:
         proband_dict (): dict of proband ID to list of SG IDs
+        previous_completions (set[str]): set of analyses we've already completed
         out_paths (): dict of family ID to output path
     Returns:
         list of Jobs
@@ -96,7 +97,7 @@ def create_gvcf_to_vcf_jobs(proband_dict: dict[str, list[SequencingGroup]], out_
     for proband, members in proband_dict.items():
 
         # skip if already done
-        if exists(out_paths[proband]):
+        if exists(out_paths[proband]) or proband in previous_completions:
             continue
 
         jobs.append(family_vcf_from_gvcf(members, str(out_paths[proband])))

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -79,12 +79,12 @@ def family_vcf_from_gvcf(family_members: list[SequencingGroup], out_path: str) -
     return job
 
 
-def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_paths: dict[str, Path]) -> list[Job]:
+def create_gvcf_to_vcf_jobs(proband_dict: dict[str, list[SequencingGroup]], out_paths: dict[str, Path]) -> list[Job]:
     """
     Create Joint VCFs for families of SG IDs
 
     Args:
-        families (): dict of proband ID to list of SG IDs
+        proband_dict (): dict of proband ID to list of SG IDs
         out_paths (): dict of family ID to output path
     Returns:
         list of Jobs
@@ -93,7 +93,7 @@ def create_gvcf_to_vcf_jobs(families: dict[str, list[SequencingGroup]], out_path
     jobs: list[Job] = []
 
     # take each family
-    for proband, members in families.items():
+    for proband, members in proband_dict.items():
 
         # skip if already done
         if exists(out_paths[proband]):
@@ -117,7 +117,7 @@ def extract_mini_ped_files(proband_dict: dict[str, list[SequencingGroup]], out_p
 
         ped_path = out_paths[proband_id]
         # don't recreate if it exists
-        if not ped_path.exists():
+        if not exists(ped_path):
             # make the pedigree for this family
             df = pd.DataFrame([sg.pedigree.get_ped_dict() for sg in members])
             with ped_path.open('w') as ped_file:

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -159,7 +159,7 @@ def make_phenopackets(family_dict: dict[str, list[SequencingGroup]], out_path: d
             json.dump(phenopacket, ppk_file, indent=2)
 
 
-def run_exomiser_14(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
+def run_exomiser(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
     """
     run jobs through Exomiser 14
     type hint is still wild

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -79,7 +79,11 @@ def family_vcf_from_gvcf(family_members: list[SequencingGroup], out_path: str) -
     return job
 
 
-def create_gvcf_to_vcf_jobs(proband_dict: dict[str, list[SequencingGroup]], previous_completions: set[str], out_paths: dict[str, Path],) -> list[Job]:
+def create_gvcf_to_vcf_jobs(
+    proband_dict: dict[str, list[SequencingGroup]],
+    previous_completions: set[str],
+    out_paths: dict[str, Path],
+) -> list[Job]:
     """
     Create Joint VCFs for families of SG IDs
 

--- a/cpg_workflows/scripts/combine_exomiser_variant_tsvs.py
+++ b/cpg_workflows/scripts/combine_exomiser_variant_tsvs.py
@@ -1,5 +1,5 @@
 """
-script for taking the per-family TSVs from Exomiser and combining them
+script for taking the per-proband TSVs from Exomiser and combining them
 into a single JSON file, also written as a Hail Table
 """
 
@@ -13,34 +13,33 @@ import hail as hl
 from cpg_utils import to_path
 
 ORDERED_ALLELES: list[str] = [f'chr{x}' for x in list(range(1, 23))] + ['chrX', 'chrY', 'chrM']
-FAM_DICT = dict[str, dict[str, list[dict]]]
+PROBAND_DICT = dict[str, dict[str, list[dict]]]
 VAR_DICT = dict[str, list[str]]
 
 
-def process_tsv(tsv_path: str) -> tuple[FAM_DICT, VAR_DICT]:
+def process_tsv(tsv_path: str) -> tuple[PROBAND_DICT, VAR_DICT]:
     """
     Read a single TSV file, and return the parsed results
     Return is in two forms:
     - a dictionary of variant IDs to lists of sample IDs & details
 
-
     the return is a dictionary of variant keys to lists of details
-    the same variant can apply to the same family with multiple MOIs so we retain all
+    the same variant can apply to the same proband with multiple MOIs so we retain all
 
     Args:
         tsv_path (str): path to this TSV file
 
     Returns:
-        a dictionary of variant keys to lists of the 'family_rank_moi'
+        a dictionary of variant keys to lists of the 'proband_rank_moi'
     """
 
-    # this is on the assumption that we retain the path/to/file/FAMILY.variant.tsv naming convention
-    # if we read into the batch as /tmp/path/FAMILY this logic is still valid
+    # this is on the assumption that we retain the path/to/file/PROBAND.variant.tsv naming convention
+    # if we read into the batch as /tmp/path/PROBAND this logic is still valid
     file_as_path = to_path(tsv_path)
-    family = file_as_path.name.split('.')[0]
+    proband = file_as_path.name.split('.')[0]
 
     variant_dictionary: VAR_DICT = defaultdict(list)
-    family_dictionary: FAM_DICT = {family: defaultdict(list)}
+    proband_dictionary: PROBAND_DICT = {proband: defaultdict(list)}
 
     with file_as_path.open() as handle:
         reader = DictReader(handle, delimiter='\t')
@@ -64,7 +63,7 @@ def process_tsv(tsv_path: str) -> tuple[FAM_DICT, VAR_DICT]:
             moi = row['MOI']
 
             # adds easily parsed details to the family dictionary, easily extensible
-            family_dictionary[family][variant_key].append(
+            proband_dictionary[proband][variant_key].append(
                 {
                     'rank': rank,
                     'moi': moi,
@@ -72,10 +71,10 @@ def process_tsv(tsv_path: str) -> tuple[FAM_DICT, VAR_DICT]:
             )
 
             # compressed representation for exporting to Hail
-            squashed_details = f'{family}_{rank}_{moi}'
+            squashed_details = f'{proband}_{rank}_{moi}'
             variant_dictionary[variant_key].append(squashed_details)
 
-    return family_dictionary, variant_dictionary
+    return proband_dictionary, variant_dictionary
 
 
 def process_and_sort_variants(all_variants: VAR_DICT) -> list[dict]:
@@ -123,7 +122,7 @@ def munge_into_hail_table(all_variants: VAR_DICT, output_path: str):
     hl.context.init_local(default_reference='GRCh38')
 
     # define the schema for each written line
-    schema = hl.dtype('struct{contig:str,position:int32,alleles:array<str>,family_details:str}')
+    schema = hl.dtype('struct{contig:str,position:int32,alleles:array<str>,proband_details:str}')
 
     # import the table, and transmute to top-level attributes
     ht = hl.import_table(temp_filepath, no_header=True, types={'f0': schema})
@@ -139,27 +138,27 @@ def munge_into_hail_table(all_variants: VAR_DICT, output_path: str):
 
 def main(input_tsvs: list[str], output_path: str, as_hail: bool = True):
     """
-    Combine the per-family TSVs into a single JSON file, and write as a Hail Table
+    Combine the per-proband TSVs into a single JSON file, and write as a Hail Table
 
-    The data will be aggregated per variant, not per family
+    The data will be aggregated per variant, not per proband
 
     Args:
-        input_tsvs (list[str]): list of paths to the per-family TSVs
+        input_tsvs (list[str]): list of paths to the per-proband TSVs
         output_path (str): where to write the output
         as_hail (bool): if True, write the data out as a Hail Table
     """
 
     variant_dictionary: VAR_DICT = defaultdict(list)
-    all_family_dictionary: FAM_DICT = {}
+    all_proband_dictionary: PROBAND_DICT = {}
     for tsv in input_tsvs:
-        family_dict, variant_dict = process_tsv(tsv)
-        all_family_dictionary.update(family_dict)
+        proband_dict, variant_dict = process_tsv(tsv)
+        all_proband_dictionary.update(proband_dict)
         for key, value_list in variant_dict.items():
             variant_dictionary[key].extend(value_list)
 
     # write the JSON
     with open(f'{output_path}.json', 'w') as handle:
-        json.dump(all_family_dictionary, handle, indent=4)
+        json.dump(all_proband_dictionary, handle, indent=4)
 
     if as_hail:
         munge_into_hail_table(variant_dictionary, output_path)
@@ -167,7 +166,7 @@ def main(input_tsvs: list[str], output_path: str, as_hail: bool = True):
 
 def cli_main():
     parser = ArgumentParser()
-    parser.add_argument('--input', help='Path to the per-family TSVs', nargs='+', required=True)
+    parser.add_argument('--input', help='Path to the Variant result TSVs', nargs='+', required=True)
     parser.add_argument('--output', help='Where to write the output, extended as .json and .ht', required=True)
     args = parser.parse_args()
 

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -114,11 +114,14 @@ class CreateFamilyVCFs(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
-        proband_dict = find_probands(dataset)
-        prefix = dataset.prefix() / f'exomiser_inputs'
+        """
+        this now writes to a temporary bucket, we don't need these VCFs again in the future
+        they cost more to keep than to regenerate
+        """
+        prefix = dataset.tmp_prefix() / f'exomiser_inputs'
         return {
             str(family): prefix / f'{family}.vcf.bgz'
-            for family in proband_dict.keys()
+            for family in find_probands(dataset).keys()
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
@@ -145,8 +148,7 @@ class MakePhenopackets(DatasetStage):
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         """
-        this actually doesn't run as Jobs, but as a function...
-        bit of an anti-pattern in this pipeline?
+        this actually doesn't run as Jobs, but as a function
         """
 
         expected_out = self.expected_outputs(dataset)

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -369,7 +369,7 @@ class ExomiserVariantsTSV(DatasetStage):
         prefix = dataset.analysis_prefix() / get_workflow().output_version
 
         return {
-            'json': prefix / 'exomiser_variant_results.tsv',
+            'json': prefix / 'exomiser_variant_results.json',
             'ht': prefix / 'exomiser_variant_results.ht',
         }
 
@@ -396,6 +396,6 @@ class ExomiserVariantsTSV(DatasetStage):
         # recursive copy of the HT
         job.command(f'gcloud storage cp -r {job.output["ht"]} {str(outputs["ht"])}')
 
-        get_batch().write_output(job.output, str(outputs['json']))
+        get_batch().write_output(job.output['json'], str(outputs['json']))
 
         return self.make_outputs(dataset, data=outputs, jobs=job)

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -40,7 +40,8 @@ query MyQuery($dataset: String!, $analysis_type: String!) {
     }
   }
 }
-""")
+""",
+)
 
 
 @cache
@@ -83,7 +84,6 @@ def find_previous_analyses(dataset: str) -> set[str]:
             if nameroot := outputs.get('nameroot'):
                 completed_runs.add(nameroot)
     return completed_runs
-
 
 
 @cache
@@ -161,11 +161,8 @@ class CreateFamilyVCFs(DatasetStage):
         this now writes to a temporary bucket, we don't need these VCFs again in the future
         they cost more to keep than to regenerate
         """
-        prefix = dataset.tmp_prefix() / f'exomiser_inputs'
-        return {
-            proband: prefix / f'{proband}.vcf.bgz'
-            for proband in find_probands(dataset).keys()
-        }
+        prefix = dataset.tmp_prefix() / 'exomiser_inputs'
+        return {proband: prefix / f'{proband}.vcf.bgz' for proband in find_probands(dataset).keys()}
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         outputs = self.expected_outputs(dataset)
@@ -185,10 +182,7 @@ class MakePhenopackets(DatasetStage):
 
     def expected_outputs(self, dataset: Dataset):
         dataset_prefix = dataset.analysis_prefix() / 'exomiser_inputs'
-        return {
-            proband: dataset_prefix / f'{proband}_phenopacket.json'
-            for proband in find_probands(dataset).keys()
-        }
+        return {proband: dataset_prefix / f'{proband}_phenopacket.json' for proband in find_probands(dataset).keys()}
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         """
@@ -211,10 +205,7 @@ class MakePedExtracts(DatasetStage):
 
     def expected_outputs(self, dataset: Dataset):
         dataset_prefix = dataset.analysis_prefix() / 'exomiser_inputs'
-        return {
-            proband: dataset_prefix / f'{proband}.ped'
-            for proband in find_probands(dataset)
-        }
+        return {proband: dataset_prefix / f'{proband}.ped' for proband in find_probands(dataset)}
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         """
@@ -282,7 +273,9 @@ class RunExomiser(DatasetStage):
         return self.make_outputs(dataset, data=output_dict, jobs=jobs)
 
 
-@stage(analysis_keys=['gene_level', 'variant_level'], required_stages=[RunExomiser], analysis_type=EXOMISER_ANALYSIS_TYPE)
+@stage(
+    analysis_keys=['gene_level', 'variant_level'], required_stages=[RunExomiser], analysis_type=EXOMISER_ANALYSIS_TYPE,
+)
 class RegisterSingleSampleExomiserResults(SequencingGroupStage):
     """
     this is a tricky little fella'
@@ -330,7 +323,7 @@ class ExomiserSeqrTSV(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return dataset.analysis_prefix() / get_workflow().output_version / f'exomiser_results.tsv'
+        return dataset.analysis_prefix() / get_workflow().output_version / 'exomiser_results.tsv'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
 
@@ -376,8 +369,8 @@ class ExomiserVariantsTSV(DatasetStage):
         prefix = dataset.analysis_prefix() / get_workflow().output_version
 
         return {
-            'json': prefix / f'exomiser_variant_results.tsv',
-            'ht': prefix / f'exomiser_variant_results.ht',
+            'json': prefix / 'exomiser_variant_results.tsv',
+            'ht': prefix / 'exomiser_variant_results.ht',
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -121,9 +121,11 @@ class CreateFamilyVCFs(DatasetStage):
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
-        proband_dict = find_probands(dataset)
         outputs = self.expected_outputs(dataset)
-        jobs = create_gvcf_to_vcf_jobs(families=proband_dict, out_paths=outputs)
+        jobs = create_gvcf_to_vcf_jobs(
+            families=find_probands(dataset),
+            out_paths=outputs,
+        )
         return self.make_outputs(dataset, outputs, jobs=jobs)
 
 
@@ -146,11 +148,12 @@ class MakePhenopackets(DatasetStage):
         bit of an anti-pattern in this pipeline?
         """
 
-        proband_dict = find_probands(dataset)
         expected_out = self.expected_outputs(dataset)
-        families_to_process = {k: v for k, v in proband_dict.items() if k in expected_out}
-        make_phenopackets(families_to_process, expected_out)
-        return self.make_outputs(dataset, data=self.expected_outputs(dataset))
+        make_phenopackets(
+            family_dict=find_probands(dataset),
+            out_path=expected_out,
+        )
+        return self.make_outputs(dataset, data=expected_out)
 
 
 @stage

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -113,17 +113,17 @@ class CreateFamilyVCFs(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
-        family_dict = find_probands(dataset)
-        exomiser_version = config_retrieve(['workflow', 'exomiser_version'], 14)
+        proband_dict = find_probands(dataset)
+        prefix = dataset.prefix() / f'exomiser_inputs'
         return {
-            str(family): dataset.prefix() / f'exomiser_{exomiser_version}_inputs' / f'{family}.vcf.bgz'
-            for family in family_dict.keys()
+            str(family): prefix / f'{family}.vcf.bgz'
+            for family in proband_dict.keys()
         }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
-        family_dict = find_probands(dataset)
+        proband_dict = find_probands(dataset)
         outputs = self.expected_outputs(dataset)
-        jobs = create_gvcf_to_vcf_jobs(families=family_dict, out_paths=outputs)
+        jobs = create_gvcf_to_vcf_jobs(families=proband_dict, out_paths=outputs)
         return self.make_outputs(dataset, outputs, jobs=jobs)
 
 

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -274,7 +274,9 @@ class RunExomiser(DatasetStage):
 
 
 @stage(
-    analysis_keys=['gene_level', 'variant_level'], required_stages=[RunExomiser], analysis_type=EXOMISER_ANALYSIS_TYPE,
+    analysis_keys=['gene_level', 'variant_level'],
+    required_stages=[RunExomiser],
+    analysis_type=EXOMISER_ANALYSIS_TYPE,
 )
 class RegisterSingleSampleExomiserResults(SequencingGroupStage):
     """

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -17,7 +17,7 @@ from cpg_workflows.jobs.exomiser import (
     create_gvcf_to_vcf_jobs,
     extract_mini_ped_files,
     make_phenopackets,
-    run_exomiser_14,
+    run_exomiser,
 )
 from cpg_workflows.utils import get_logger
 from cpg_workflows.workflow import Dataset, DatasetStage, SequencingGroup, StageInput, StageOutput, get_workflow, stage
@@ -230,7 +230,7 @@ class RunExomiser(DatasetStage):
             if '_variants' not in family
         }
 
-        jobs = run_exomiser_14(single_dict)
+        jobs = run_exomiser(single_dict)
 
         return self.make_outputs(dataset, data=output_dict, jobs=jobs)
 

--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -134,11 +134,11 @@ class MakePhenopackets(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset):
-        family_dict = find_probands(dataset)
-
-        exomiser_version = config_retrieve(['workflow', 'exomiser_version'], 14)
-        dataset_prefix = dataset.analysis_prefix() / f'exomiser_{exomiser_version}_inputs'
-        return {family: dataset_prefix / f'{family}_phenopacket.json' for family in family_dict.keys()}
+        dataset_prefix = dataset.analysis_prefix() / 'exomiser_inputs'
+        return {
+            family: dataset_prefix / f'{family}_phenopacket.json'
+            for family in find_probands(dataset).keys()
+        }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         """
@@ -146,11 +146,11 @@ class MakePhenopackets(DatasetStage):
         bit of an anti-pattern in this pipeline?
         """
 
-        dataset_families = find_probands(dataset)
+        proband_dict = find_probands(dataset)
         expected_out = self.expected_outputs(dataset)
-        families_to_process = {k: v for k, v in dataset_families.items() if k in expected_out}
+        families_to_process = {k: v for k, v in proband_dict.items() if k in expected_out}
         make_phenopackets(families_to_process, expected_out)
-        return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=[])
+        return self.make_outputs(dataset, data=self.expected_outputs(dataset))
 
 
 @stage

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from cpg_utils.config import set_config_paths
 from cpg_workflows import defaults_config_path
 from cpg_workflows.stages.clinvarbitration import PackageForRelease
 from cpg_workflows.stages.cram_qc import CramMultiQC
-from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, ExomiserVariantsTSV
+from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults
 from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.fraser import Fraser
 from cpg_workflows.stages.gatk_sv.gatk_sv_multisample import FilterBatch, GenotypeBatch, MtToEsSv
@@ -49,7 +49,7 @@ from cpg_workflows.workflow import StageDecorator, run_workflow
 WORKFLOWS: dict[str, list[StageDecorator]] = {
     'clinvarbitration': [PackageForRelease],
     'talos': [MakePhenopackets, ValidateMOI, CreateTalosHTML, MinimiseOutputForSeqr],
-    'exomiser': [ExomiserSeqrTSV, ExomiserVariantsTSV],
+    'exomiser': [ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults],
     'long_read_snps_indels_annotation': [MtToEsLrSNPsIndels],
     'long_read_sv_annotation': [MtToEsLrSv],
     'pre_alignment': [FastQCMultiQC],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.33.2',
+    version='1.34.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Firstly - this keeps the bulk of the content the same, so that's cool. Exomiser is run in the same way.

Dodgy things:
- within each dataset I previously collected all families with at least one affected member, then arbitrarily chose one of the affected participants and focused the analysis on them. This was usually _the_ proband, but didn't address multi-proband families, or affected parents.
- The ID chosen for the results was the external ID for the chosen family member. I also called this `family_id`, when it wasn't. Getting this pipeline going was a nightmare, I blame general delerium.
- Generating these analyses on the basis of an external sample ID makes it really tricky to aggregate them later, e.g. for use in Talos and Seqr. One Ext. Sample ID can have multiple CPG IDs, but each CPG ID has only one Sample ID. By carrying out analyses and storing results on the CPG SG ID, we can unambiguously know which member has been analysed as a proband, and link this through more easily to other systems.

Changes:
- do the same filtering to find every family with at least one affected member
- for each family:
    - check if there are any affected members with parents in the family (in which case we assume at least one affected parent and child)
    - if there was an affected child, generate a separate analysis for every affected child only (do not analyse parents as probands)
    - if there was no affected child, generate a separate analysis for every affected family member (singletons, sibling duos, de novo trios)
    - each of these analyses uses the primary member's CPG ID, not external ID
   
- we don't use Exomiser 13, so the output path `exomiser_14_[input|output]` is now just `exomiser_[input|output]`
- Exomiser 13 job scheduling methods are deleted
- per-analysis family gVCFs are now in `-tmp`

This includes a novel little follow-on SequencingGroupStage `RegisterSingleSampleExomiserResults` to register the results of a previous DatasetStage. This was needed because `RunExomiser` is a DatasetStage, but it generates per-SG results, which can't be easily registered. There's a separate helper method to pull these analysis entries, which is used to prevent VCFs being regenerated when the final results already exist.