### PR TITLE
Re-point images-dev docker images

### DIFF
--- a/configs/defaults/clinvarbitration.toml
+++ b/configs/defaults/clinvarbitration.toml
@@ -1,6 +1,3 @@
 [workflow]
 sequencing_type = 'genome'
 site_blacklist = ["victorian clinical genetics services, murdoch childrens research institute"]
-
-[images]
-bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools_120:1.20"

--- a/configs/defaults/clinvarbitration.toml
+++ b/configs/defaults/clinvarbitration.toml
@@ -3,4 +3,4 @@ sequencing_type = 'genome'
 site_blacklist = ["victorian clinical genetics services, murdoch childrens research institute"]
 
 [images]
-bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/bcftools:1.20"
+bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools_120:1.20"

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -28,7 +28,7 @@ gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
 gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
-sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/gatk-sv_issue_661:n_a"
+sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/gatk-sv_issue_661:n_a"
 
 [references.gatk_sv]
 # a couple of annotation arguments are not files


### PR DESCRIPTION
It's me, hi, I'm the problem it's me.

These are the two instances I know of where an `images-dev` Docker image is being used in routine work.

The GATK-SV one was being trialed before a merge to main in images, and the image path was never updated after it was tested successfully. The main and `-dev` images are from the same Dockerfile, and contain the same patch.

The ClinvArbitration one was built from [this branch](https://github.com/populationgenomics/images/pull/154) when there was no consensus on how/if it should be moved forward. The same image is now built with a different name (bcftools_120), but is not needed in this pipeline. Going forward I'm hoping this pipeline will be run outside of production-pipelines (see [here](https://github.com/populationgenomics/ClinvArbitration/pull/14))