### PR TITLE
Add option to subset matrixtable to only certain families and SGs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.9
+current_version = 1.36.10
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.9
+  VERSION: 1.36.10
 
 jobs:
   docker:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -156,7 +156,6 @@ def get_family_sequencing_groups(dataset: Dataset) -> dict:
     Get the subset of sequencing groups that are in the specified families for a dataset
     Returns a dict containing the sequencing groups and a name suffix for the outputs
     """
-    dataset_name = dataset.name (+ '-test' if config_retrieve(['workflow', 'access_level']) == 'test' else '')
     only_family_ids = set(config_retrieve(['workflow', dataset.name, 'only_families'], []))
     # keep only the SG IDs for the families in the only_families list
     family_sg_ids = [sg.id for sg in dataset.get_sequencing_groups() if sg.pedigree.fam_id in only_family_ids]

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -158,6 +158,9 @@ def get_family_sequencing_groups(dataset: Dataset) -> dict:
     """
     only_family_ids = set(config_retrieve(['workflow', dataset.name, 'only_families'], []))
     # keep only the SG IDs for the families in the only_families list
+    get_logger.info(f'Finding sequencing groups for families {only_family_ids} in dataset {dataset.name}')
+    for sg in dataset.get_sequencing_groups():
+        print(sg.id, sg.pedigree.fam_id)
     family_sg_ids = [sg.id for sg in dataset.get_sequencing_groups() if sg.pedigree.fam_id in only_family_ids]
     if not family_sg_ids:
         raise ValueError(f'No sequencing groups found for families {only_family_ids} in dataset {dataset.name}. Available sequencing groups: {[sg.id for sg in dataset.get_sequencing_groups()]}')

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -156,11 +156,12 @@ def get_family_sequencing_groups(dataset: Dataset) -> dict:
     Get the subset of sequencing groups that are in the specified families for a dataset
     Returns a dict containing the sequencing groups and a name suffix for the outputs
     """
+    dataset_name = dataset.name (+ '-test' if config_retrieve(['workflow', 'access_level']) == 'test' else '')
     only_family_ids = set(config_retrieve(['workflow', dataset.name, 'only_families'], []))
     # keep only the SG IDs for the families in the only_families list
     family_sg_ids = [sg.id for sg in dataset.get_sequencing_groups() if sg.pedigree.fam_id in only_family_ids]
     if not family_sg_ids:
-        raise ValueError(f'No sequencing groups found for families {only_family_ids} in dataset {dataset.name}')
+        raise ValueError(f'No sequencing groups found for families {only_family_ids} in dataset {dataset.name}. Available sequencing groups: {[sg.id for sg in dataset.get_sequencing_groups()]}')
     get_logger().info(f'Keeping only {len(family_sg_ids)} SGs from families {len(only_family_ids)} in {dataset}:')
     get_logger().info(only_family_ids)
     get_logger().info(family_sg_ids)

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -3,6 +3,8 @@ All Stages relating to the seqr_loader pipeline, reimplemented from scratch to
 use the gVCF combiner instead of joint-calling.
 """
 
+from functools import cache
+
 from google.api_core.exceptions import PermissionDenied
 
 from hail.vds import read_vds
