### PR TITLE
Gatk sv multisample disable qc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.14
+current_version = 1.36.15
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.14
+  VERSION: 1.36.15
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -769,11 +769,14 @@ class MakeCohortVcf(MultiCohortStage):
 
     def expected_outputs(self, multicohort: MultiCohort) -> dict:
         """create output paths"""
-        return {
+        outputs = {
             'vcf': self.prefix / 'cleaned.vcf.gz',
             'vcf_index': self.prefix / 'cleaned.vcf.gz.tbi',
-            'vcf_qc': self.prefix / 'cleaned_SV_VCF_QC_output.tar.gz',
         }
+        if config_retrieve(['MakeCohortVcf', 'MainVcfQc', 'do_per_sample_qc'], False):
+            outputs |= {'vcf_qc': self.prefix / 'cleaned_SV_VCF_QC_output.tar.gz'}
+
+        return outputs
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput:
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.14',
+    version='1.36.15',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a new default config which will prevent the various QC plotting subworkflows from running during the MakeCohortVcf stage. These plots are unused so there's no need to run them.