### PR TITLE
Long read seqr load pipeline

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.35.1
+current_version = 1.35.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.35.1
+  VERSION: 1.35.2
 
 jobs:
   docker:

--- a/configs/defaults/seqr_loader_long_read.toml
+++ b/configs/defaults/seqr_loader_long_read.toml
@@ -2,7 +2,10 @@
 name = 'seqr_loader_long_read'
 dataset_gcp_project = 'seqr-308602'
 status_reporter = 'metamist'
-bam_to_cram_analysis_type = 'pacbio_cram'
 
-[resource_overrides]
-bam_to_cram_storage_gb = 50
+[workflow.bam_to_cram]
+analysis_type = 'pacbio_cram'
+
+[resource_overrides.bam_to_cram]
+nthreads = 1
+storage_gb = 50

--- a/cpg_workflows/jobs/bam_to_cram.py
+++ b/cpg_workflows/jobs/bam_to_cram.py
@@ -45,17 +45,17 @@ def bam_to_cram(
     res = STANDARD.set_resources(
         j,
         ncpu=nthreads,
-        storage_gb=config_retrieve(['resource_overrides', 'bam_to_cram_storage_gb'], 50),
+        storage_gb=config_retrieve(['resource_overrides', 'bam_to_cram', 'storage_gb'], 50),
     )
 
     j.declare_resource_group(
         sorted_cram={
             'cram': '{root}.cram',
-            'cram.crai': '{root}.cram.crai',
+            'crai': '{root}.cram.crai',
         },
     )
 
-    cmd = f'samtools view -@ {res.get_nthreads() - 1} -T {fasta.fasta} -C {input_bam.bam} | tee {j.sorted_cram["cram"]} | samtools index -@ {res.get_nthreads() - 1} - {j.sorted_cram["cram.crai"]}'
+    cmd = f'samtools view -@ {res.get_nthreads() - 1} -T {fasta.fasta} -C {input_bam.bam} | tee {j.sorted_cram["cram"]} | samtools index -@ {res.get_nthreads() - 1} - {j.sorted_cram["crai"]}'
     j.command(command(cmd, monitor_space=True))
 
     return j, j.sorted_cram

--- a/cpg_workflows/jobs/seqr_loader_snps_indels.py
+++ b/cpg_workflows/jobs/seqr_loader_snps_indels.py
@@ -38,6 +38,7 @@ def annotate_cohort_jobs_snps_indels(
             None,  # site_only_vqsr_vcf_path
             str(checkpoint_prefix),
             True,  # long_read
+            True,  # remove_invalid_contigs
         ),
     )
     return j

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -77,33 +77,12 @@ def annotate_cohort(
     # Remove any contigs not in the 22 autosomes, X, Y, M
     if remove_invalid_contigs:
         logging.info('Removing invalid contigs')
+        # fmt: off
         chromosomes = [
-            '1',
-            '2',
-            '3',
-            '4',
-            '5',
-            '6',
-            '7',
-            '8',
-            '9',
-            '10',
-            '11',
-            '12',
-            '13',
-            '14',
-            '15',
-            '16',
-            '17',
-            '18',
-            '19',
-            '20',
-            '21',
-            '22',
-            'X',
-            'Y',
-            'M',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13',
+            '14', '15', '16', '17', '18', '19', '20', '21', '22', 'X', 'Y', 'M',
         ]
+        # fmt: on
         standard_contigs = hl.literal(
             hl.literal([f'chr{chrom}' for chrom in chromosomes]),
         )

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -139,7 +139,11 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, new_id: str | None
 
             # a quick check, if we can
             if l_split[3] != 'N':
-                assert new_base == l_split[3][0], f'Discrepancy between faidx and Sniffles: {new_base}, {l_split[3]}'
+                # If using the hg38 masked reference, the base will always be upper case
+                # So make sure the compairson to the Sniffles REF is upper case too
+                assert (
+                    new_base == l_split[3][0].upper()
+                ), f'Discrepancy between faidx and Sniffles: {new_base}, {l_split[3]}'
 
             # replace the REF String
             l_split[3] = new_base

--- a/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
+++ b/cpg_workflows/scripts/long_read_sniffles_vcf_modifier.py
@@ -140,7 +140,7 @@ def modify_sniffles_vcf(file_in: str, file_out: str, fa: str, new_id: str | None
             # a quick check, if we can
             if l_split[3] != 'N':
                 # If using the hg38 masked reference, the base will always be upper case
-                # So make sure the compairson to the Sniffles REF is upper case too
+                # So make sure the comparison to the Sniffles REF is upper case too
                 assert (
                     new_base == l_split[3][0].upper()
                 ), f'Discrepancy between faidx and Sniffles: {new_base}, {l_split[3]}'

--- a/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/bam_to_cram.py
@@ -3,8 +3,8 @@ Stage that converts a BAM file to a CRAM file.
 Intended for use with long-read BAM files from PacBio.
 """
 
-from cpg_utils import Path
-from cpg_utils.config import config_retrieve, reference_path
+from cpg_utils import Path, to_path
+from cpg_utils.config import config_retrieve, image_path, reference_path
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.jobs import bam_to_cram
@@ -19,14 +19,14 @@ def make_long_read_cram_path(sequencing_group: SequencingGroup) -> CramPath:
     return CramPath(
         path=path,
         index_path=path.with_suffix('.cram.crai'),
-        reference_assembly=reference_path('broad/ref_fasta'),
+        reference_assembly=config_retrieve(['workflow', 'ref_fasta'], reference_path('broad/ref_fasta')),
     )
 
 
-@stage(analysis_type=config_retrieve(['workflow', 'bam_to_cram_analysis_type'], 'cram'), analysis_keys=['cram'])
-class BamToCram(SequencingGroupStage):
+@stage(analysis_type=config_retrieve(['workflow', 'bam_to_cram', 'analysis_type'], 'cram'), analysis_keys=['cram'])
+class ConvertPacBioBamToCram(SequencingGroupStage):
     """
-    Convert a BAM to a CRAM file.
+    Convert a PacBio BAM to a CRAM file.
     """
 
     def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, Path]:
@@ -38,7 +38,7 @@ class BamToCram(SequencingGroupStage):
         else:
             cram_path = make_long_read_cram_path(sequencing_group)
 
-        return {'cram': cram_path.path, 'cram.crai': cram_path.index_path}
+        return {'cram': cram_path.path, 'crai': cram_path.index_path}
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
         """
@@ -47,15 +47,15 @@ class BamToCram(SequencingGroupStage):
         b = get_batch()
         assert (
             sequencing_group.sequencing_type == 'genome'
-        ), f'Only genome sequencing type is supported for BAM to CRAM conversion, unavailable for {sequencing_group.id}'
+        ), f'Only genomes are supported for BAM to CRAM conversion, unavailable for {sequencing_group.id}'
         input_bam = b.read_input_group(bam=str(sequencing_group.alignment_input))
         job, output_cram = bam_to_cram.bam_to_cram(
             b=get_batch(),
             input_bam=input_bam,
             extra_label='long_read',
             job_attrs=self.get_job_attrs(sequencing_group),
-            requested_nthreads=1,
-            reference_fasta_path=reference_path('broad/ref_fasta'),
+            requested_nthreads=config_retrieve(['resource_overrides', 'bam_to_cram', 'nthreads'], 1),
+            reference_fasta_path=to_path(config_retrieve(['workflow', 'ref_fasta'], reference_path('broad/ref_fasta'))),
         )
         b.write_output(output_cram, str(self.expected_outputs(sequencing_group)['cram']).removesuffix('.cram'))
 

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
@@ -62,16 +62,10 @@ def query_for_snps_indels_vcfs(dataset_name: str) -> dict[str, str]:
     """
     return_dict: dict[str, str] = {}
     analysis_results = query(VCF_QUERY, variables={'dataset': dataset_name})
-    for sg_id_section in analysis_results['project']['sequencingGroups']:
-        for analysis in sg_id_section['analyses']:
-            # check 'output' (old string path format) and 'outputs' (new dict format)
-            if analysis['output'].endswith('SNPs_Indels.phased.vcf.gz'):
-                return_dict[sg_id_section['id']] = analysis['output']
-                continue
-            if isinstance(analysis['outputs'], dict):
-                if analysis['outputs'].get('path', '').endswith('SNPs_Indels.phased.vcf.gz'):
-                    return_dict[sg_id_section['id']] = analysis['outputs'].get('path', '')
-                    break
+    for sg in analysis_results['project']['sequencingGroups']:
+        for analysis in sg['analyses']:
+            if analysis['output'].endswith('snp_indel.phased.vcf.gz'):
+                return_dict[sg['id']] = analysis['output']
 
     return return_dict
 
@@ -130,12 +124,14 @@ class ReFormatPacBioSNPsIndels(SequencingGroupStage):
             f'--sex {sex} ',
         )
 
-        # block-gzip and index that result
-        tabix_job = get_batch().new_job(f'BGZipping and Indexing for {sg.id}', {'tool': 'bcftools'})
+        # normalise, then block-gzip and index that result
+        tabix_job = get_batch().new_job(f'Normalising, BGZipping, and Indexing for {sg.id}', {'tool': 'bcftools'})
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         tabix_job.image(image=image_path('bcftools'))
         tabix_job.storage('10Gi')
-        tabix_job.command(f'bcftools view {mod_job.output} | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}')
+        tabix_job.command(
+            f'bcftools norm -m -any -f {fasta} -c s {mod_job.output} | bcftools sort | bgzip -c > {tabix_job.vcf_out["vcf.bgz"]}',
+        )
         tabix_job.command(f'tabix {tabix_job.vcf_out["vcf.bgz"]}')
 
         # write from temp storage into GCP

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -34,6 +34,7 @@ VCF_QUERY = gql(
       id
       analyses(type: {eq: "pacbio_vcf"}) {
         output
+        meta
       }
     }
   }
@@ -55,11 +56,12 @@ def query_for_sv_vcfs(dataset_name: str) -> dict[str, str]:
         a dictionary of the SG IDs and their phased SV VCF
     """
     return_dict: dict[str, str] = {}
+    get_logger().info(f'Querying for SV VCFs for {dataset_name}')
     analysis_results = query(VCF_QUERY, variables={'dataset': dataset_name})
-    for sg_id_section in analysis_results['project']['sequencingGroups']:
-        for analysis in sg_id_section['analyses']:
-            if analysis['output'].endswith('.SVs.phased.vcf.gz'):
-                return_dict[sg_id_section['id']] = analysis['output']
+    for sg in analysis_results['project']['sequencingGroups']:
+        for analysis in sg['analyses']:
+            if analysis['meta'].get('variant_type') == 'SV':
+                return_dict[sg['id']] = analysis['output']
 
     return return_dict
 

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ from cpg_workflows.stages.rd_combiner import (
     TrainVqsrSnpTranches,
 )
 from cpg_workflows.stages.seqr_loader import AnnotateDataset, DatasetVCF, MtToEs
-from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import BamToCram
+from cpg_workflows.stages.seqr_loader_long_read.bam_to_cram import ConvertPacBioBamToCram
 from cpg_workflows.stages.seqr_loader_long_read.long_read_snps_indels_annotation import MtToEsLrSNPsIndels
 from cpg_workflows.stages.seqr_loader_long_read.long_read_sv_annotation import MtToEsLrSv
 from cpg_workflows.stages.stripy import Stripy
@@ -76,7 +76,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
         MitoReport,
     ],
     'seqr_loader_long_read': [
-        BamToCram,
+        ConvertPacBioBamToCram,
     ],
     'validation': [ValidationMtToVcf, ValidationHappyOnVcf],
     'large_cohort': [LoadVqsr, Frequencies, AncestryPlots, GvcfMultiQC, CramMultiQC],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.35.1',
