### PR TITLE
Add QOB params to VEP parsing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.35.4
+current_version = 1.35.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.35.4
+  VERSION: 1.35.5
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -28,14 +28,14 @@ indel_recal_disc_size = 20
 snps_gather_disc_size = 10
 snps_recal_disc_size = 20
 
-[workflow.es_index]
-# if false, use a non-preemptible instance to run the ES export
-spot_instance = false
-
 # without this setting we use the native Hail version in the container
 # not currently in use as the cpg-utils default contains these patches by default, plus extra logging
 # most recently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 0.2.133 + 400'retry + StreamConstraints patch
 #default_jar_spec_revision = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
+
+[workflow.es_index]
+# if false, use a non-preemptible instance to run the ES export
+spot_instance = false
 
 [combiner]
 # used to decide if we should resume from a previous combiner plan

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -32,15 +32,10 @@ snps_recal_disc_size = 20
 # if false, use a non-preemptible instance to run the ES export
 spot_instance = false
 
-# choices of jar specs to use for the various steps
-# without this setting we would default to matching the native Hail version in the container
-# currently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 0.2.133 + 400'retry + StreamConstraints patch
-[workflow.jar_spec_revisions]
-annotate_cohort = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
-annotate_dataset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
-combiner = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
-densify = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
-subset = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
+# without this setting we use the native Hail version in the container
+# not currently in use as the cpg-utils default contains these patches by default, plus extra logging
+# most recently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 0.2.133 + 400'retry + StreamConstraints patch
+#default_jar_spec_revision = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 
 [combiner]
 # used to decide if we should resume from a previous combiner plan

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -120,7 +120,11 @@ def annotate_cohort(
         Nothing, but hopefully writes out a new MT
     """
 
-    init_batch()
+    init_batch(
+        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
+        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
+        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+    )
 
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -10,7 +10,6 @@ import hail as hl
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, reference_path
 from cpg_utils.hail_batch import genome_build, init_batch
-from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import can_reuse, get_logger
 from hail_scripts.computed_fields import variant_id, vep
 
@@ -125,12 +124,6 @@ def annotate_cohort(
         driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
         driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
     )
-
-    # this overrides the jar spec for the current session
-    # and requires `init_batch()` to be called before any other hail methods
-    # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
-    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'annotate_cohort'], False):
-        override_jar_spec(jar_spec)
 
     # hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/permissions.20issues/near/398711114
     # don't override the block size, as it explodes the number of partitions when processing TB+ datasets

--- a/cpg_workflows/scripts/annotate_dataset_small_vars.py
+++ b/cpg_workflows/scripts/annotate_dataset_small_vars.py
@@ -8,7 +8,6 @@ import hail as hl
 
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
-from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import get_logger
 
 
@@ -22,11 +21,6 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
         driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
         driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
     )
-
-    # this overrides the jar spec for the current session
-    # and requires `init_batch()` to be called before any other hail methods
-    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'annotate_dataset'], False):
-        override_jar_spec(jar_spec)
 
     mt = hl.read_matrix_table(mt_path)
 

--- a/cpg_workflows/scripts/annotate_dataset_small_vars.py
+++ b/cpg_workflows/scripts/annotate_dataset_small_vars.py
@@ -17,7 +17,11 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
     Add dataset-level annotations.
     """
 
-    init_batch()
+    init_batch(
+        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
+        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
+        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+    )
 
     # this overrides the jar spec for the current session
     # and requires `init_batch()` to be called before any other hail methods

--- a/cpg_workflows/scripts/densify_VDS_to_MT.py
+++ b/cpg_workflows/scripts/densify_VDS_to_MT.py
@@ -20,7 +20,6 @@ import hail as hl
 
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
-from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import can_reuse, get_logger
 from gnomad.utils.sparse_mt import default_compute_info
 from gnomad.utils.vcf import adjust_vcf_incompatible_types
@@ -57,10 +56,6 @@ def main(
     )
 
     get_logger().info(f'Partition strategy {partition_strategy} is not currently in use (see #1078)')
-
-    # if we need to manually specify a non-standard Hail QoB JAR file
-    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'densify'], False):
-        override_jar_spec(jar_spec)
 
     # check here to see if we can reuse the dense MT
     if not can_reuse(dense_mt_out):

--- a/cpg_workflows/scripts/subset_mt_to_dataset.py
+++ b/cpg_workflows/scripts/subset_mt_to_dataset.py
@@ -9,7 +9,6 @@ import hail as hl
 from cpg_utils import to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
-from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import get_logger
 
 
@@ -23,13 +22,11 @@ def subset_mt_to_samples(input_mt: str, sg_id_file: str, output: str):
         output (str): path to write the result.
     """
 
-    init_batch()
-
-    # this overrides the jar spec for the current session
-    # and requires `init_batch()` to be called before any other hail methods
-    # we satisfy this requirement by calling `init_batch()` in the query_command wrapper
-    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'subset'], False):
-        override_jar_spec(jar_spec)
+    init_batch(
+        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
+        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
+        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+    )
 
     mt = hl.read_matrix_table(input_mt)
 

--- a/cpg_workflows/scripts/vep_json_to_ht.py
+++ b/cpg_workflows/scripts/vep_json_to_ht.py
@@ -26,6 +26,7 @@ from argparse import ArgumentParser
 
 import hail as hl
 
+from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import init_batch
 
 
@@ -39,7 +40,11 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
         out_path ():
     """
 
-    init_batch()
+    init_batch(
+        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
+        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
+        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+    )
 
     # Differences relative to the 105 schema:
     # - minimised, int32, new field at top level

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.35.4',
+    version='1.35.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Possibly relevant: https://github.com/populationgenomics/production-pipelines/issues/1066

See https://batch.hail.populationgenomics.org.au/batches/589951

The QOB aggregation and manipulation of the VEP JSONs is running into some memory issues I've not had previously. Maybe adding another single operation into the JSON parsing was a step too far 😬 

The issue ticket #1066 is a suggestion that we can use the rolling gcloud compose to concatenate all the VEP JSONs into a single file before parsing into a Hail Table. That innately feels like way less work in memory than combining 2500 separate files... If this quick patch still results in memory issues I'll investigate further, but this has previously worked fine with no additional resources

A semi-related update being bundled here is that the per-module JAR spec overrides are removed from scripts and config. These are hopefully now not needed, given the current main version contains patches and logging. 