### PR TITLE
Don't register tmp outputs in metamist

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.3
+current_version = 1.36.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.3
+  VERSION: 1.36.4
 
 jobs:
   docker:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -512,7 +512,6 @@ class AnnotateFragmentedVcfWithVep(MultiCohortStage):
 
 
 @stage(
-    analysis_type='matrixtable',
     required_stages=[
         CreateDenseMtFromVdsWithHail,
         AnnotateFragmentedVcfWithVep,
@@ -557,7 +556,7 @@ class AnnotateCohortSmallVariantsWithHailQuery(MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=job)
 
 
-@stage(required_stages=[AnnotateCohortSmallVariantsWithHailQuery], analysis_type='matrixtable', analysis_keys=['mt'])
+@stage(required_stages=[AnnotateCohortSmallVariantsWithHailQuery])
 class SubsetMatrixTableToDatasetUsingHailQuery(DatasetStage):
     """
     Subset the MT to a single dataset

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.3',
+    version='1.36.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I'd been registering the output of AnnotateCohort SubsetMtToCohort in Metamist, even though the MTs are only stored in tmp.

This removes that registration going forward.