### PR TITLE
Split out reqs into a requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
-COPY requirements.txt README.md setup.py .
+COPY requirements.txt README.md .
 RUN pip install --no-cache-dir -r  requirements.txt
 
+COPY setup.py .
 COPY cpg_workflows cpg_workflows
 COPY seqr-loading-pipelines/hail_scripts hail_scripts
 COPY gnomad_methods/gnomad gnomad

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
-ADD requirements.txt .
+COPY requirements.txt README.md setup.py .
 RUN pip install --no-cache-dir -r  requirements.txt
 
-COPY README.md setup.py .
 COPY cpg_workflows cpg_workflows
 COPY seqr-loading-pipelines/hail_scripts hail_scripts
 COPY gnomad_methods/gnomad gnomad

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
-RUN pip install metamist
-COPY README.md .
-COPY setup.py .
+ADD requirements.txt .
+RUN pip install --no-cache-dir -r  requirements.txt
+
+COPY README.md setup.py .
 COPY cpg_workflows cpg_workflows
 COPY seqr-loading-pipelines/hail_scripts hail_scripts
 COPY gnomad_methods/gnomad gnomad
-RUN pip install .
+RUN pip install --no-cache-dir .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,25 @@
+cpg-utils>=5.1.1
+cyvcf2==0.30.18
+analysis-runner>=2.43.3
+# Pin Hail at CPGs installed version
+hail==0.2.134
+networkx>=2.8.3
+# Avoid dependency resolution backtracking
+grpcio-status>=1.48,<1.50
+onnx
+onnxruntime
+skl2onnx
+metamist>=6.9.0
+pandas
+# Avoid 0.4.7 which is incompatible
+peddy>=0.4.8
+pyfaidx>=0.8.1.1
+fsspec
+slack_sdk
+elasticsearch==8.*
+coloredlogs
+bokeh
+numpy
+click
+tenacity
+toml

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'cpg-utils>=5.1.1',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
-        'hail==0.2.133',  # Pin Hail at CPG's installed version
+        'hail==0.2.134',  # Pin Hail at CPG's installed version
         'networkx>=2.8.3',
         'obonet>=0.3.1',  # for HPO parsing
         'grpcio-status>=1.48,<1.50',  # Avoid dependency resolution backtracking


### PR DESCRIPTION
Issue: cpg_workflows as a package has its dependencies exclusively in the setup.py file, so installing the dependencies can't be split off from installing the package.

This means the final layer of the docker build is installing code, scripts, and dependencies, and any cache is voided because the content inside cpg_workflows is changed.

This suggestion takes the requirements in the setup.py file and splits them out into a `requirements.txt` file. 

The Dockerfile installs all dependencies prior to copying in source code, so the pip installation can be reused from prior builds, hopefully reducing build time.

It also swaps the pip installs down to non-cache installations, which should remove a teeny bit of bulk.

--- 

I think there's a proper discussion to be had about how to package code better. 

UV has a `--no-install-project` option which could be useful here, but we're not ready for a UV conversation. 

I'm not sure on conventions for what should go in a setup.py vs. a requirements file.

The more modern approach is moving everything into a pyproject.toml rather than a setup.py??

Many options.