### PR TITLE
Add SpliceVarDb to Talos

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.33.2
+current_version = 1.33.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.33.2
+  VERSION: 1.33.3
 
 jobs:
   docker:

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -56,8 +56,9 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import ConfigError, config_retrieve, image_path
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch
 from cpg_workflows.resources import STANDARD
-from cpg_workflows.utils import get_logger, tshirt_mt_sizing
-from cpg_workflows.workflow import Dataset, DatasetStage, StageInput, StageOutput, stage
+from cpg_workflows.targets import Dataset
+from cpg_workflows.utils import exists, get_logger, tshirt_mt_sizing
+from cpg_workflows.workflow import DatasetStage, StageInput, StageOutput, stage
 from metamist.graphql import gql, query
 
 CHUNKY_DATE = datetime.now().strftime('%Y-%m-%d')
@@ -486,7 +487,9 @@ class RunHailFiltering(DatasetStage):
 
         # find, localise, and use the SpliceVarDB table, if available - if not, don't pass the flag
         # currently just passed in from config, will eventually be generated a different way
-        if svdb := config_retrieve(['RunHailFiltering', 'svdb_mt'], None):
+        if svdb := config_retrieve(['RunHailFiltering', 'svdb_ht'], None):
+            if not exists(svdb):
+                raise ValueError(f'SVDB {svdb} does not exist')
             svdb_name = svdb.split('/')[-1]
             job.command(f'gcloud --no-user-output-enabled storage cp -r {svdb} $BATCH_TMPDIR')
             job.command('echo "SpliceVarDB MT copied"')

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -405,8 +405,8 @@ class QueryPanelapp(DatasetStage):
 @stage(required_stages=[MakeRuntimeConfig, QueryPanelapp])
 class FindGeneSymbolMap(DatasetStage):
 
-    def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
-        return {'symbol_lookup': dataset.prefix() / get_date_folder() / 'symbol_to_ensg.json'}
+    def expected_outputs(self, dataset: Dataset) -> Path:
+        return dataset.prefix() / get_date_folder() / 'symbol_to_ensg.json'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         job = get_batch().new_job(f'Find Symbol-ENSG lookup: {dataset.name}')
@@ -423,7 +423,7 @@ class FindGeneSymbolMap(DatasetStage):
         job.command(f'sleep {randint(0, 30)}')
         job.command(f'FindGeneSymbolMap --input {panel_json} --output {job.output}')
 
-        get_batch().write_output(job.output, str(expected_out['symbol_lookup']))
+        get_batch().write_output(job.output, str(expected_out))
 
         return self.make_outputs(dataset, data=expected_out, jobs=job)
 
@@ -666,7 +666,7 @@ class HPOFlagging(DatasetStage):
         conf_in_batch = get_batch().read_input(runtime_config)
 
         results_json = get_batch().read_input(str(inputs.as_path(dataset, ValidateMOI)))
-        gene_map = get_batch().read_input(str(inputs.as_dict(dataset, FindGeneSymbolMap)['symbol_lookup']))
+        gene_map = get_batch().read_input(str(inputs.as_path(dataset, FindGeneSymbolMap)))
 
         job.command(f'export TALOS_CONFIG={conf_in_batch}')
         job.command(

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -302,8 +302,8 @@ class MakePhenopackets(DatasetStage):
     and generates a phenopacket file (GA4GH compliant)
     """
 
-    def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
-        return {'phenopackets': dataset.prefix() / get_date_folder() / 'phenopackets.json'}
+    def expected_outputs(self, dataset: Dataset) -> Path:
+        return dataset.prefix() / get_date_folder() / 'phenopackets.json'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         """
@@ -333,8 +333,8 @@ class MakePhenopackets(DatasetStage):
             f'--type {seq_type} '
             f'--hpo {hpo_file}',
         )
-        get_batch().write_output(job.output, str(expected_out['phenopackets']))
-        get_logger().info(f'Phenopacket file for {dataset.name} going to {expected_out["phenopackets"]}')
+        get_batch().write_output(job.output, str(expected_out))
+        get_logger().info(f'Phenopacket file for {dataset.name} going to {expected_out}')
 
         return self.make_outputs(dataset, data=expected_out, jobs=job)
 
