### PR TITLE
Exomiser Analysis Outputs can be a string or a dict

### DIFF
--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -10,7 +10,7 @@ As a dataset Stage
 
 from functools import cache
 
-from cpg_utils import Path
+from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.jobs.exomiser import (
@@ -81,8 +81,10 @@ def find_previous_analyses(dataset: str) -> set[str]:
     for analysis in metamist_results['project']['analyses']:
         # uses the new metamist outputs formatted block
         if outputs := analysis['outputs']:
-            if nameroot := outputs.get('nameroot'):
+            if isinstance(outputs, dict) and (nameroot := outputs.get('nameroot')):
                 completed_runs.add(nameroot)
+            elif isinstance(outputs, str):
+                completed_runs.add(to_path(outputs).stem)
     return completed_runs
 
 


### PR DESCRIPTION
I failed to account for the situation where a **first class files** section can be either a dictionary or a string.

This tests for the exact output type, then processes accordingly.

Specific cause here (a guess based on results) is that the `outputs` dictionary attached to the analysis entry is only generated if the output file path is a _file_, not a _directory_. In situations where we can register either a HT/MT or an exact single file as the given type, we need to account for both data structures when parsing metamist results. @nevoodoo / @vivbak  can you confirm if this is the parsing logic in Metamist for FCF? That would make sense given that directories won't have `size` or `file_checksum` attrs.