### PR TITLE
Hard check on vds contents

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.5
+current_version = 1.36.6
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.5
+  VERSION: 1.36.6
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -9,6 +9,11 @@ status_reporter = 'metamist'
 # as of 11-02-2025 we have a base VDS for all exome and genome datasets, so by default, do check
 check_for_existing_vds = true
 
+# during development and the transition to input_cohorts over input_datasets, there are some instances
+# where we have VDS entries in Metamist, but the analysis entry contains SG IDs which weren't combined into the VDS
+# this is not expected to be a long term problem, but is a way of confirming explicitly which SGs still need combining
+manually_check_vds_sg_ids = true
+
 ## If this is populated with an integer, we will use the VDS with this ID in Metamist as the starting point
 #use_specific_vds = 1234
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -4,11 +4,11 @@ use the gVCF combiner instead of joint-calling.
 """
 
 from google.api_core.exceptions import PermissionDenied
-
+from hail.vds import read_vds
 from cpg_utils import Path, to_path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import config_retrieve, genome_build
-from cpg_utils.hail_batch import get_batch
+from cpg_utils.hail_batch import get_batch, init_batch
 from cpg_workflows.jobs.gcloud_composer import gcloud_compose_vcf_from_manifest
 from cpg_workflows.jobs.rd_combiner import combiner
 from cpg_workflows.jobs.rd_combiner.vep import add_vep_jobs
@@ -21,7 +21,7 @@ from cpg_workflows.jobs.rd_combiner.vqsr import (
     train_vqsr_snps,
 )
 from cpg_workflows.targets import Dataset, MultiCohort
-from cpg_workflows.utils import get_all_fragments_from_manifest, get_logger, tshirt_mt_sizing
+from cpg_workflows.utils import get_all_fragments_from_manifest, get_logger, tshirt_mt_sizing, exists
 from cpg_workflows.workflow import (
     DatasetStage,
     MultiCohortStage,
@@ -124,6 +124,27 @@ def query_for_latest_vds(dataset: str, entry_type: str = 'combiner') -> dict | N
     return analyses_by_date[sorted(analyses_by_date)[-1]]
 
 
+def manually_find_ids_from_vds(vds_path: str) -> set[str]:
+    """
+    during development and the transition to input_cohorts over input_datasets, there are some instances
+    where we have VDS entries in Metamist, but the analysis entry contains SG IDs which weren't combined into the VDS
+
+    This check bypasses the quick "get all SG IDs in the VDS analysis entry" check,
+    and instead checks the exact contents of the VDS
+
+    Args:
+        vds_path (str): path to the VDS. Assuming it exists, this will be checked before calling this method
+
+    Returns:
+        set[str]: the set of sample IDs in the VDS
+    """
+    init_batch()
+    vds = read_vds(vds_path)
+
+    # find the samples in the Variant Data MT
+    return set(vds.variant_data.s.collect())
+
+
 @stage(analysis_type='combiner', analysis_keys=['vds'])
 class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
     def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path | str]:
@@ -158,6 +179,15 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
         else:
             get_logger(__file__).info('Not continuing from any previous VDS, creating new Combiner from gVCFs only')
+
+        # quick check - if we found a VDS, guarantee it exists
+        if vds_path and not exists(vds_path):
+            raise ValueError(f'VDS {vds_path} does not exist, but has an Analysis Entry')
+
+        # this is a more computationally expensive, but much more certain check, on prior VDS contents
+        # it is not used by default, but can be enabled by setting manually_check_vds_sg_ids to true
+        if vds_path and config_retrieve(['workflow', 'manually_check_vds_sg_ids'], False):
+            sg_ids_in_vds = manually_find_ids_from_vds(vds_path)
 
         new_sg_gvcfs: list[str] = [
             str(sg.gvcf)

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -4,7 +4,9 @@ use the gVCF combiner instead of joint-calling.
 """
 
 from google.api_core.exceptions import PermissionDenied
+
 from hail.vds import read_vds
+
 from cpg_utils import Path, to_path
 from cpg_utils.cloud import read_secret
 from cpg_utils.config import config_retrieve, genome_build
@@ -21,7 +23,7 @@ from cpg_workflows.jobs.rd_combiner.vqsr import (
     train_vqsr_snps,
 )
 from cpg_workflows.targets import Dataset, MultiCohort
-from cpg_workflows.utils import get_all_fragments_from_manifest, get_logger, tshirt_mt_sizing, exists
+from cpg_workflows.utils import exists, get_all_fragments_from_manifest, get_logger, tshirt_mt_sizing
 from cpg_workflows.workflow import (
     DatasetStage,
     MultiCohortStage,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.5',
+    version='1.36.6',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
See https://batch.hail.populationgenomics.org.au/batches/590461

Looks like some of the analysis entries for the VDSs we have on file suggest they include more SGs than they actually do. 

This check doesn't trust the metamist records, instead guaranteeing the VDS contents by checking directly.

Hopefully this is all just a teething problem