### PR TITLE
Fix ICA upload and download commands

### DIFF
--- a/cpg_workflows/stages/realign_genotype_with_dragen.py
+++ b/cpg_workflows/stages/realign_genotype_with_dragen.py
@@ -120,11 +120,11 @@ class UploadDataToIca(SequencingGroupStage):
             cram_status=$(icav2 projectdata list --parent-folder /{bucket}/{upload_folder}/{sequencing_group.name}/ --data-type FILE --file-name {sequencing_group.name}.cram --match-mode EXACT -o json | jq -r '.items[].details.status')
             if [[ $cram_status != "AVAILABLE" ]]
             then
-                mkdir /io/{sequencing_group.name}
-                gcloud storage cp {sequencing_group.cram} /io/{sequencing_group.name}/
-                gcloud storage cp {sequencing_group.cram}.crai /io/{sequencing_group.name}/
-                icav2 projectdata upload /io/{sequencing_group.name}/{sequencing_group.name}.cram /{bucket}/{upload_folder}/{sequencing_group.name}/
-                icav2 projectdata upload /io/{sequencing_group.name}/{sequencing_group.name}.cram.crai /{bucket}/{upload_folder}/{sequencing_group.name}/
+                mkdir $BATCH_TMPDIR/{sequencing_group.name}
+                gcloud storage cp {sequencing_group.cram} $BATCH_TMPDIR/{sequencing_group.name}/
+                gcloud storage cp {sequencing_group.cram}.crai $BATCH_TMPDIR/{sequencing_group.name}/
+                icav2 projectdata upload $BATCH_TMPDIR/{sequencing_group.name}/{sequencing_group.name}.cram /{bucket}/{upload_folder}/{sequencing_group.name}/
+                icav2 projectdata upload $BATCH_TMPDIR/{sequencing_group.name}/{sequencing_group.name}.cram.crai /{bucket}/{upload_folder}/{sequencing_group.name}/
             fi
 
             icav2 projectdata list --parent-folder /{bucket}/{upload_folder}/{sequencing_group.name}/ --data-type FILE --file-name {sequencing_group.name}.cram --match-mode EXACT -o json | jq -r '.items[].id' > cram_id

--- a/cpg_workflows/stages/realign_genotype_with_dragen.py
+++ b/cpg_workflows/stages/realign_genotype_with_dragen.py
@@ -116,6 +116,8 @@ class UploadDataToIca(SequencingGroupStage):
         # Check if the CRAM already exists in ICA before uploading. If it exists, just return the ID for the CRAM and CRAI
         upload_job.command(
             f"""
+            pwd
+            df --si
             {ICA_CLI_SETUP}
             cram_status=$(icav2 projectdata list --parent-folder /{bucket}/{upload_folder}/{sequencing_group.name}/ --data-type FILE --file-name {sequencing_group.name}.cram --match-mode EXACT -o json | jq -r '.items[].details.status')
             if [[ $cram_status != "AVAILABLE" ]]
@@ -126,7 +128,7 @@ class UploadDataToIca(SequencingGroupStage):
                 icav2 projectdata upload $BATCH_TMPDIR/{sequencing_group.name}/{sequencing_group.name}.cram /{bucket}/{upload_folder}/{sequencing_group.name}/
                 icav2 projectdata upload $BATCH_TMPDIR/{sequencing_group.name}/{sequencing_group.name}.cram.crai /{bucket}/{upload_folder}/{sequencing_group.name}/
             fi
-
+            df --si
             icav2 projectdata list --parent-folder /{bucket}/{upload_folder}/{sequencing_group.name}/ --data-type FILE --file-name {sequencing_group.name}.cram --match-mode EXACT -o json | jq -r '.items[].id' > cram_id
             icav2 projectdata list --parent-folder /{bucket}/{upload_folder}/{sequencing_group.name}/ --data-type FILE --file-name {sequencing_group.name}.cram.crai --match-mode EXACT -o json | jq -r '.items[].id' > crai_id
 

--- a/cpg_workflows/stages/realign_genotype_with_dragen.py
+++ b/cpg_workflows/stages/realign_genotype_with_dragen.py
@@ -390,7 +390,9 @@ class DownloadCramFromIca(SequencingGroupStage):
                 exit 1
             else
                 echo "MD5 checksums match."
+            fi
 
+            # Copy the CRAM and CRAI files to the bucket
             # Checksums are already checked by `gcloud storage cp`
             gcloud storage cp {sequencing_group.name}/{sequencing_group.name}.cram gs://{bucket_name}/{GCP_FOLDER_FOR_ICA_DOWNLOAD}/cram/
             gcloud storage cp {sequencing_group.name}/{sequencing_group.name}.cram.crai gs://{bucket_name}/{GCP_FOLDER_FOR_ICA_DOWNLOAD}/cram/
@@ -480,7 +482,9 @@ class DownloadGvcfFromIca(SequencingGroupStage):
                 exit 1
             else
                 echo "MD5 checksums match."
+            fi
 
+            # Copy the gVCF and gVCF TBI files to the bucket
             # Checksums are already checked by `gcloud storage cp`
             gcloud storage cp {sequencing_group.name}/{sequencing_group.name}.hard-filtered.gvcf.gz gs://{bucket_name}/{GCP_FOLDER_FOR_ICA_DOWNLOAD}/base_gvcf/
             gcloud storage cp {sequencing_group.name}/{sequencing_group.name}.hard-filtered.gvcf.gz.tbi gs://{bucket_name}/{GCP_FOLDER_FOR_ICA_DOWNLOAD}/base_gvcf/


### PR DESCRIPTION
## Issue 1:
[During the upload](https://batch.hail.populationgenomics.org.au/batches/590809/jobs/3) of crams to Batch VMs we are seeing `"No space left on device"` for some jobs. We think that changing the upload directory to be `/io` will avoid these storage issues.

## Issue 2:
Additionally, the cram files in GCP do not have md5 hashes calculated and so comparing the ICA md5sum to the once on GCP returns an error and the file still gets downloaded but the job fails and is not registered to metamist. Consulting the `gcloud storage` documentation [here](https://cloud.google.com/storage/docs/data-validation#cli) we see:

> For the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud/reference/storage), data copied to or from a Cloud Storage bucket is validated. This applies to cp, mv, and rsync commands. If the checksum of the source data does not match the checksum of the destination data, the gcloud CLI deletes the invalid copy and prints a warning message.

So we are only performing md5sum matching after downloading from ICA via `icav2` and not when copying from the local directory to GCP.