### PR TITLE
Cast the AD values to a comma separated string

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.8
+current_version = 1.36.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.8
+  VERSION: 1.36.9
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/annotate_dataset_small_vars.py
+++ b/cpg_workflows/scripts/annotate_dataset_small_vars.py
@@ -37,7 +37,7 @@ def annotate_dataset_mt(mt_path: str, out_mt_path: str):
             ),
             hl.sum(mt.AD),
         ),
-        'ad': mt.AD,
+        'ad': hl.if_else(is_called, hl.delimit(mt.AD, ','), hl.missing(hl.tstr)),
         'dp': hl.if_else(is_called, hl.int(hl.min(mt.DP, 32000)), hl.missing(hl.tfloat)),
         'sample_id': mt.s,
     }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.8',
+    version='1.36.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Makes the AD values exported to the annotated dataset consistent with seqr's expected format of a comma separated string, like the example data [here](https://github.com/broadinstitute/seqr/blob/cb32e5b5c490e9dd24f1961fad3be64047205bd8/seqr/fixtures/1kg_project.json#L1822).