### PR TITLE
Fix compound key in hail

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.35.3
+current_version = 1.35.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.35.3
+  VERSION: 1.35.4
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/vep_json_to_ht.py
+++ b/cpg_workflows/scripts/vep_json_to_ht.py
@@ -203,9 +203,7 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
     ht = ht.transmute(vep=ht.f0)
     # we're using split multiallelics, so we need to compound key on chr/pos/ref/alt
     ht = ht.annotate(
-        locus=hl.locus(
-            ht.vep.seq_region_name, hl.parse_int(ht.vep.input.split('\t')[1])
-        ),
+        locus=hl.locus(ht.vep.seq_region_name, hl.parse_int(ht.vep.input.split('\t')[1])),
         alleles=ht.vep.allele_string.split('/'),
     )
     ht = ht.key_by(ht.locus, ht.alleles)

--- a/cpg_workflows/scripts/vep_json_to_ht.py
+++ b/cpg_workflows/scripts/vep_json_to_ht.py
@@ -201,14 +201,13 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
 
     ht = hl.import_table(paths=vep_result_paths, no_header=True, types={'f0': json_schema})
     ht = ht.transmute(vep=ht.f0)
-    # Can't use ht.vep.start for start because it can be modified by VEP (e.g. it
-    # happens for indels). So instead parsing POS from the original VCF line stored
-    # as ht.vep.input field.
-    original_vcf_line = ht.vep.input
-    start = hl.parse_int(original_vcf_line.split('\t')[1])
-    chrom = ht.vep.seq_region_name
-    ht = ht.annotate(locus=hl.locus(chrom, start))
     # we're using split multiallelics, so we need to compound key on chr/pos/ref/alt
+    ht = ht.annotate(
+        locus=hl.locus(
+            ht.vep.seq_region_name, hl.parse_int(ht.vep.input.split('\t')[1])
+        ),
+        alleles=ht.vep.allele_string.split('/'),
+    )
     ht = ht.key_by(ht.locus, ht.alleles)
     ht.write(out_path, overwrite=True)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.35.3',
+    version='1.35.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Correction to #1125 

VEP outputs don't have REF/ALF alleles as individual attributes, they only have them within the larger input string, so we need to do some string manipulation to get them

See https://github.com/populationgenomics/production-pipelines/pull/602/files#r1936638900

I previously addressed these issues in a concept PR/branch for making seqr_loader consistently normalise/split multiallelic variants 😅 