### PR TITLE
Create index files script

### DIFF
--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -50,7 +50,7 @@ def index_with_samtools(
     """
     for file_to_index_path, index_file_path in input_files:
         input_file = b.read_input(file_to_index_path)
-        j = b.new_bash_job(b, f'samtools index {file_to_index_path}')
+        j = b.new_bash_job(f'samtools index {file_to_index_path}')
         j.image(image_path('samtools'))
         # Set resource requirements
         storage_gb = 20 if to_path(file_to_index_path).stat().st_size < 1e10 else 100

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -92,7 +92,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {f.bam} -o {j.out_bam["bam.bai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_bam, str(file_to_index).removesuffix(".bai"))
+        b.write_output(j.out_bam["bam.bai"], str(file_to_index).removesuffix(".bai"))
     elif file_to_index.suffix == '.cram':
         j.declare_resource_group(
             out_cram={
@@ -102,7 +102,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {f.cram} -o {j.out_cram["cram.crai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_cram,  str(file_to_index).removesuffix(".crai"))
+        b.write_output(j.out_cram["cram.crai"],  str(file_to_index).removesuffix(".crai"))
     else:
         raise ValueError('Resource group must contain a bam or cram file')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -52,11 +52,11 @@ def index_files(
     """
     for file_to_index in files_to_index:
         if file_to_index.suffix == '.bam':
-            b.read_input_group(bam=file_to_index)
-            index_with_samtools(b, file_to_index)
+            f = b.read_input_group(bam=file_to_index)
+            index_with_samtools(b, f)
         elif file_to_index.suffix == '.cram':
-            b.read_input_group(cram=file_to_index)
-            index_with_samtools(b, file_to_index)
+            f = b.read_input_group(cram=file_to_index)
+            index_with_samtools(b, f)
         else:
             raise ValueError(f'Unknown file extension: {file_to_index.suffix}')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -102,7 +102,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.cram} -o {j.out_cram["cram.crai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_cram["cram.crai"],  str(file_to_index) + '.crai')
+        b.write_output(j.out_cram["cram.crai"], str(file_to_index) + '.crai')
     else:
         raise ValueError('Resource group must contain a bam or cram file')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import click
 from google.cloud import storage
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -70,17 +70,18 @@ def index_with_samtools(
     """
     assert isinstance(input_file, ResourceGroup)
 
-    job_name = 'Samtools index'
+    job_name = 'Samtools index ' + file_to_index.name
     j_attrs = dict(label=job_name, tool='samtools')
     j = b.new_job(name=job_name, attributes=j_attrs)
     j.image(image_path('samtools'))
 
     # Set resource requirements
+    storage_gb = 20 if file_to_index.stat().st_size < 1e9 else 100
     nthreads = 8
     res = STANDARD.set_resources(
         j,
         ncpu=nthreads,
-        storage_gb=100,
+        storage_gb=storage_gb,
     )
     if file_to_index.suffix == '.bam':
         j.declare_resource_group(

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -25,7 +25,7 @@ def find_files_to_index(
     # Find all files with the given extensions
     files_to_index = []
     blobs = bucket.list_blobs(prefix=prefix)
-    blob_names = [blob.path for blob in blobs if blob.path.endswith(extensions)]
+    blob_names = [[f'gs://{bucket_name}/{blob.name}' for blob in blobs]]
     for blob_name in blob_names:
         # Check if the index file exists
         if blob_name.endswith('.bam'):

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -83,7 +83,7 @@ def index_with_samtools(
         ncpu=nthreads,
         storage_gb=100,
     )
-    if f.bam:
+    if file_to_index.suffix == '.bam':
         j.declare_resource_group(
             out_bam={
                 'bam': '{root}.bam',
@@ -93,7 +93,7 @@ def index_with_samtools(
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {j.bam} -o {j.out_bam["bam.bai"]}'
         j.command(command(cmd, monitor_space=True))
         b.write_output(j.out_bam, str(file_to_index).removesuffix(".bai"))
-    elif f.cram:
+    elif file_to_index.suffix == '.cram':
         j.declare_resource_group(
             out_cram={
                 'cram': '{root}.cram',

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -92,7 +92,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.bam} -o {j.out_bam["bam.bai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_bam["bam.bai"], str(file_to_index) + '.bam')
+        b.write_output(j.out_bam["bam.bai"], str(file_to_index) + '.bai')
     elif file_to_index.suffix == '.cram':
         j.declare_resource_group(
             out_cram={
@@ -102,7 +102,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.cram} -o {j.out_cram["cram.crai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_cram["cram.crai"],  str(file_to_index) + '.cram')
+        b.write_output(j.out_cram["cram.crai"],  str(file_to_index) + '.crai')
     else:
         raise ValueError('Resource group must contain a bam or cram file')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -92,7 +92,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.bam} -o {j.out_bam["bam.bai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_bam["bam.bai"], str(file_to_index).removesuffix('.bam'))
+        b.write_output(j.out_bam["bam.bai"], str(file_to_index) + '.bam')
     elif file_to_index.suffix == '.cram':
         j.declare_resource_group(
             out_cram={
@@ -102,7 +102,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.cram} -o {j.out_cram["cram.crai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_cram["cram.crai"],  str(file_to_index).removesuffix('.cram'))
+        b.write_output(j.out_cram["cram.crai"],  str(file_to_index) + '.cram')
     else:
         raise ValueError('Resource group must contain a bam or cram file')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -90,7 +90,7 @@ def index_with_samtools(
                 'bam.bai': '{root}.bam.bai',
             },
         )
-        cmd = f'samtools index -@ {res.get_nthreads() - 1} {j.bam} -o {j.out_bam["bam.bai"]}'
+        cmd = f'samtools index -@ {res.get_nthreads() - 1} {f.bam} -o {j.out_bam["bam.bai"]}'
         j.command(command(cmd, monitor_space=True))
         b.write_output(j.out_bam, str(file_to_index).removesuffix(".bai"))
     elif file_to_index.suffix == '.cram':
@@ -100,7 +100,7 @@ def index_with_samtools(
                 'cram.crai': '{root}.cram.crai',
             },
         )
-        cmd = f'samtools index -@ {res.get_nthreads() - 1} {j.cram} -o {j.out_cram["cram.crai"]}'
+        cmd = f'samtools index -@ {res.get_nthreads() - 1} {f.cram} -o {j.out_cram["cram.crai"]}'
         j.command(command(cmd, monitor_space=True))
         b.write_output(j.out_cram,  str(file_to_index).removesuffix(".crai"))
     else:

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -32,7 +32,7 @@ def find_files_to_index(
         elif blob_name.endswith('.cram'):
             index_blob_name = f'{blob_name}.crai'
         else:
-            raise ValueError(f'Unknown file extension: {blob_name}')
+            continue
 
         index_blob = bucket.blob(index_blob_name)
         if not index_blob.exists():

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -111,7 +111,6 @@ def index_with_samtools(
 @click.option(
     '--input-path',
     help='Path to the input files',
-    type=click.Path(exists=True),
 )
 def main(input_path: str):
     # Find all bam and cram files that need to be indexed

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -92,7 +92,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.bam} -o {j.out_bam["bam.bai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_bam["bam.bai"], str(file_to_index).removesuffix(".bai"))
+        b.write_output(j.out_bam["bam.bai"], str(file_to_index).removesuffix('.bam'))
     elif file_to_index.suffix == '.cram':
         j.declare_resource_group(
             out_cram={
@@ -102,7 +102,7 @@ def index_with_samtools(
         )
         cmd = f'samtools index -@ {res.get_nthreads() - 1} {input_file.cram} -o {j.out_cram["cram.crai"]}'
         j.command(command(cmd, monitor_space=True))
-        b.write_output(j.out_cram["cram.crai"],  str(file_to_index).removesuffix(".crai"))
+        b.write_output(j.out_cram["cram.crai"],  str(file_to_index).removesuffix('.cram'))
     else:
         raise ValueError('Resource group must contain a bam or cram file')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -14,8 +14,7 @@ from cpg_workflows.resources import STANDARD
 
 def find_files_to_index(
     path: Path,
-    extensions: tuple[str, str] = ('.bam', '.cram'),
-):
+) -> list[Path]:
     """Finds bam and cram files and queues them for indexing if they are not already indexed."""
     client = storage.Client()
     bucket_name = path.as_uri().split('/')[2]
@@ -25,7 +24,7 @@ def find_files_to_index(
     # Find all files with the given extensions
     files_to_index = []
     blobs = bucket.list_blobs(prefix=prefix)
-    blob_names = [[f'gs://{bucket_name}/{blob.name}' for blob in blobs]]
+    blob_names = [f'gs://{bucket_name}/{blob.name}' for blob in blobs]
     for blob_name in blob_names:
         # Check if the index file exists
         if blob_name.endswith('.bam'):

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -76,7 +76,7 @@ def index_with_samtools(
     j.image(image_path('samtools'))
 
     # Set resource requirements
-    storage_gb = 20 if file_to_index.stat().st_size < 1e9 else 100
+    storage_gb = 20 if file_to_index.stat().st_size < 1e10 else 100
     nthreads = 8
     res = STANDARD.set_resources(
         j,

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -1,0 +1,123 @@
+import click
+from google.cloud import storage
+
+from hailtop.batch import ResourceGroup
+from hailtop.batch.job import Job
+
+from cpg_utils import Path, to_path
+from cpg_utils.config import get_gcp_project, image_path
+from cpg_utils.hail_batch import Batch, command, get_batch
+from cpg_workflows.resources import STANDARD
+
+
+def find_files_to_index(
+    path: Path,
+    extensions: tuple[str, str] = ('.bam', '.cram'),
+):
+    """Finds bam and cram files and queues them for indexing if they are not already indexed."""
+    client = storage.Client()
+    bucket_name = path.as_uri().split('/')[2]
+    prefix = '/'.join(path.as_uri().split('/')[3:])
+    bucket = client.bucket(bucket_name, user_project=get_gcp_project())
+
+    # Find all files with the given extensions
+    files_to_index = []
+    blobs = bucket.list_blobs(prefix=prefix)
+    blob_names = [blob.path for blob in blobs if blob.path.endswith(extensions)]
+    for blob_name in blob_names:
+        # Check if the index file exists
+        if blob_name.endswith('.bam'):
+            index_blob_name = f'{blob_name}.bai'
+        elif blob_name.endswith('.cram'):
+            index_blob_name = f'{blob_name}.crai'
+        else:
+            raise ValueError(f'Unknown file extension: {blob_name}')
+
+        index_blob = bucket.blob(index_blob_name)
+        if not index_blob.exists():
+            files_to_index.append(to_path(blob_name))
+        else:
+            print(f'Index file already exists: {index_blob_name}')
+
+    return files_to_index
+
+
+def index_files(
+    b: Batch,
+    files_to_index: list[Path],
+):
+    """
+    Index a list of bam or cram files using samtools.
+    """
+    for file_to_index in files_to_index:
+        if file_to_index.suffix == '.bam':
+            b.read_input_group(bam=file_to_index)
+            index_with_samtools(b, file_to_index)
+        elif file_to_index.suffix == '.cram':
+            b.read_input_group(cram=file_to_index)
+            index_with_samtools(b, file_to_index)
+        else:
+            raise ValueError(f'Unknown file extension: {file_to_index.suffix}')
+
+
+def index_with_samtools(
+    b: Batch,
+    file_to_index: ResourceGroup,
+):
+    """
+    Index a bam or cram file using samtools and return the job and the index file.
+    """
+    assert isinstance(file_to_index, ResourceGroup)
+
+    job_name = 'Samtools index'
+    j_attrs = dict(label=job_name, tool='samtools')
+    j = b.new_job(name=job_name, attributes=j_attrs)
+    j.image(image_path('samtools'))
+
+    # Set resource requirements
+    nthreads = 8
+    res = STANDARD.set_resources(
+        j,
+        ncpu=nthreads,
+        storage_gb=100,
+    )
+    if file_to_index.bam:
+        j.declare_resource_group(
+            out_bam={
+                'bam': '{root}.bam',
+                'bam.bai': '{root}.bam.bai',
+            },
+        )
+        cmd = f'samtools index -@ {res.get_nthreads() - 1} {j.bam} -o {j.out_bam["bam.bai"]}'
+        j.command(command(cmd, monitor_space=True))
+        b.write_output(j.out_bam, f'{j.out_bam["bam.bai"].removesuffix(".bai")}')
+    elif file_to_index.cram:
+        j.declare_resource_group(
+            out_cram={
+                'cram': '{root}.cram',
+                'cram.crai': '{root}.cram.crai',
+            },
+        )
+        cmd = f'samtools index -@ {res.get_nthreads() - 1} {j.cram} -o {j.out_cram["cram.crai"]}'
+        j.command(command(cmd, monitor_space=True))
+        b.write_output(j.out_cram, f'{j.out_cram["cram.crai"].removesuffix(".crai")}')
+    else:
+        raise ValueError('Resource group must contain a bam or cram file')
+
+
+@click.command()
+@click.option(
+    '--input-path',
+    help='Path to the input files',
+    type=click.Path(exists=True),
+)
+def main(input_path: str):
+    # Find all bam and cram files that need to be indexed
+    files_to_index = find_files_to_index(to_path(input_path))
+    # Index the files
+    index_files(get_batch(), files_to_index)
+    get_batch().run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A script that will take a GCP folder and then find BAM/CRAM files within that don't have corresponding bai/crai index files. Any files missing an index will have a samtools index job queued. 

The script is intended to create indexes for reads received to ingest, because having an index file present means that the reads can be re-aligned easier. 

See a test example of the script running here:
https://batch.hail.populationgenomics.org.au/batches/590102/jobs/1

In this test, the directory has 2 bams and 4 crams. 2 of the crams already have index .crai files, so they are skipped. Samtools index jobs are then queued for the 2 bams and 2 crams without indexes, and the bai and crai files are written to the correct output path.

Question - Do we need to also add a "samtools sort" in this code? 