### PR TITLE
Bamtocram resourcegroup fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.0
+current_version = 1.36.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.0
+  VERSION: 1.36.1
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/bam_to_cram.py
+++ b/cpg_workflows/jobs/bam_to_cram.py
@@ -51,11 +51,11 @@ def bam_to_cram(
     j.declare_resource_group(
         sorted_cram={
             'cram': '{root}.cram',
-            'crai': '{root}.cram.crai',
+            'cram.crai': '{root}.cram.crai',
         },
     )
 
-    cmd = f'samtools view -@ {res.get_nthreads() - 1} -T {fasta.fasta} -C {input_bam.bam} | tee {j.sorted_cram["cram"]} | samtools index -@ {res.get_nthreads() - 1} - {j.sorted_cram["crai"]}'
+    cmd = f'samtools view -@ {res.get_nthreads() - 1} -T {fasta.fasta} -C {input_bam.bam} | tee {j.sorted_cram["cram"]} | samtools index -@ {res.get_nthreads() - 1} - {j.sorted_cram["cram.crai"]}'
     j.command(command(cmd, monitor_space=True))
 
     return j, j.sorted_cram

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.0',
+    version='1.36.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Changing the resource group to `".crai"` instead of `".cram.crai"` had the effect of saving the index files with just the `.crai` extension. This had downstream effects in Seqr, so the change is being reverted to how it was in [the prior commit](https://github.com/populationgenomics/production-pipelines/blob/536aa1b9942911d2415454856c88df912f1cf4b4/cpg_workflows/jobs/bam_to_cram.py).