### PR TITLE
Use new config section in talos

### DIFF
--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1446,7 +1446,9 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
         job.image(image_path('bcftools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-        job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+
+        local_sgid_file = get_batch().read_input(sgids_list_path)
+        job.command(f'bcftools view {input_vcf} -S {local_sgid_file} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
 
         get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -785,7 +785,9 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
         job.image(image_path('bcftools_120'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-        job.command(f'bcftools view {input_vcf} -S {sgids_list_path} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+
+        local_sgid_file = get_batch().read_input(sgids_list_path)
+        job.command(f'bcftools view {input_vcf} -S {local_sgid_file} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
 
         get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
 

--- a/cpg_workflows/stages/talos.py
+++ b/cpg_workflows/stages/talos.py
@@ -278,11 +278,10 @@ class MakeRuntimeConfig(DatasetStage):
         # optionally, all SG IDs to remove from analysis
         new_config['ValidateMOI']['solved_cases'] = dataset_conf.get('solved_cases', [])
 
-        # these attributes are present, or missing completely
-        if all(x in seq_type_conf for x in SEQR_KEYS):
-            for key in SEQR_KEYS:
-                if key in seq_type_conf:
-                    new_config['CreateTalosHTML'][key] = seq_type_conf[key]
+        # adapt to new hyperlink config structure
+        if hyperlinks := seq_type_conf.get('hyperlinks'):
+            new_config['CreateTalosHTML']['hyperlinks'] = hyperlinks
+
         if 'external_labels' in seq_type_conf:
             new_config['CreateTalosHTML']['external_labels'] = seq_type_conf['external_labels']
 


### PR DESCRIPTION
Talos has a flexible hyperlink generation functionality, prod-pipes needs to use it, moving away from the previous method which only copied relevant `seqr` keys