### PR TITLE
Fix join vep on compound key

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.35.2
+current_version = 1.35.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.35.2
+  VERSION: 1.35.3
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -170,7 +170,7 @@ def annotate_cohort(
             AN=mt.variant_qc.AN,
             AC=mt.variant_qc.AC,
         ),
-        vep=vep_ht[mt.locus].vep,
+        vep=vep_ht[mt.row_key].vep,
     )
     mt = mt.drop('variant_qc')
 

--- a/cpg_workflows/scripts/vep_json_to_ht.py
+++ b/cpg_workflows/scripts/vep_json_to_ht.py
@@ -208,7 +208,8 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
     start = hl.parse_int(original_vcf_line.split('\t')[1])
     chrom = ht.vep.seq_region_name
     ht = ht.annotate(locus=hl.locus(chrom, start))
-    ht = ht.key_by(ht.locus)
+    # we're using split multiallelics, so we need to compound key on chr/pos/ref/alt
+    ht = ht.key_by(ht.locus, ht.alleles)
     ht.write(out_path, overwrite=True)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.35.2',
+    version='1.35.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
RD_Combiner downstream consistently uses split representations, so we need to adjust for this in VEP (previously keyed on locus alone) and when joining Variants & VEP (previously joined on locus alone)