### PR TITLE
Allow no SV callers to run in singlesample workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.10
+current_version = 1.36.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.10
+  VERSION: 1.36.11
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_single_sample.py
@@ -36,12 +36,12 @@ def get_sv_callers():
     if only_jobs := config_retrieve(['workflow', 'GatherSampleEvidence', 'only_jobs'], None):
         callers = [caller for caller in SV_CALLERS if caller in only_jobs]
         if not callers:
-            raise ValueError('No SV callers enabled')
+            logging.warning('No SV callers enabled')
         return callers
     return SV_CALLERS
 
 
-@stage(analysis_keys=[f'{caller}_vcf' for caller in get_sv_callers()], analysis_type='sv')
+@stage(analysis_keys=[f'{caller}_vcf' for caller in get_sv_callers()] if get_sv_callers() else None, analysis_type='sv')
 class GatherSampleEvidence(SequencingGroupStage):
     """
     https://github.com/broadinstitute/gatk-sv#gathersampleevidence

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.10',
+    version='1.36.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Removes the exception when none of `'manta'`, `'wham'`, or `'scramble'` are in the `workflow.GatherSampleEvidence.only_jobs` config list. This allows us to run the other two subworkflows in isolation, `'coverage_counts'` and `'pesr'`. Several sequencing groups have outputs for the SV callers but are missing outputs for the evidence collection jobs, so this change will allow those outputs to be recovered without running any callers.

In the absence of any caller jobs in the list, the analysis keys in the stage decorator will be set to None in this case because the pesr and coverage counts outputs are not written to analysis records (something that should probably be added in future).