### PR TITLE
Updates to RD_Combiner

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.2
+current_version = 1.36.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.2
+  VERSION: 1.36.3
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -6,7 +6,8 @@ status_reporter = 'metamist'
 #last_stages = ['CreateDenseMtFromVdsWithHail']
 
 ## if this is False, we will not check for existing VDS - always create fresh VDS from gVCFs
-check_for_existing_vds = false
+# as of 11-02-2025 we have a base VDS for all exome and genome datasets, so by default, do check
+check_for_existing_vds = true
 
 ## If this is populated with an integer, we will use the VDS with this ID in Metamist as the starting point
 #use_specific_vds = 1234

--- a/cpg_workflows/targets.py
+++ b/cpg_workflows/targets.py
@@ -453,7 +453,7 @@ class Dataset(Target):
         prefix at all.
         """
         seq_type = get_config()['workflow'].get('sequencing_type')
-        return '' if not self.cohort or not seq_type or seq_type == 'genome' else seq_type
+        return '' if not seq_type or seq_type == 'genome' else seq_type
 
     def prefix(self, **kwargs) -> Path:
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.2',
+    version='1.36.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Slight change to config so that we always start from an existing VDS base.

---

Patch to an issue - the namespacing of `seq_type_subdir` in MultiCohorts has a condition which doesn't need to be there. This returns '' if the Dataset.cohort is None.

https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/targets.py#L450-L456

The analysis_dataset of a MultiCohort is always created without a Cohort ([line here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/targets.py#L155)), so this is always None, meaning that in CPG_workflows, all genome and exome results from a MultiCohort are namespaced into the same folder.

This condition has already been refactored out in cpg-flow

https://github.com/populationgenomics/cpg-flow/blob/main/src/cpg_flow/targets/helpers.py#L12-L17

