### PR TITLE
Allow user to specify the GatherSampleEvidence jobs to run

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.7
+current_version = 1.36.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.7
+  VERSION: 1.36.8
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_singlesample.toml
+++ b/configs/defaults/gatk_sv_singlesample.toml
@@ -4,6 +4,10 @@ ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapie
 status_reporter = 'metamist'
 time_limit_seconds = 86400  # 24 hrs max runtime
 
+# Use this option to run only a subset of jobs in the GatherSampleEvidence workflow
+# [workflow.GatherSampleEvidence]
+# only_jobs = ['coverage_counts', 'pesr', 'scramble', 'wham', 'manta']
+
 # these workflows take a VCF result from a GatherSampleEvidence stage, and optionally a baseline VCF
 # from the same caller, and runs a VCFMetrics comparison of the two
 # we don't have like-for-like baselines for any of our samples (AFAIK), and the workflows don't allow

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -35,6 +35,7 @@ def get_sv_callers():
         callers = [caller for caller in SV_CALLERS if caller in only_jobs]
         if not callers:
             raise ValueError('No SV callers enabled')
+        return callers
     return SV_CALLERS
 
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -30,7 +30,18 @@ from cpg_workflows.workflow import (
 )
 
 
-@stage(analysis_keys=[f'{caller}_vcf' for caller in SV_CALLERS], analysis_type='sv')
+def get_sv_callers():
+    if only_jobs := config_retrieve(['workflow', 'GatherSampleEvidence', 'only_jobs']):
+        callers = []
+        for job in only_jobs:
+            for caller in SV_CALLERS:
+                if caller in job:
+                    callers.append(caller)
+        return callers
+    return SV_CALLERS
+
+
+@stage(analysis_keys=[f'{caller}_vcf' for caller in get_sv_callers()], analysis_type='sv')
 class GatherSampleEvidence(SequencingGroupStage):
     """
     https://github.com/broadinstitute/gatk-sv#gathersampleevidence

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -32,12 +32,9 @@ from cpg_workflows.workflow import (
 
 def get_sv_callers():
     if only_jobs := config_retrieve(['workflow', 'GatherSampleEvidence', 'only_jobs']):
-        callers = []
-        for job in only_jobs:
-            for caller in SV_CALLERS:
-                if caller in job:
-                    callers.append(caller)
-        return callers
+        callers = [caller for caller in SV_CALLERS if caller in only_jobs]
+        if not callers:
+            raise ValueError('No SV callers enabled')
     return SV_CALLERS
 
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -73,7 +73,7 @@ class GatherSampleEvidence(SequencingGroupStage):
         }
 
         # Caller's VCFs
-        for caller in SV_CALLERS:
+        for caller in get_sv_callers():
             d[f'{caller}_vcf'] = sequencing_group.make_sv_evidence_path / f'{sequencing_group.id}.{caller}.vcf.gz'
             d[f'{caller}_index'] = sequencing_group.make_sv_evidence_path / f'{sequencing_group.id}.{caller}.vcf.gz.tbi'
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -130,14 +130,6 @@ class GatherSampleEvidence(SequencingGroupStage):
             # this is useful for samples which need to re-run specific jobs
             # e.g. if manta failed and needs to be re-run with more memory
 
-            # remove the expected outputs for the jobs that are not in only_jobs
-            new_expected = {}
-            for job in only_jobs:
-                for key, path in expected_d.items():
-                    if job in key:
-                        new_expected[key] = path
-            expected_d = new_expected
-
             # disable the evidence collection jobs if they're not in only_jobs
             if 'coverage_counts' not in only_jobs:
                 input_dict['collect_coverage'] = False
@@ -149,6 +141,14 @@ class GatherSampleEvidence(SequencingGroupStage):
                 if key in [f'{caller}_docker' for caller in SV_CALLERS]:
                     caller = key.removesuffix('_docker')
                     input_dict[key] = val if caller in only_jobs else None
+
+            # remove the expected outputs for the jobs that are not in only_jobs
+            new_expected = {}
+            for job in only_jobs:
+                for key, path in expected_d.items():
+                    if job in key:
+                        new_expected[key] = path
+            expected_d = new_expected
 
         # billing labels!
         # https://cromwell.readthedocs.io/en/stable/wf_options/Google/

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.7',
+    version='1.36.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Updates the GatherSampleEvidence stage to allow for the user to specify the jobs that should be run using a new config option `workflow.GatherSampleEvidence.only_jobs`. 

This option will also determine the outputs that are collected from the cromwell server and copied to GCP + the analyses written to Metamist.

To do this, we need to
1. Stop the jobs not in the `only_jobs` list from running as part of the Cromwell workflow
2. Stop the Hail batch driver job from submitting "collect outputs" jobs for the Cromwell jobs which are not running

---

### 1. Stop certain cromwell jobs from running within the GatherSampleEvidence workflow

The GatherSampleEvidence stage runs the [GatherSampleEvidence.wdl](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/GatherSampleEvidence.wdl) workflow in Cromwell. 
This workflow will submit a bunch of Cromwell jobs for a sample, namely:
- coverage counts
- 'pesr'  jobs
- scramble calling
- whamg calling
- manta calling

These jobs can be set to not run if the workflow input is changed. 
- [The coverage counts and pesr jobs can be turned off by setting the evidence collection flags to `False`](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/GatherSampleEvidence.wdl#L26)
  - i.e. `collect_coverage = false`, `collect_pesr = false`
- [The caller jobs can be turned off by unsetting each of the `{caller}_docker` variables](https://github.com/populationgenomics/gatk-sv/blob/main/wdl/GatherSampleEvidence.wdl#L148) 
  - i.e. `scramble_docker = null`, `wham_docker=null`, ... 
  - Note that `melt_docker` is undefined in our pipeline, hence that caller's jobs are never submitted

The workflow input can be changed by altering the `input_dict` defined in the cpg_workflows stage.

### 2. Don't try to collect outputs for jobs which didn't run

The cpg_workflows code will submit "collect outputs" jobs to the Hail batch run that submits and watches the cromwell workflow. These "collect outputs" jobs also need to be disabled if the related cromwell job is not running. 

To stop the "collect outputs" jobs from running, the stages `expected_outputs` dictionary must be updated before the jobs are submitted. 

---

A simple code block which parses the `only_jobs` config list can be used to update both the `input_dict` and the `expected_outputs`, effectively limiting the Cromwell workflow to just the jobs specified. 

---

Test batch running only Manta: https://batch.hail.populationgenomics.org.au/batches/590770