### PR TITLE
Echtvar workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.8
+current_version = 1.36.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.8
+  VERSION: 1.36.9
 
 jobs:
   docker:

--- a/configs/defaults/echtvar.toml
+++ b/configs/defaults/echtvar.toml
@@ -1,0 +1,35 @@
+[workflow]
+
+# The name of the workflow
+name = "echtvar"
+
+# the cohort isn't important, so this is a dummy value
+input_cohorts = ['COH2142']
+sequencing_type = 'genome'
+
+[references."gnomad_4.1_vcfs"]
+chr1 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr1.vcf.bgz"
+chr2 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr2.vcf.bgz"
+chr3 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr3.vcf.bgz"
+chr4 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr4.vcf.bgz"
+chr5 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr5.vcf.bgz"
+chr6 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr6.vcf.bgz"
+chr7 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr7.vcf.bgz"
+chr8 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr8.vcf.bgz"
+chr9 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr9.vcf.bgz"
+chr10 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr10.vcf.bgz"
+chr11 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr11.vcf.bgz"
+chr12 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr12.vcf.bgz"
+chr13 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr13.vcf.bgz"
+chr14 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr14.vcf.bgz"
+chr15 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr15.vcf.bgz"
+chr16 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr16.vcf.bgz"
+chr17 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr17.vcf.bgz"
+chr18 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr18.vcf.bgz"
+chr19 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr19.vcf.bgz"
+chr20 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr20.vcf.bgz"
+chr21 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr21.vcf.bgz"
+chr22 = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chr22.vcf.bgz"
+chrX = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chrX.vcf.bgz"
+chrY = "gs://cpg-common-main/references/gnomad/v4.1/vcfs/gnomad.genomes.v4.1.sites.chrY.vcf.bgz"
+chrM = "gs://cpg-common-main/references/gnomad/v3.1/vcf/gnomad.genomes.r3.1.sites.chrM.vcf.bgz"

--- a/cpg_workflows/stages/echtvar.py
+++ b/cpg_workflows/stages/echtvar.py
@@ -9,8 +9,8 @@ from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, image_path
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.targets import MultiCohort
-from cpg_workflows.workflow import MultiCohortStage, StageInput, StageOutput, exists, stage
 from cpg_workflows.utils import get_logger
