### PR TITLE
Subset annotate sv vcf by dataset

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.13
+current_version = 1.36.14
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.13
+  VERSION: 1.36.14
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -29,7 +29,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
 )
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.targets import Cohort, Dataset, MultiCohort
-from cpg_workflows.utils import get_logger
+from cpg_workflows.utils import get_logger, ExpectedResultT
 from cpg_workflows.workflow import (
     CohortStage,
     DatasetStage,
@@ -38,7 +38,7 @@ from cpg_workflows.workflow import (
     StageOutput,
     get_multicohort,
     get_workflow,
-    stage,
+    stage, TargetT, Action,
 )
 from metamist.graphql import gql, query
 
@@ -1417,3 +1417,17 @@ class MtToEsSv(DatasetStage):
         job.command(f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {index_name} --flag {flag_name}')
 
         return self.make_outputs(dataset, data=outputs['index_name'], jobs=job)
+
+
+@stage(required_stages=SpiceUpSVIDs)
+class SplitAnnotatedVcfByDataset(DatasetStage):
+    """
+    takes the whole MultiCohort annotated VCF
+    splits it up into separate VCFs for each dataset
+    """
+    def expected_outputs(self, dataset: Dataset) -> Path:
+        return dataset.prefix() / 'annotated_sv.vcf.bgz'
+
+    def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
+
+        ...

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -29,7 +29,7 @@ from cpg_workflows.stages.gatk_sv.gatk_sv_common import (
 )
 from cpg_workflows.stages.seqr_loader import es_password
 from cpg_workflows.targets import Cohort, Dataset, MultiCohort
-from cpg_workflows.utils import get_logger, ExpectedResultT
+from cpg_workflows.utils import get_logger
 from cpg_workflows.workflow import (
     CohortStage,
     DatasetStage,
@@ -38,7 +38,7 @@ from cpg_workflows.workflow import (
     StageOutput,
     get_multicohort,
     get_workflow,
-    stage, TargetT, Action,
+    stage,
 )
 from metamist.graphql import gql, query
 
@@ -1422,6 +1422,7 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
     takes the whole MultiCohort annotated VCF
     splits it up into separate VCFs for each dataset
     """
+
     def expected_outputs(self, dataset: Dataset) -> Path:
         return dataset.prefix() / 'annotated_sv.vcf.bgz'
 
@@ -1437,7 +1438,7 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
                     f.write(f'{sgid}\n')
         job = get_batch().new_job(
             name=f'SplitAnnotatedSvVcfByDataset: {dataset}',
-            attributes=self.get_job_attrs() | {'tool': 'bcftools'}
+            attributes=self.get_job_attrs() | {'tool': 'bcftools'},
         )
         job.image(image_path('bctools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -580,12 +580,8 @@ class AnnotateCNV(MultiCohortStage):
 
 @stage(required_stages=AnnotateCNV, analysis_type='cnv', analysis_keys=['strvctvre_vcf'])
 class AnnotateCNVVcfWithStrvctvre(MultiCohortStage):
-    def expected_outputs(self, multicohort: MultiCohort) -> dict[str, Path]:
-        prefix = self.prefix
-        return {
-            'strvctvre_vcf': prefix / 'cnv_strvctvre_annotated.vcf.bgz',
-            'strvctvre_vcf_index': prefix / 'cnv_strvctvre_annotated.vcf.bgz.tbi',
-        }
+    def expected_outputs(self, multicohort: MultiCohort) -> Path:
+        return self.prefix / 'cnv_strvctvre_annotated.vcf.bgz'
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
         strv_job = get_batch().new_job('StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'})
@@ -617,7 +613,7 @@ class AnnotateCNVVcfWithStrvctvre(MultiCohortStage):
 
         get_batch().write_output(
             strv_job.output_vcf,
-            str(expected_d['strvctvre_vcf']).replace('.vcf.bgz', ''),
+            str(expected_d).replace('.vcf.bgz', ''),
         )
         return self.make_outputs(multicohort, data=expected_d, jobs=strv_job)
 
@@ -636,7 +632,7 @@ class AnnotateCohortgCNV(MultiCohortStage):
         Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
         """
 
-        vcf_path = str(inputs.as_path(target=multicohort, stage=AnnotateCNVVcfWithStrvctvre, key='strvctvre_vcf'))
+        vcf_path = str(inputs.as_path(target=multicohort, stage=AnnotateCNVVcfWithStrvctvre))
         outputs = self.expected_outputs(multicohort)
 
         j = get_batch().new_job('annotate gCNV cohort', self.get_job_attrs(multicohort))
@@ -759,3 +755,38 @@ class MtToEsCNV(DatasetStage):
         job.command(f'mt_to_es --mt_path "${{BATCH_TMPDIR}}/{mt_name}" --index {index_name} --flag {flag_name}')
 
         return self.make_outputs(dataset, data=outputs, jobs=job)
+
+
+@stage(required_stages=AnnotateCNVVcfWithStrvctvre, analysis_type='single_dataset_cnv_annotated')
+class SplitAnnotatedCnvVcfByDataset(DatasetStage):
+    """
+    takes the whole MultiCohort annotated VCF
+    splits it up into separate VCFs for each dataset
+    """
+
+    def expected_outputs(self, dataset: Dataset) -> Path:
+        return dataset.prefix() / 'annotated_sv.vcf.bgz'
+
+    def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
+        output = self.expected_outputs(dataset)
+        input_vcf = get_batch().read_input(inputs.as_path(get_multicohort(), AnnotateCNVVcfWithStrvctvre))
+
+        # write a temp file for this dataset containing all relevant SGs
+        sgids_list_path = dataset.tmp_prefix() / get_workflow().output_version / 'sgid-list.txt'
+        if not config_retrieve(['workflow', 'dry_run'], False):
+            with sgids_list_path.open('w') as f:
+                for sgid in dataset.get_sequencing_group_ids():
+                    f.write(f'{sgid}\n')
+
+        job = get_batch().new_job(
+            name=f'SplitAnnotatedCnvVcfByDataset: {dataset}',
+            attributes=self.get_job_attrs() | {'tool': 'bcftools'}
+        )
+        job.image(image_path('bctools_120'))
+        job.cpu(1).memory('highmem').storage('10Gi')
+        job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
+        job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+
+        get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
+
+        return self.make_outputs(dataset, data=output, jobs=job)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -780,7 +780,7 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
 
         job = get_batch().new_job(
             name=f'SplitAnnotatedCnvVcfByDataset: {dataset}',
-            attributes=self.get_job_attrs() | {'tool': 'bcftools'}
+            attributes=self.get_job_attrs() | {'tool': 'bcftools'},
         )
         job.image(image_path('bctools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')

--- a/main.py
+++ b/main.py
@@ -17,7 +17,12 @@ from cpg_workflows.stages.cram_qc import CramMultiQC
 from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults
 from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.fraser import Fraser
-from cpg_workflows.stages.gatk_sv.gatk_sv_multisample import FilterBatch, GenotypeBatch, MtToEsSv, SplitAnnotatedSvVcfByDataset
+from cpg_workflows.stages.gatk_sv.gatk_sv_multisample import (
+    FilterBatch,
+    GenotypeBatch,
+    MtToEsSv,
+    SplitAnnotatedSvVcfByDataset,
+)
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
 from cpg_workflows.stages.gcnv import AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV, SplitAnnotatedCnvVcfByDataset
 from cpg_workflows.stages.gvcf_qc import GvcfMultiQC

--- a/main.py
+++ b/main.py
@@ -17,9 +17,9 @@ from cpg_workflows.stages.cram_qc import CramMultiQC
 from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults
 from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.fraser import Fraser
-from cpg_workflows.stages.gatk_sv.gatk_sv_multisample import FilterBatch, GenotypeBatch, MtToEsSv
+from cpg_workflows.stages.gatk_sv.gatk_sv_multisample import FilterBatch, GenotypeBatch, MtToEsSv, SplitAnnotatedSvVcfByDataset
 from cpg_workflows.stages.gatk_sv.gatk_sv_single_sample import CreateSampleBatches
-from cpg_workflows.stages.gcnv import AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV
+from cpg_workflows.stages.gcnv import AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV, SplitAnnotatedCnvVcfByDataset
 from cpg_workflows.stages.gvcf_qc import GvcfMultiQC
 from cpg_workflows.stages.happy_validation import ValidationHappyOnVcf, ValidationMtToVcf
 from cpg_workflows.stages.large_cohort import AncestryPlots, Frequencies, LoadVqsr
@@ -83,9 +83,9 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
     'validation': [ValidationMtToVcf, ValidationHappyOnVcf],
     'large_cohort': [LoadVqsr, Frequencies, AncestryPlots, GvcfMultiQC, CramMultiQC],
     'gatk_sv_singlesample': [CreateSampleBatches],
-    'gatk_sv_multisample': [FilterBatch, GenotypeBatch, MtToEsSv],
+    'gatk_sv_multisample': [FilterBatch, GenotypeBatch, MtToEsSv, SplitAnnotatedSvVcfByDataset],
     'rare_disease_rnaseq': [Outrider, Fraser],
-    'gcnv': [AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV],
+    'gcnv': [AnnotateCohortgCNV, AnnotateDatasetCNV, MtToEsCNV, SplitAnnotatedCnvVcfByDataset],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.13',
+    version='1.36.14',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Recently Talos swapped to reading the SVAnnotate VCF directly, instead of using the per-dataset result of the SV/CNV equivalent of AnnotateDataset. A side effect here was that the annotated VCFs are never subdivided by cohort, and their analysis entries are stored in metamist under the Seqr project. Talos operates per-dataset, and has previously queried metamist for the SV MT in the specific dataset.

The choice was between:
- query for latest annotated VCF in the **seqr** project, reading in the whole VCF, then selecting only the samples relevant to _this_ analysis. This would work, but would involve reading in the data from multiple projects, and subsetting down to the data each project should be allowed to see.
- adding a new terminal stage in the CNV/SV pipelines which selects only the single-dataset samples from the whole callset, and saves a new VCF

The latter seems like a more responsible choice