### PR TITLE
Combine exomiser and talos

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.34.2
+current_version = 1.34.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.34.2
+  VERSION: 1.34.3
 
 jobs:
   docker:

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -81,7 +81,6 @@ sv = 10
 small_variants = 15000
 sv = 3600
 
-
 [categories]
 1 = 'ClinVar Pathogenic'
 3 = 'High Impact Variant'
@@ -90,7 +89,9 @@ sv = 3600
 6 = 'AlphaMissense P/LP'
 pm5 = 'ACMG PM5 - missense in same residue as known pathogenic'
 support = 'High in Silico Scores'
+svdb = 'SpliceVarDB Predicted Splice-Altering'
 sv1 = 'Predicted LOF SV'
+exomiser = 'Variant prioritised by Exomiser'
 
 # cohort specific parts of the config are not stored in this repository due to data protection concerns.
 # Instead, AIP runs in production-pipelines should use the config from github::production-pipelines-configuration

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -42,6 +42,9 @@ phenotype_match = ['6']
 ## all these labels will be removed
 #ignore_categories = ['categoryboolean6']
 
+# by default, only consider the top 2 exomiser results
+exomiser_rank_threshold = 2
+
 [RunHailFiltering]
 # variables for the hail operations, including CSQ sets and filter thresholds
 ac_threshold = 0.01

--- a/cpg_workflows/scripts/combine_exomiser_variant_tsvs.py
+++ b/cpg_workflows/scripts/combine_exomiser_variant_tsvs.py
@@ -90,10 +90,10 @@ def process_and_sort_variants(all_variants: VAR_DICT) -> list[dict]:
 
     # first, split the data up into component parts
     all_vars: list[dict] = []
-    for variant_key, family_details in all_variants.items():
+    for variant_key, proband_data in all_variants.items():
         chrom, pos, ref, alt = variant_key.split(':')
         all_vars.append(
-            {'contig': chrom, 'position': int(pos), 'alleles': [ref, alt], 'family_details': '::'.join(family_details)},
+            {'contig': chrom, 'position': int(pos), 'alleles': [ref, alt], 'proband_details': '::'.join(proband_data)},
         )
 
     # then sort on chr and position
@@ -134,6 +134,7 @@ def munge_into_hail_table(all_variants: VAR_DICT, output_path: str):
 
     # write out to the specified location
     ht.write(f'{output_path}.ht', overwrite=True)
+    ht.show()
 
 
 def main(input_tsvs: list[str], output_path: str, as_hail: bool = True):

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -148,14 +148,17 @@ def query_for_sv_mt(dataset: str) -> list[tuple[str, str]]:
 
 
 @lru_cache(maxsize=None)
-def query_for_latest_mt(dataset: str) -> str:
+def query_for_latest_hail_object(dataset: str, analysis_type: str, object_suffix: str = '.mt') -> str:
     """
     query for the latest MT for a dataset
     the exact metamist entry type to search for is handled by config, defaulting to the new rd_combiner MT
     Args:
         dataset (str): project to query for
+        analysis_type (str): analysis type to query for - rd_combiner writes MTs to metamist as 'matrixtable',
+                             seqr_loader used 'custom': using a config entry we can decide which type to use
+        object_suffix (str): suffix to detect on analysis path (choose between .mt or .ht)
     Returns:
-        str, the path to the latest MT for the given type
+        str, the path to the latest object for the given type
     """
 
     # hot swapping to a string we can freely modify
@@ -163,18 +166,16 @@ def query_for_latest_mt(dataset: str) -> str:
     if config_retrieve(['workflow', 'access_level']) == 'test' and 'test' not in query_dataset:
         query_dataset += '-test'
 
-    # the rd_combiner writes MTs to metamist as 'matrixtable', seqr_loader used 'custom'
-    # using a config entry we can decide which type to use
-    entry_type: str = config_retrieve(['workflow', 'mt_entry_type'], 'matrixtable')
-    get_logger().info(f'Querying for {entry_type} in {query_dataset}')
+    get_logger().info(f'Querying for {analysis_type} in {query_dataset}')
 
-    result = query(MTA_QUERY, variables={'dataset': query_dataset, 'type': entry_type})
+    result = query(MTA_QUERY, variables={'dataset': query_dataset, 'type': analysis_type})
+
+    # get all the relevant entries, and bin by date
     mt_by_date = {}
