### PR TITLE
Skip members with no gVCF

### DIFF
--- a/cpg_workflows/stages/exomiser.py
+++ b/cpg_workflows/stages/exomiser.py
@@ -109,6 +109,9 @@ def find_probands(dataset: Dataset) -> dict[str, list[SequencingGroup]]:
 
     dict_by_family: dict[str, list[SequencingGroup]] = {}
     for sg in dataset.get_sequencing_groups():
+        # skip over members without a gVCF - unusable in this analysis
+        if sg.gvcf is None:
+            continue
         family_id = str(sg.pedigree.fam_id)
         dict_by_family.setdefault(family_id, []).append(sg)
 


### PR DESCRIPTION
Spotted in a couple of cohorts - these analyses are based on gVCFs, not the SequencingGroup alone. If no gVCF entry is populated from Metamist the member can't be considered for analysis.