### PR TITLE
Update config option for combiner es-index datasets

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.4
+current_version = 1.36.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.4
+  VERSION: 1.36.5
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -15,6 +15,9 @@ check_for_existing_vds = true
 ## Subsetting and AnnotateDataset will only run for these datasets
 #write_mt_for_datasets = ['test_dataset', ]
 
+## Writing an es-index will only run for these datasets
+#create_es_index_for_datasets = ['test_dataset', ]
+
 ## number of partitions to coalesce the data into
 densify_partitions = 2500
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -683,7 +683,7 @@ class ExportMtAsEsIndex(DatasetStage):
         Transforms the MT into a Seqr index, no DataProc
         """
         # only create the elasticsearch index for the datasets specified in the config
-        eligible_datasets = config_retrieve(['workflow', 'write_mt_for_datasets'], default=[])
+        eligible_datasets = config_retrieve(['workflow', 'create_es_index_for_datasets'], default=[])
         if dataset.name not in eligible_datasets:
             get_logger().info(f'Skipping ES index creation for {dataset}')
             return None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.4',
+    version='1.36.5',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Small change that fixes the config option that determines which datasets to create an es-index for, to align with the seqr_loader pipeline. No bumpversion because it's so minor but I could add one.