### PR TITLE
Improve target as x methods

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.35.1
+current_version = 1.36.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.35.1
+  VERSION: 1.36.0
 
 jobs:
   docker:

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -171,8 +171,6 @@ class StageOutput:
         res = self._get(key)
         if not isinstance(res, (os.PathLike, str)):
             raise ValueError(f'{res} is not a str or valid Pathlike, will not convert.')
-        if isinstance(res, str):
-            return res
         return str(res)
 
     def as_path(self, key=None) -> Path:
@@ -184,8 +182,6 @@ class StageOutput:
         res = self._get(key)
         if not isinstance(res, (os.PathLike, str)):
             raise ValueError(f'{res} is not a path object or a valid String, cannot return as Path.')
-        if isinstance(res, os.PathLike):
-            return res
         return to_path(res)
 
     def as_dict(self) -> dict[str, Path]:

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -23,7 +23,7 @@ import networkx as nx
 
 from hailtop.batch.job import Job
 
-from cpg_utils import to_path, Path
+from cpg_utils import Path, to_path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import get_batch, reset_batch
 
@@ -1073,8 +1073,8 @@ class Workflow:
         # We want to run stages only appearing in only_stages, and check outputs of
         # imediate predecessor stages, but skip everything else.
         required_stages: set[str] = set()
-        for os in only_stages:
-            rs = nx.descendants_at_distance(graph, os, 1)
+        for only_stage in only_stages:
+            rs = nx.descendants_at_distance(graph, only_stage, 1)
             required_stages |= set(rs)
 
         for stage in stages:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.35.1',
+    version='1.36.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #611

Minimal modification:
### as_str

- gets the target value from StageInput in the same way
- checks if the target is a `str` or `os.PathLike` - other types are not tolerated
- convert the value to a String, and return it

### as_path

- gets the target value from StageInput in the same way
- checks if the target is a `str` or `os.PathLike` - other types are not tolerated
- return the `to_path` representation

---

I flirted with the idea of keeping the `cast` calls - they don't change the actual object, they just communicate the type to the checker. I don't really rate casts. 

The logic could be "if the object is the expected type, return it casted to the correct type, else convert it", but that adds an extra if condition, which isn't really necessary. Running `str('string')` has no computational burden, and running `to_path('PATH')` calls through to `to_anypath`, which returns the unchanged object if it passes `isinstance(s, (CloudPath, Path))`. 

The other aspect here is that the method has a return type of Path or String, which is enough to satisfy the type checker that a type has changed, without using cast.

Given that there's no burden in converting these objects to the type they already are, there's no need to use a typing-only transformation, and no real reason to add extra conditional lines to avoid the type conversion.