@@ -51,6 +53,27 @@ LATEST_ANALYSIS_QUERY = gql(
     }
 """,
 )
+
+FAMILY_SGS_QUERY = gql(
+    """
+    projectFamilySequencingGroups($dataset: String!, $sequencing_type: String!) {
+        project(name: $dataset) {
+            families {
+                id
+                externalId
+                participants {
+                    samples {
+                        sequencingGroups(type: {eq: $sequencing_type}) {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """,
+)
+
 SPECIFIC_VDS_QUERY = gql(
     """
     query getVDSByAnalysisId($vds_id: Int!) {
@@ -145,6 +168,34 @@ def manually_find_ids_from_vds(vds_path: str) -> set[str]:
 
     # find the samples in the Variant Data MT
     return set(vds.variant_data.s.collect())
+
+
+@cache
+def query_for_family_sequencing_groups(dataset: str, sequencing_type: str, only_families: list) -> dict:
+    """
+    Query for the sequencing groups in certain families for a dataset
+    """
+    # get the SG IDs for all families in the dataset
+    family_sgs = query(FAMILY_SGS_QUERY, variables={'dataset': dataset, 'sequencing_type': sequencing_type})
+    # keep only the SG IDs for the families in the only_families list
+    family_sg_ids = [
+        sg['id']
+        for family in family_sgs['project']['families']
+        for participant in family['participants']
+        for sample in participant['samples']
+        for sg in sample['sequencingGroups']
+        if (family['externalId'] in only_families) or (family['id'] in only_families)
+    ]
+    only_family_ids = [
+        (family['id'], family['externalId'])
+        for family in family_sgs['project']['families']
+        if family['id'] in only_families or family['externalId'] in only_families
+    ]
+    get_logger().info(f'Keeping only {len(family_sg_ids)} SGs from families {len(only_family_ids)} in {dataset}:')
+    get_logger().info(only_family_ids)
+    get_logger().info(family_sg_ids)
+
+    return {'family_sg_ids': family_sg_ids, 'only_family_ids': only_family_ids}
 
 
 @stage(analysis_type='combiner', analysis_keys=['vds'])
@@ -591,22 +642,41 @@ class AnnotateCohortSmallVariantsWithHailQuery(MultiCohortStage):
 @stage(required_stages=[AnnotateCohortSmallVariantsWithHailQuery])
 class SubsetMatrixTableToDatasetUsingHailQuery(DatasetStage):
     """
-    Subset the MT to a single dataset
+    Subset the MT to a single dataset - or a subset of families within a dataset
     Skips this stage if the MultiCohort has only one dataset
     """
 
     def expected_outputs(self, dataset: Dataset) -> dict[str, Path] | None:
         """
         Expected to generate a MatrixTable
-        This is kinda transient, so shove it in tmp
+        This is kinda transient, so shove it in tmp.
+
+        If subsetting to certain families, the output will be named accordingly
         """
         if len(get_multicohort().get_datasets()) == 1:
             get_logger().info(f'Skipping SubsetMatrixTableToDataset for single Dataset {dataset}')
             return None
-        return {
-            'mt': dataset.tmp_prefix() / 'mt' / self.name / f'{get_workflow().output_version}-{dataset.name}.mt',
-            'id_file': dataset.tmp_prefix() / f'{get_workflow().output_version}-{dataset.name}-SG-ids.txt',
-        }
+        if only_families := config_retrieve(['workflow', dataset.name, 'only_families'], []):
+            family_sg_data = query_for_family_sequencing_groups(
+                dataset.name,
+                config_retrieve(['workflow', 'sequencing_type']),
+                only_families,
+            )
+            n_sgs = len(family_sg_data['family_sg_ids'])
+            n_families = len(family_sg_data['only_family_ids'])
+            return {
+                'mt': dataset.tmp_prefix()
+                / 'mt'
+                / self.name
+                / f'{get_workflow().output_version}-{dataset.name}-{n_sgs}_sgs-{n_families}_families.mt',
+                'id_file': dataset.tmp_prefix()
+                / f'{get_workflow().output_version}-{dataset.name}-{n_sgs}_sgs-{n_families}_families-SG-ids.txt',
+            }
+        else:
+            return {
+                'mt': dataset.tmp_prefix() / 'mt' / self.name / f'{get_workflow().output_version}-{dataset.name}.mt',
+                'id_file': dataset.tmp_prefix() / f'{get_workflow().output_version}-{dataset.name}-SG-ids.txt',
+            }
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
 
@@ -622,11 +692,21 @@ class SubsetMatrixTableToDatasetUsingHailQuery(DatasetStage):
 
         variant_mt = inputs.as_path(target=get_multicohort(), stage=AnnotateCohortSmallVariantsWithHailQuery)
 
+        if only_families := config_retrieve(['workflow', dataset.name, 'only_families'], []):
+            family_sg_ids = query_for_family_sequencing_groups(
+                dataset.name,
+                config_retrieve(['workflow', 'sequencing_type']),
+                only_families,
+            )['family_sg_ids']
+        else:
+            family_sg_ids = None
+
         # write a list of all the SG IDs to retain
         if not config_retrieve(['workflow', 'dry_run'], False):
             with outputs['id_file'].open('w') as f:
                 for sg in dataset.get_sequencing_groups():
-                    f.write(f'{sg.id}\n')
+                    if not family_sg_ids or sg.id in family_sg_ids:
+                        f.write(f'{sg.id}\n')
 
         job = get_batch().new_job(self.name, self.get_job_attrs(dataset))
         job.image(config_retrieve(['workflow', 'driver_image']))
@@ -652,7 +732,22 @@ class AnnotateDatasetSmallVariantsWithHailQuery(DatasetStage):
         """
         Expected to generate a matrix table
         """
-        return dataset.prefix() / 'mt' / self.name / f'{get_workflow().output_version}-{dataset.name}.mt'
+        if only_families := config_retrieve(['workflow', dataset.name, 'only_families'], []):
+            family_sg_data = query_for_family_sequencing_groups(
+                dataset.name,
+                config_retrieve(['workflow', 'sequencing_type']),
+                only_families,
+            )
+            n_sgs = len(family_sg_data['family_sg_ids'])
+            n_families = len(family_sg_data['only_family_ids'])
+            return (
+                dataset.prefix()
+                / 'mt'
+                / self.name
+                / f'{get_workflow().output_version}-{dataset.name}-{n_sgs}_sgs-{n_families}_families.mt'
+            )
+        else:
+            return dataset.prefix() / 'mt' / self.name / f'{get_workflow().output_version}-{dataset.name}.mt'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
 
@@ -704,7 +799,17 @@ class ExportMtAsEsIndex(DatasetStage):
         Expected to generate a Seqr index, which is not a file
         """
         sequencing_type = config_retrieve(['workflow', 'sequencing_type'])
-        index_name = f'{dataset.name}-{sequencing_type}-{get_workflow().run_timestamp}'.lower()
+        if only_families := config_retrieve(['workflow', dataset.name, 'only_families'], []):
+            family_sg_data = query_for_family_sequencing_groups(
+                dataset.name,
+                config_retrieve(['workflow', 'sequencing_type']),
+                only_families,
+            )
+            n_sgs = len(family_sg_data['family_sg_ids'])
+            n_families = len(family_sg_data['only_family_ids'])
+            index_name = f'{dataset.name}-{sequencing_type}-{n_sgs}_sgs-{n_families}_families-{get_workflow().run_timestamp}'.lower()
+        else:
+            index_name = f'{dataset.name}-{sequencing_type}-{get_workflow().run_timestamp}'.lower()
         return {
             'index_name': index_name,
             'done_flag': dataset.prefix() / 'es' / f'{index_name}.done',

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -169,7 +169,7 @@ def get_family_sequencing_groups(dataset: Dataset) -> dict:
     import hashlib
 
     h = hashlib.sha256(''.join(sorted(family_sg_ids)).encode()).hexdigest()[:4]
-    name_suffix = f'{len(family_sg_ids)}_sgs-{len(only_family_ids)}_families_{h}'
+    name_suffix = f'{len(family_sg_ids)}_sgs-{len(only_family_ids)}_families-{h}'
 
     return {'family_sg_ids': family_sg_ids, 'name_suffix': name_suffix}
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -158,7 +158,7 @@ def get_family_sequencing_groups(dataset: Dataset) -> dict:
     """
     only_family_ids = set(config_retrieve(['workflow', dataset.name, 'only_families'], []))
     # keep only the SG IDs for the families in the only_families list
-    get_logger.info(f'Finding sequencing groups for families {only_family_ids} in dataset {dataset.name}')
+    get_logger().info(f'Finding sequencing groups for families {only_family_ids} in dataset {dataset.name}')
     for sg in dataset.get_sequencing_groups():
         print(sg.id, sg.pedigree.fam_id)
     family_sg_ids = [sg.id for sg in dataset.get_sequencing_groups() if sg.pedigree.fam_id in only_family_ids]

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -159,11 +159,9 @@ def get_family_sequencing_groups(dataset: Dataset) -> dict:
     only_family_ids = set(config_retrieve(['workflow', dataset.name, 'only_families'], []))
     # keep only the SG IDs for the families in the only_families list
     get_logger().info(f'Finding sequencing groups for families {only_family_ids} in dataset {dataset.name}')
-    for sg in dataset.get_sequencing_groups():
-        print(sg.id, sg.pedigree.fam_id)
     family_sg_ids = [sg.id for sg in dataset.get_sequencing_groups() if sg.pedigree.fam_id in only_family_ids]
     if not family_sg_ids:
-        raise ValueError(f'No sequencing groups found for families {only_family_ids} in dataset {dataset.name}. Available sequencing groups: {[sg.id for sg in dataset.get_sequencing_groups()]}')
+        raise ValueError(f'No sequencing groups found for families {only_family_ids} in dataset {dataset.name}.')
     get_logger().info(f'Keeping only {len(family_sg_ids)} SGs from families {len(only_family_ids)} in {dataset}:')
     get_logger().info(only_family_ids)
     get_logger().info(family_sg_ids)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.9',
+    version='1.36.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Add a config option for RD combiner `workflow.dataset.only_families`
  - populate the `only_families` list with the internal ~or external~ IDs of families to keep in the subset
- Find the sequencing groups within this list of families by ~querying metamist for them~ checking each sequencing group's `pedigree.fam_id` attribute
- Write a new matrix table subsetted from the cohort matrix table for just these SGs
- Include this family subsetting logic in the `expected_outputs` for the `SubsetMatrixTableToDatasetUsingHailQuery`, `AnnotateDatasetSmallVariantsWithHailQuery`, and `ExportMtAsEsIndex` stages for consistency
- Also modify the names of the outputs to include the SG count, family count, and SG hash in the output filenames, as a way to differente them from the outputs that include the full dataset (or different family subsets)

Subsetting a cohort mt to a single family from a test dataset: https://batch.hail.populationgenomics.org.au/batches/591428