### PR TITLE
VEP patch to correct for InDel variants

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.35.5
+current_version = 1.36.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.35.5
+  VERSION: 1.36.0
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/vep_json_to_ht.py
+++ b/cpg_workflows/scripts/vep_json_to_ht.py
@@ -207,9 +207,15 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
     ht = hl.import_table(paths=vep_result_paths, no_header=True, types={'f0': json_schema})
     ht = ht.transmute(vep=ht.f0)
     # we're using split multiallelics, so we need to compound key on chr/pos/ref/alt
+    # the ref and alt can't be taken from the VEP output, as they are manipulated
+    # e.g. ["T","-"] for a Deletion, or ["-","AC"] for an insertion
+    # instead we need to generate the Alleles from the exact VCF input String
+    # this issue was alluded to in the previous script which formatted VEP annotations as a Hail Table, but that script
+    # didn't use alleles at all (joining only on chr:pos, multiallelics were not split)
+    split_vep_input = ht.vep.input.split('\t')
     ht = ht.annotate(
-        locus=hl.locus(ht.vep.seq_region_name, hl.parse_int(ht.vep.input.split('\t')[1])),
-        alleles=ht.vep.allele_string.split('/'),
+        locy=hl.locus(ht.vep.seq_region_name, hl.parse_int(split_vep_input[1])),
+        alleles2=[split_vep_input[3], split_vep_input[4]],
     )
     ht = ht.key_by(ht.locus, ht.alleles)
     ht.write(out_path, overwrite=True)

--- a/cpg_workflows/scripts/vep_json_to_ht.py
+++ b/cpg_workflows/scripts/vep_json_to_ht.py
@@ -214,8 +214,8 @@ def vep_json_to_ht(vep_result_paths: list[str], out_path: str):
     # didn't use alleles at all (joining only on chr:pos, multiallelics were not split)
     split_vep_input = ht.vep.input.split('\t')
     ht = ht.annotate(
-        locy=hl.locus(ht.vep.seq_region_name, hl.parse_int(split_vep_input[1])),
-        alleles2=[split_vep_input[3], split_vep_input[4]],
+        locus=hl.locus(ht.vep.seq_region_name, hl.parse_int(split_vep_input[1])),
+        alleles=[split_vep_input[3], split_vep_input[4]],
     )
     ht = ht.key_by(ht.locus, ht.alleles)
     ht.write(out_path, overwrite=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.35.5',
+    version='1.36.0',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Previous process (seqr_loader) only used contig and position from the VEP data (`seq_region_name` and position from `hl.parse_int(ht.vep.input.split('\t')[1])`)

New process on split multiallelics requires the Alleles [REF, ALT] to be populated, as this is part of the table key when we join VEP data into the variant table.

I was populating the Allele Strings using `vep.allele_string`, which seemed logical. This was a bad idea, as [this comment](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/query_modules/vep.py#L357-L359)   alluded to. As I've clarified in the extended comment attached to the new code block, VEP was doing a transformation of all Indels to a dodgy format (e.g. T/- instead of AT/A). By taking VEP.allele_string, ALL Indels in the VEP data were given an Allele string featuring `-` as either the REF or ALT.

- VEP HT was indexed on invalid Alleles
- Invalid alleles couldn't be joined to the variant data
- All variants had VEP completely missing VEP annotation
- Many downstream impacts, mainly evident to us as Talos filtering removing ALL indels (the first filter for "is this gene in the Green gene list" failed for every InDel - vep.gene_ids = `NA`)

---

The current performance of the RD_Combiner pipeline is now even worse than before 😅 

- Before we were incorrectly adding one set of annotation to all variants which were split from the same multiallelic row. Most variants were being correctly annotated.
- Now all SNVs are being correctly annotated, even if they were part of a multiallelic row
- **But** all Indels, multiallelic or not, are failing 😬 