### PR TITLE
Validate sv multisample inputs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.11
+current_version = 1.36.12
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.11
+  VERSION: 1.36.12
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.11',
+    version='1.36.12',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Resolves https://github.com/populationgenomics/production-pipelines/issues/1153

The `gatk_sv_multisample` workflow uses the outputs generated in the `gatk_sv_single_sample` workflow as inputs. 

Since these are two disconnected workflows, the outputs are not explicitly checked for existence as the stages are not explicitly linked.

This adds an explicit path existence check for every input path before the multisample workflow starts. If any inputs are not found, they will be printed in the logs and an error is raised.