+    version='1.35.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Updates the seqr loader long read pipeline with several changes compared to the initial version merged in 2024.

This PR is intended to create SNV/Indel and SV callsets from the provided PacBio VCFs, all the way up to the point they can be loaded into Seqr. There are a number of other changes being trialled in the draft PR https://github.com/populationgenomics/production-pipelines/pull/1115 which are not in scope for this PR, mentioned at the bottom.

---

**BAM to CRAM**
- Rename the stage to `ConvertPacBioBamToCram`
- Minor changes to stage and job config options, allowing user to change resourcing requirements and input reference fasta.


**SNPs / Indels VCFs Annotation**
- Update Metamist query to account for new file name formats
- Normalise the sample VCFs before merging and joining by adding a `bcftools norm -m -any -f ref.fa -c s in.vcf` command to the VCF processing step in the `ReFormatPacBioSNPsIndels` stage. This is required because merging un-normalized VCFs was not compatible with the downstream Hail stage to annotate the cohort mt. See this [Slack discussion](https://centrepopgen.slack.com/archives/C082NA58R7S/p1737442347259089?thread_ts=1737410276.815149&cid=C082NA58R7S) for more detail.
- New arg `remove_invalid_contigs` - will filter the matrix table to remove entries with a contig not in the standard 22XYM set. See [example job](https://batch.hail.populationgenomics.org.au/batches/589417/jobs/1) where not removing invalid contigs causes failure.
- Set the `mt.info.AC` and `mt.info.AF` rows to take the array values at index `mt.a_index` rather than `mt.a_index - 1`. This is a bit involved, but basically because we have to normalise the sample VCFs before merging, and then overwrite the `AF`/`AC` values with those from `hl.variant_qc` before calling `hl.split_multi_hts`, it means `a_index` is always `1` for every row. But `mt.info.AC` / `mt.info.AF` arrays always have length 2, with the WT allele values at index 0, and the alt allele values at index 1. Since we want the alt allele values, we need to remove the `-1` from the indexing. See this [Slack discussion](https://centrepopgen.slack.com/archives/C037XB40XFW/p1737526958523809?thread_ts=1737502555.496289&cid=C037XB40XFW) for more detail.


**SV VCF annotation**
- Update Metamist query to account for new file name formats
- When checking for faidx / sniffles REF base consistency, make sure that the sniffles base is uppercase. This is because the hg38 masked reference only contains upper case bases, while the input VCF may have lower case bases, indicating masking/repetition. See [Slack discussion here](https://centrepopgen.slack.com/archives/C082NA58R7S/p1738189204370249) for more detail.


---


**NOT IN SCOPE**
- Adding read group information during the BAM > CRAM conversion
- Reheadering the CRAMs with the hg38 masked reference contig information
- Adding CramQC / Somalier stages 