-
     for analysis in result['project']['analyses']:
         if (
             analysis['output']
-            and analysis['output'].endswith('.mt')
+            and analysis['output'].endswith(object_suffix)
             and (analysis['meta']['sequencing_type'] == config_retrieve(['workflow', 'sequencing_type']))
         ):
             mt_by_date[analysis['timestampCompleted']] = analysis['output']
@@ -443,7 +444,18 @@ class RunHailFiltering(DatasetStage):
         return dataset.prefix() / get_date_folder() / 'hail_labelled.vcf.bgz'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
-        input_mt = config_retrieve(['workflow', 'matrix_table'], query_for_latest_mt(dataset.name))
+        input_mt = config_retrieve(
+            ['workflow', 'matrix_table'],
+            default=query_for_latest_hail_object(
+                dataset=dataset.name,
+                analysis_type=config_retrieve(
+                    ['workflow', 'mt_entry_type'],
+                    default='matrixtable',
+                ),
+                object_suffix='.mt',
+            ),
+        )
+
         job = get_batch().new_job(f'Run hail labelling: {dataset.name}')
         job.image(image_path('talos'))
         job.command('set -eux pipefail')
@@ -486,6 +498,21 @@ class RunHailFiltering(DatasetStage):
         job.command(f'gcloud --no-user-output-enabled storage cp -r {clinvar_decisions} $BATCH_TMPDIR')
         job.command('echo "ClinvArbitration decisions copied"')
 
+        # see if we can find any exomiser results to integrate
+        try:
+            exomiser_ht = query_for_latest_hail_object(
+                dataset=dataset.name,
+                analysis_type='exomiser',
+                object_suffix='.ht',
+            )
+            exomiser_name = exomiser_ht.split('/')[-1]
+            job.command(f'gcloud --no-user-output-enabled storage cp -r {exomiser_ht} $BATCH_TMPDIR')
+            job.command('echo "SpliceVarDB MT copied"')
+            exomiser_argument = f'--exomiser "${{BATCH_TMPDIR}}/{exomiser_name}" '
+        except ValueError:
+            get_logger().info(f'No exomiser results found for {dataset.name}, skipping')
+            exomiser_argument = ' '
+
         # find, localise, and use the SpliceVarDB table, if available - if not, don't pass the flag
         # currently just passed in from config, will eventually be generated a different way
         if svdb := config_retrieve(['RunHailFiltering', 'svdb_ht'], None):
@@ -494,9 +521,9 @@ class RunHailFiltering(DatasetStage):
             svdb_name = svdb.split('/')[-1]
             job.command(f'gcloud --no-user-output-enabled storage cp -r {svdb} $BATCH_TMPDIR')
             job.command('echo "SpliceVarDB MT copied"')
-            svdb_argument = f'--svdb "${{BATCH_TMPDIR}}/{svdb_name}"'
+            svdb_argument = f'--svdb "${{BATCH_TMPDIR}}/{svdb_name}" '
         else:
-            svdb_argument = ''
+            svdb_argument = ' '
 
         pm5 = get_clinvar_table('clinvar_pm5')
         pm5_name = pm5.split('/')[-1]
@@ -518,7 +545,8 @@ class RunHailFiltering(DatasetStage):
             f'--clinvar "${{BATCH_TMPDIR}}/{clinvar_name}" '
             f'--pm5 "${{BATCH_TMPDIR}}/{pm5_name}" '
             f'--checkpoint "${{BATCH_TMPDIR}}/checkpoint.mt" '
-            f'{svdb_argument}',
+            f'{svdb_argument} '
+            f'{exomiser_argument} ',
         )
         get_batch().write_output(job.output, str(expected_out).removesuffix('.vcf.bgz'))
 

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -507,7 +507,7 @@ class RunHailFiltering(DatasetStage):
             )
             exomiser_name = exomiser_ht.split('/')[-1]
             job.command(f'gcloud --no-user-output-enabled storage cp -r {exomiser_ht} $BATCH_TMPDIR')
-            job.command('echo "SpliceVarDB MT copied"')
+            job.command('echo "Exomiser HT copied"')
             exomiser_argument = f'--exomiser "${{BATCH_TMPDIR}}/{exomiser_name}" '
         except ValueError:
             get_logger().info(f'No exomiser results found for {dataset.name}, skipping')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.34.2',
+    version='1.34.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Relies on https://github.com/populationgenomics/talos/pull/471
Matt to fill out both PRs

Alters the `find latest MT` method to be more versatile - finding HTs or MTs, of any analysis type (configurable)

Uses this to find Exomiser data, which is chucked into the labelling stage as another annotation source