### PR TITLE
Fix Talos-prep

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1443,7 +1443,7 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
             name=f'SplitAnnotatedSvVcfByDataset: {dataset}',
             attributes=self.get_job_attrs() | {'tool': 'bcftools'},
         )
-        job.image(image_path('bctools_120'))
+        job.image(image_path('bcftools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -782,7 +782,7 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
             name=f'SplitAnnotatedCnvVcfByDataset: {dataset}',
             attributes=self.get_job_attrs() | {'tool': 'bcftools'},
         )
-        job.image(image_path('bctools_120'))
+        job.image(image_path('bcftools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -60,15 +60,16 @@ def does_final_file_path_exist(dataset: Dataset) -> bool:
     exists. In that scenario I just want no jobs to be planned.
 
     This method builds the path to the final object, and checks if it exists in GCP
-    If it does, we can skip all other
+    If it does, we can skip all other stages
 
     Args:
-        dataset ():
+        dataset (Dataset):
 
     Returns:
-
+        bool, whether the final file in the workflow already exists
     """
-    path = get_workflow().prefix / SquashMtIntoTarball.name / f'{dataset.name}.mt.tar'
+    # if the name of the SquashMtIntoTarball Stage changes, update this String
+    path = get_workflow().prefix / 'SquashMtIntoTarball' / f'{dataset.name}.mt.tar'
     return exists(path)
 
 


### PR DESCRIPTION
Tried to be smart, shouldn't have done that.

I put in a method that recreates the path to the final output of the Stage, then checks if it exists - if it does, prevent every stage in the workflow which writes to tmp from creating jobs. If this works that same approach would also be useful in the rd_combiner/VQSR stages.

However... you can't call XXX.name on an abstract class definition. The final Stage is called `SquashMtIntoTarball`, and you can't do `SquashMtIntoTarball.name` because the class hasn't been instantiated yet.

I could do `SquashMtIntoTarball().name` to make an instance and get its name, but in a worst case scenario (when a workflow isn't already set up), cpg_workflows will run off and make an entire workflow instance, including Metamist queries, to tell me what the name of this Stage is. So... no.


Also fixes a horrendous copy-paste error where I mis-spelt `bcftools_120`, so stages were failing to look up images in the image dictionary.