### PR TITLE
Localise the SGID file being passed to BCFtools

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1446,7 +1446,9 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
         job.image(image_path('bcftools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-        job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+
+        local_sgid_file = get_batch().read_input(sgids_list_path)
+        job.command(f'bcftools view {input_vcf} -S {local_sgid_file} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
 
         get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -785,7 +785,9 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
         job.image(image_path('bcftools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-        job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+
+        local_sgid_file = get_batch().read_input(sgids_list_path)
+        job.command(f'bcftools view {input_vcf} -S {local_sgid_file} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
 
         get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
 


### PR DESCRIPTION
The file containing SG IDs for bcftools subsetting must be localised to be read