@@ -363,7 +363,7 @@ class GeneratePanelData(DatasetStage):
 
         hpo_file = get_batch().read_input(config_retrieve(['GeneratePanelData', 'obo_file']))
         local_phenopacket = get_batch().read_input(
-            str(inputs.as_path(target=dataset, stage=MakePhenopackets, key='phenopackets')),
+            str(inputs.as_path(target=dataset, stage=MakePhenopackets)),
         )
 
         job.command(f'export TALOS_CONFIG={conf_in_batch}')

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -227,12 +227,12 @@ class GeneratePED(DatasetStage):
     revert to just using the metamist/CPG-flow Pedigree generation
     """
 
-    def expected_outputs(self, dataset: Dataset) -> dict[str, Path]:
-        return {'pedigree': dataset.prefix() / get_date_folder() / 'pedigree.ped'}
+    def expected_outputs(self, dataset: Dataset) -> Path:
+        return dataset.prefix() / get_date_folder() / 'pedigree.ped'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         expected_out = self.expected_outputs(dataset)
-        pedigree = dataset.write_ped_file(out_path=expected_out['pedigree'])
+        pedigree = dataset.write_ped_file(out_path=expected_out)
         get_logger().info(f'PED file for {dataset.name} written to {pedigree}')
 
         return self.make_outputs(dataset, data=expected_out)
@@ -468,7 +468,7 @@ class RunHailFiltering(DatasetStage):
         panelapp_json = get_batch().read_input(
             str(inputs.as_path(target=dataset, stage=QueryPanelapp, key='panel_data')),
         )
-        pedigree = inputs.as_path(target=dataset, stage=GeneratePED, key='pedigree')
+        pedigree = inputs.as_path(target=dataset, stage=GeneratePED)
         expected_out = self.expected_outputs(dataset)
 
         # copy vcf & index out manually
@@ -543,7 +543,7 @@ class RunHailFilteringSV(DatasetStage):
         panelapp_json = get_batch().read_input(
             str(inputs.as_path(target=dataset, stage=QueryPanelapp, key='panel_data')),
         )
-        pedigree = inputs.as_path(target=dataset, stage=GeneratePED, key='pedigree')
+        pedigree = inputs.as_path(target=dataset, stage=GeneratePED)
         local_ped = get_batch().read_input(str(pedigree))
 
         required_storage: int = config_retrieve(['RunHailFiltering', 'storage', 'sv'], 10)
@@ -604,7 +604,7 @@ class ValidateMOI(DatasetStage):
         conf_in_batch = get_batch().read_input(runtime_config)
 
         hpo_panels = get_batch().read_input(str(inputs.as_dict(dataset, GeneratePanelData)['hpo_panels']))
-        pedigree = get_batch().read_input(str(inputs.as_path(target=dataset, stage=GeneratePED, key='pedigree')))
+        pedigree = get_batch().read_input(str(inputs.as_path(target=dataset, stage=GeneratePED)))
         hail_inputs = inputs.as_dict(dataset, RunHailFiltering)
 
         # If there are SV VCFs, read each one in and add to the arguments

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -597,9 +597,9 @@ class ValidateMOI(DatasetStage):
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig))
         conf_in_batch = get_batch().read_input(runtime_config)
 
-        hpo_panels = get_batch().read_input(str(inputs.as_dict(dataset, GeneratePanelData)))
+        hpo_panels = get_batch().read_input(str(inputs.as_path(dataset, GeneratePanelData)))
         pedigree = get_batch().read_input(str(inputs.as_path(target=dataset, stage=GeneratePED)))
-        hail_inputs = inputs.as_dict(dataset, RunHailFiltering)
+        hail_inputs = inputs.as_path(dataset, RunHailFiltering)
 
         # If there are SV VCFs, read each one in and add to the arguments
         sv_paths_or_empty = query_for_sv_mt(dataset.name)
@@ -665,7 +665,7 @@ class HPOFlagging(DatasetStage):
         runtime_config = str(inputs.as_path(dataset, MakeRuntimeConfig))
         conf_in_batch = get_batch().read_input(runtime_config)
 
-        results_json = get_batch().read_input(str(inputs.as_dict(dataset, ValidateMOI)))
+        results_json = get_batch().read_input(str(inputs.as_path(dataset, ValidateMOI)))
         gene_map = get_batch().read_input(str(inputs.as_dict(dataset, FindGeneSymbolMap)['symbol_lookup']))
 
         job.command(f'export TALOS_CONFIG={conf_in_batch}')
@@ -770,7 +770,7 @@ class MinimiseOutputForSeqr(DatasetStage):
             get_logger().warning(f'No Seqr lookup file for {dataset.name} {seq_type}')
             return self.make_outputs(dataset, skipped=True)
 
-        input_localised = get_batch().read_input(str(inputs.as_dict(dataset, ValidateMOI)['summary_json']))
+        input_localised = get_batch().read_input(str(inputs.as_path(dataset, ValidateMOI)))
 
         # create a job to run the minimisation script
         job = get_batch().new_job(f'Talos Prep for Seqr: {dataset.name}')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.33.2',
+    version='1.33.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Heavily tied to https://github.com/populationgenomics/talos/pull/467

If the SVDB Hail Table is given in config, copy it into the VM and use as an annotation source

This also contains a number of other inter-stage interface simplifications. Primarily non-functional, just a reduction in overall boilerplate lines. Has been tested with a local dry-run to confirm that the stages can all talk to each other properly