### PR TITLE
Fix flaky Compress into batch tmp Stage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.16
+current_version = 1.36.17
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.16
+  VERSION: 1.36.17
 
 jobs:
   docker:

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -382,7 +382,7 @@ class SquashMtIntoTarball(DatasetStage):
         job.command(f'gcloud --no-user-output-enabled storage cp --do-not-decompress -r {mt} $BATCH_TMPDIR')
 
         # once the data is copied - cd into the tmpdir, then tar it up
-        job.command(f'cd $BATCH_TMPDIR')
+        job.command('cd $BATCH_TMPDIR')
         # no compression - the Hail objects are all internally gzipped so not much to gain there
         job.command(f'tar --remove-files -cf {job.output} {dataset.name}.mt')
 

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -320,7 +320,7 @@ class JumpAnnotationsFromHtToFinalMt(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return self.tmp_prefix / f'{dataset.name}_talos_ready.mt'
+        return self.tmp_prefix / f'{dataset.name}.mt'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
 
@@ -377,14 +377,12 @@ class SquashMtIntoTarball(DatasetStage):
 
         # get the annotated MatrixTable - needs to be localised by copy, Hail Batch's service backend can't write local
         mt = str(inputs.as_path(dataset, JumpAnnotationsFromHtToFinalMt))
-        mt_name = mt.split('/')[-1]
 
         # copy the MT into the image, bundle it into a Tar-Ball
         job.command(f'gcloud --no-user-output-enabled storage cp --do-not-decompress -r {mt} $BATCH_TMPDIR')
 
         # once the data is copied - cd into the tmpdir before changing the filename with a mv, then tar it up
         job.command(f'cd $BATCH_TMPDIR')
-        job.command(f'mv {mt_name} {dataset.name}.mt')
         # no compression - the Hail objects are all internally gzipped so not much to gain there
         job.command(f'tar --remove-files -cf {job.output} {dataset.name}.mt')
 

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -381,7 +381,7 @@ class SquashMtIntoTarball(DatasetStage):
         # copy the MT into the image, bundle it into a Tar-Ball
         job.command(f'gcloud --no-user-output-enabled storage cp --do-not-decompress -r {mt} $BATCH_TMPDIR')
 
-        # once the data is copied - cd into the tmpdir before changing the filename with a mv, then tar it up
+        # once the data is copied - cd into the tmpdir, then tar it up
         job.command(f'cd $BATCH_TMPDIR')
         # no compression - the Hail objects are all internally gzipped so not much to gain there
         job.command(f'tar --remove-files -cf {job.output} {dataset.name}.mt')

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -381,7 +381,10 @@ class SquashMtIntoTarball(DatasetStage):
 
         # copy the MT into the image, bundle it into a Tar-Ball
         job.command(f'gcloud --no-user-output-enabled storage cp --do-not-decompress -r {mt} $BATCH_TMPDIR')
-        job.command(f'mv $BATCH_TMPDIR/{mt_name} {dataset.name}.mt')
+
+        # once the data is copied - cd into the tmpdir before changing the filename with a mv, then tar it up
+        job.command(f'cd $BATCH_TMPDIR')
+        job.command(f'mv {mt_name} {dataset.name}.mt')
         # no compression - the Hail objects are all internally gzipped so not much to gain there
         job.command(f'tar --remove-files -cf {job.output} {dataset.name}.mt')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.16',
+    version='1.36.17',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Sometimes this works, most of the time it doesn't, e.g. https://batch.hail.populationgenomics.org.au/batches/593251/jobs/1

I was downloading the data into BATCH_TMPDIR (which works fine), then using `mv` to rename the downloaded files. This `mv` is causing the data to be transferred into the job's local storage instead of the allocated storage. 

---

Instead of this dodgy approach I'm changing the MT name upstream, so the MT doesn't need to be `mv'd` at all, then changing directory into the batch tmp instead of moving the downloaded data. 