### PR TITLE
Update combiner to include correct sgids

### DIFF
--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -27,6 +27,8 @@ def run(
     genome_build: str,
     save_path: str | None,
     force_new_combiner: bool = False,
+    sequencing_group_names: list[str] | None = None,
+    gvcf_external_header: str | None = None,
     gvcf_paths: list[str] | None = None,
     vds_paths: list[str] | None = None,
     specific_intervals: list[str] | None = None,
@@ -79,6 +81,11 @@ def run(
             output_path=output_vds_path,
             save_path=save_path,
             gvcf_paths=gvcf_paths,
+            gvcf_sample_names=sequencing_group_names,
+            # Header must be used with gvcf_sample_names, otherwise gvcf_sample_names
+            # will be ignored. The first gvcf path works fine as a header because it will
+            # be only read until the last line that begins with "#":
+            gvcf_external_header=gvcf_external_header,
             vds_paths=vds_paths,
             reference_genome=genome_build,
             temp_path=tmp_prefix,

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -112,6 +112,8 @@ class Combiner(CohortStage):
             genome_build=genome_build(),
             save_path=output_paths['combiner_plan'],
             force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),
+            gvcf_sample_names=[str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds],
+            gvcf_external_header=new_sg_gvcfs[0],
             gvcf_paths=new_sg_gvcfs,
             vds_paths=vds_paths,
         )

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -112,7 +112,9 @@ class Combiner(CohortStage):
             genome_build=genome_build(),
             save_path=output_paths['combiner_plan'],
             force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),
-            gvcf_sample_names=[str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds],
+            sequencing_group_names=[
+                str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds
+            ],
             gvcf_external_header=new_sg_gvcfs[0],
             gvcf_paths=new_sg_gvcfs,
             vds_paths=vds_paths,


### PR DESCRIPTION
The VDS being created by `Combiner` pull sthe sgid from the gvcf header when we do not supply sample names to the combiner. This is an issue as all test gvcfs when copied to the test bucket using `create_test_subset.py` have their filenames changed to the correct sgid but their headers still refer to the sgid's in main where they came from, leading to issues where the sgids that are indexing the VDS are the sgids in main and not the ones in test. This causes downstream issues where SampleQC correctly pulls the test sgids and we're left in a situation where the keys of one Hail Table do not match the keys of another, see the snippet from [sample_qc.py](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/large_cohort/sample_qc.py) below:

```python
# cpg_workflows/large_cohort/sample_qc.py

ht = initialise_sample_table()

sqc_ht_path = to_path(tmp_prefix) / 'sample_qc.ht'
if can_reuse(sqc_ht_path):
        sqc_ht = hl.read_table(str(sqc_ht_path))
    else:
        # Filter to autosomes:
        autosome_vds = hl.vds.filter_chromosomes(vds, keep=[f'chr{chrom}' for chrom in range(1, 23)])
        sqc_ht = hl.vds.sample_qc(autosome_vds)
        sqc_ht = sqc_ht.checkpoint(str(sqc_ht_path), overwrite=True)
ht = ht.annotate(sample_qc=sqc_ht[ht.s]) <---- sgids are keys of `ht` and `sqc_ht`and are different producing an empty `ht`
```

[Batch](https://batch.hail.populationgenomics.org.au/batches/590723) that has produced correct VDS and SampleQC output