### PR TITLE
Talos can select between rd_combiner and seqr_loader MTs

### DIFF
--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -8,6 +8,11 @@ status_reporter = 'metamist'
 #clinvar_decisions = "HailTable path to private ClinVar"
 #clinvar_pm5 = "HailTable path to ClinVar PM5"
 
+# this can be "custom" or "matrixtable"
+# "custom" if the analysis entry type written by seqr_loader
+# "matrixtable" if the analysis entry type written by the rd_combiner
+mt_entry_type = 'matrixtable'
+
 [GeneratePanelData]
 default_panel = 137
 obo_file = 'gs://cpg-common-test/references/aip/hpo_terms.obo'

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -148,21 +148,26 @@ def query_for_sv_mt(dataset: str) -> list[tuple[str, str]]:
 
 
 @lru_cache(maxsize=None)
-def query_for_latest_mt(dataset: str, entry_type: str = 'custom') -> str:
+def query_for_latest_mt(dataset: str) -> str:
     """
     query for the latest MT for a dataset
+    the exact metamist entry type to search for is handled by config, defaulting to the new rd_combiner MT
     Args:
         dataset (str): project to query for
-        entry_type (str): type of analysis entry to query for
     Returns:
         str, the path to the latest MT for the given type
     """
 
     # hot swapping to a string we can freely modify
     query_dataset = dataset
-
     if config_retrieve(['workflow', 'access_level']) == 'test' and 'test' not in query_dataset:
         query_dataset += '-test'
+
+    # the rd_combiner writes MTs to metamist as 'matrixtable', seqr_loader used 'custom'
+    # using a config entry we can decide which type to use
+    entry_type: str = config_retrieve(['workflow', 'mt_entry_type'], 'matrixtable')
+    get_logger().info(f'Querying for {entry_type} in {query_dataset}')
+
     result = query(MTA_QUERY, variables={'dataset': query_dataset, 'type': entry_type})
     mt_by_date = {}
 


### PR DESCRIPTION
Just spotted this as I was attempting to run Talos on one of the new rd_combiner MTs - the analysis entries from the new pipeline are created as a different type, which means we need to adapt the query to make sure we're picking up the new MTs. This change also includes flexibility to swap back to the seqr_loader MTs, but defaulting to the new pipeline.

I previously ran Talos on one of the new MTs using the specific override (exact MT path), but that doesn't scale to multiple projects.