### PR TITLE
Add ability to increase worker core count to SampleQC

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -139,11 +139,14 @@ class SampleQC(CohortStage):
         init_batch_args: dict[str, str | int] = {}
         workflow_config = config_retrieve('workflow')
 
+        # Memory parameters
         for config_key, batch_key in [('highmem_workers', 'worker_memory'), ('highmem_drivers', 'driver_memory')]:
             if workflow_config.get(config_key):
                 init_batch_args[batch_key] = 'highmem'
-        if 'driver_cores' in workflow_config:
-            init_batch_args['driver_cores'] = workflow_config['driver_cores']
+        # Cores parameter
+        for key in ['driver_cores', 'worker_cores']:
+            if workflow_config.get(key):
+                init_batch_args[key] = workflow_config[key]
 
         j.image(image_path('cpg_workflows'))
         j.command(


### PR DESCRIPTION
Adding ability to increase worker_cores for SampleQC to increase memory allowance further

See failing batch job [here](https://batch.hail.populationgenomics.org.au/batches/589298/jobs/107)