### PR TITLE
Add gnomAD V4 annotations

### DIFF
--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -42,6 +42,9 @@ snps_recal_disc_size = 20
 # most recently set to 'a8be268326b2ac168035b629a78465c9d94fc7b9' - 0.2.133 + 400'retry + StreamConstraints patch
 #default_jar_spec_revision = 'a8be268326b2ac168035b629a78465c9d94fc7b9'
 
+# path to an echtvar-encoded gnomAD V4.1 Exome & Genome annotation resource
+echtvar = "gs://cpg-common-main/gnomad/echtvar/gnomad_4.1_region_merged_GRCh38_whole_genome.zip"
+
 [workflow.es_index]
 # if false, use a non-preemptible instance to run the ES export
 spot_instance = false

--- a/cpg_workflows/scripts/annotate_cohort_small_vars.py
+++ b/cpg_workflows/scripts/annotate_cohort_small_vars.py
@@ -171,11 +171,20 @@ def annotate_cohort(
     )
     mt = mt.drop('variant_qc')
 
+    # split the AC/AF attributes into separate entries, overwriting the array in INFO
+    # these elements become a 1-element array for [ALT] instead [REF, ALT]
+    mt = mt.annotate_rows(
+        info=mt.info.annotate(
+            AF=[mt.info.AF[1]],
+            AC=[mt.info.AC[1]],
+        ),
+    )
+
     get_logger().info('Annotating with clinvar and munging annotation fields')
     mt = mt.annotate_rows(
         # still taking just a single value here for downstream compatibility in Seqr
-        AC=mt.info.AC[1],
-        AF=mt.info.AF[1],
+        AC=mt.info.AC[0],
+        AF=mt.info.AF[0],
         AN=mt.info.AN,
         aIndex=mt.a_index,
         wasSplit=mt.was_split,


### PR DESCRIPTION
Uses echtvar to annotate the VQSR whole-genome VCF, adding gnomAD data
pulls that out into the MatrixTable

In its current form this would break things - we don't VSQR-analyse any long read data, so these fields wouldn't be available to extract. Another reason we should disentangle those two pipelines

relevant https://github.com/populationgenomics/images/pull/195