+from cpg_workflows.workflow import MultiCohortStage, StageInput, StageOutput, exists, stage
 
 CANONICAL_CHROMOSOMES = [f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y', 'whole_genome']]
 common_folder = join(config_retrieve(['storage', 'common', 'analysis']), 'gnomad', 'echtvar')

--- a/cpg_workflows/stages/echtvar.py
+++ b/cpg_workflows/stages/echtvar.py
@@ -1,0 +1,64 @@
+"""
+all processes related to echtvar - generating a VCF annotation resource from raw inputs, or applying those annotations
+this is not confined to a specific cohort/project
+"""
+
+from os.path import join
+
+from cpg_utils import Path, to_path
+from cpg_utils.config import config_retrieve, image_path
+from cpg_utils.hail_batch import get_batch
+from cpg_workflows.targets import MultiCohort
+from cpg_workflows.workflow import MultiCohortStage, StageInput, StageOutput, stage, exists
+
+CANONICAL_CHROMOSOMES = [f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y', 'whole_genome']]
+common_folder = join(config_retrieve(['storage', 'common', 'analysis']), 'gnomad', 'echtvar')
+
+
+@stage
+class RunEchtvarOnGnomad(MultiCohortStage):
+    """Run echtvar on gnomAD data, generate annotation sources"""
+
+    def expected_outputs(self, multicohort: MultiCohort) -> Path:
+
+        # run for each chromosome, and again for the whole genome
+        return {chrom: to_path(f'{common_folder}/gnomad_4.1_{chrom}.zip') for chrom in CANONICAL_CHROMOSOMES}
+
+    def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
+        """
+        run echtvar encode on all gnomadV4 contigs, separately and combined
+        we need to do this once ever, estimated cost $5
+        """
+
+        output = self.expected_outputs(multicohort)
+
+        contig_files = []
+        for contig in CANONICAL_CHROMOSOMES:
+            # don't do this for the whole genome output
+            if contig == 'whole_genome':
+                continue
+
+            # localise this one file
+            contig_localised = get_batch().read_input(config_retrieve(['references', 'gnomad_4.1_vcfs', contig]))
+            # add to the list of inputs for the whole genome job
+            contig_files.append(contig_localised)
+            # create and resource a job
+            contig_job = get_batch().new_job(f'Run echtvar on gnomad v4.1 {contig}')
+            contig_job.image(image_path('echtvar'))
+            contig_job.storage('10Gi')
+            contig_job.cpu(4)
+            contig_job.memory('highmem')
+            # run the echtvar encode command
+            contig_job.command(f'echtvar encode {contig_job.output} $ECHTVAR_CONFIG {contig_localised}')
+            get_batch().write_output(contig_job.output, str(output[contig]))
+
+        job = get_batch().new_job('Run echtvar on gnomad v4.1, whole genome')
+        job.image(image_path('echtvar'))
+        job.storage('700G')
+        job.cpu(4)
+        job.memory('highmem')
+
+        job.command(f'echtvar encode {job.output} $ECHTVAR_CONFIG {" ".join(contig_files)}')
+        get_batch().write_output(job.output, str(output['whole_genome']))
+
+        return self.make_outputs(target=multicohort, jobs=job, data=output)

--- a/cpg_workflows/stages/echtvar.py
+++ b/cpg_workflows/stages/echtvar.py
@@ -51,7 +51,7 @@ class RunEchtvarOnGnomad(MultiCohortStage):
             # create and resource a job
             contig_job = get_batch().new_job(f'Run echtvar on gnomad v4.1, {contig}')
             contig_job.image(image_path('echtvar'))
-            contig_job.storage('10Gi')
+            contig_job.storage('50Gi')
             contig_job.cpu(4)
             contig_job.memory('highmem')
             # run the echtvar encode command
@@ -62,7 +62,7 @@ class RunEchtvarOnGnomad(MultiCohortStage):
         if not exists(output['whole_genome']):
             job = get_batch().new_job('Run echtvar on gnomad v4.1, whole genome')
             job.image(image_path('echtvar'))
-            job.storage('700G')
+            job.storage('600G')
             job.cpu(4)
             job.memory('highmem')
             job.command(f'echtvar encode {job.output} $ECHTVAR_CONFIG {" ".join(contig_files)}')

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from cpg_utils.config import set_config_paths
 from cpg_workflows import defaults_config_path
 from cpg_workflows.stages.clinvarbitration import PackageForRelease
 from cpg_workflows.stages.cram_qc import CramMultiQC
+from cpg_workflows.stages.echtvar import RunEchtvarOnGnomad
 from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults
 from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.fraser import Fraser
@@ -48,6 +49,7 @@ from cpg_workflows.workflow import StageDecorator, run_workflow
 
 WORKFLOWS: dict[str, list[StageDecorator]] = {
     'clinvarbitration': [PackageForRelease],
+    'echtvar': [RunEchtvarOnGnomad],
     'talos': [MakePhenopackets, ValidateMOI, CreateTalosHTML, MinimiseOutputForSeqr],
     'exomiser': [ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults],
     'long_read_snps_indels_annotation': [MtToEsLrSNPsIndels],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.8',
+    version='1.36.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This adds the [echtvar](https://github.com/brentp/echtvar) workflow - digesting the whole of gnomAD v4.1 (selected annotations), and generating a condensed representation for ultrafast annotation.

This is not a destructive process, we're keeping all the raw gnomAD data as well.

This is a partner to https://github.com/populationgenomics/images/pull/189

The resulting file here is a shade under 4GB in total size.

---

I'd like to start a conversation about whether we can host this data for public use. $5 funds 12 downloads of the whole-genome file generated here (50GB data allowance). We can cross-post to the Echtvar repository - they make the tool, we host some data, they link to us for their users. 

1. We host the data in a way which is publicly accessible, which is a gateway to using Talos (see related PR). We'd expect these users to be people looking to use Talos, but who are put off by installing and configuring our exact version of VEP
2. We provide a way for users of a generic tool to discover us 
 - Echtvar has a link in their release page saying "CPG is generously hosting a pre-processed version of the gnomAD v4.1 dataset" 
 - they land on our repository dedicated to preparing data from VCF for Talos
 - they download the gnomAD files they need
 - User discovers Talos...

We'd be paying 40¢ per download to potentially lead people to Talos who we wouldn't normally be able to connect to