### PR TITLE
Avoid extracting absent SG from callset

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.8
+current_version = 1.36.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.8
+  VERSION: 1.36.9
 
 jobs:
   docker:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -626,6 +626,14 @@ class SubsetMatrixTableToDatasetUsingHailQuery(DatasetStage):
         if not config_retrieve(['workflow', 'dry_run'], False):
             with outputs['id_file'].open('w') as f:
                 for sg in dataset.get_sequencing_groups():
+
+                    # skip over SGs without gVCFs, they can't have been combined into the MT, so cannot be extracted
+                    if not sg.gvcf:
+                        get_logger().error(f'SG {sg.id} has no gVCF, will not attempt to extract from the MT')
+                        get_logger().error(f'Note! {sg.id} will still appear in the metamist analysis entry for the MT')
+                        get_logger().error(f'If {sg.id} is not in this callset, it should be removed from the cohort')
+                        continue
+
                     f.write(f'{sg.id}\n')
 
         job = get_batch().new_job(self.name, self.get_job_attrs(dataset))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.8',
+    version='1.36.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Partially addresses https://github.com/populationgenomics/production-pipelines/issues/1149

This will throw an error (but not crash the pipeline) if there are SGs in the Cohort which aren't in the callset. The error states that the better solution would be to remove the SG from the cohort completely, but in the interim this allows the unchanged cohort to complete through the workflow.