### PR TITLE
Shard exome bams/cram inputs during align stage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.1
+current_version = 1.36.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.1
+  VERSION: 1.36.2
 
 jobs:
   docker:

--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -14,6 +14,9 @@ highmem_workers = true
 # Write the sorted BAM file to the temp bucket after alignment and before MarkDuplicates
 checkpoint_sorted_bam = false
 
+# Shard exome BAMs and CRAMs with bazam to align them in chunks
+exome_realignment_shards = 1
+
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -19,6 +19,9 @@ vep_version = '110'
 # Write the sorted BAM file to the temp bucket after alignment and before MarkDuplicates
 checkpoint_sorted_bam = false
 
+# Shard exome BAMs and CRAMs with bazam to align them in chunks
+exome_realignment_shards = 1
+
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -160,7 +160,7 @@ def align(
         realignment_shards_num = 10
     else:
         assert sequencing_group.sequencing_type == 'exome'
-        realignment_shards_num = 1
+        realignment_shards_num = 5
 
     sharded_fq = isinstance(alignment_input, FastqPairs) and len(alignment_input) > 1
     sharded_bazam = (

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -160,7 +160,7 @@ def align(
         realignment_shards_num = 10
     else:
         assert sequencing_group.sequencing_type == 'exome'
-        realignment_shards_num = 5
+        realignment_shards_num = config_retrieve(['workflow', 'exome_realignment_shards'], 1)
 
     sharded_fq = isinstance(alignment_input, FastqPairs) and len(alignment_input) > 1
     sharded_bazam = (

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -160,6 +160,8 @@ def align(
         realignment_shards_num = 10
     else:
         assert sequencing_group.sequencing_type == 'exome'
+        # consider setting the shard count to at least 2 when the input is large,
+        # or else dragen-os can run out of memory and cause the VM to continually restart
         realignment_shards_num = config_retrieve(['workflow', 'exome_realignment_shards'], 1)
 
     sharded_fq = isinstance(alignment_input, FastqPairs) and len(alignment_input) > 1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.1',
+    version='1.36.2',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR adds a config option `workflow.exome_realign_shards` which can be used to determine how many shards to split bams/crams into before aligning each shard in parallel with dragen-os.

Currently, for genomes, the input is sharded into 10 fragments with bazam. But for exomes, no sharding takes place. 

It seems like the dragen-os align job struggles with processing an unsharded BAM, even when a high memory worker is allocated for the align job. The job will report an out of memory error (code 137) as the docker container crashes, but then it will restart itself and reattempt the align job. This has lead to overspending, as jobs that should simply fail instead restart themselves and accrue costs without any chance of succeeding.

An extensive discussion has taken place in [this slack thread](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1738889941313949), which contains links to various batches showing the issue and how this sharding option resolves it.

**Tests to realign an 8.3gb exome CRAM**

Failing run with no sharding, using a high mem machine:
https://batch.hail.populationgenomics.org.au/batches/590285

Successful run with 5 shards, using high mem machines:
https://batch.hail.populationgenomics.org.au/batches/590291

Successful run with 2 shards, using standard mem machines:
https://batch.hail.populationgenomics.org.au/batches/590293