### PR TITLE
More flexible sample subset extraction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.17
+current_version = 1.36.18
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.17
+  VERSION: 1.36.18
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1448,7 +1448,13 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
 
         local_sgid_file = get_batch().read_input(sgids_list_path)
-        job.command(f'bcftools view {input_vcf} -S {local_sgid_file} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+        job.command(
+            f'bcftools view {input_vcf} '
+            f'--force-samples '
+            f'-S {local_sgid_file} '
+            f'-Oz -o {job.output["vcf.bgz"]} '
+            f'--write-index=tbi',
+        )
 
         get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -787,7 +787,13 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
 
         local_sgid_file = get_batch().read_input(sgids_list_path)
-        job.command(f'bcftools view {input_vcf} -S {local_sgid_file} -Oz -o {job.output["vcf.bgz"]} --write-index=tbi')
+        job.command(
+            f'bcftools view {input_vcf} '
+            f'--force-samples '
+            f'-S {local_sgid_file} '
+            f'-Oz -o {job.output["vcf.bgz"]} '
+            f'--write-index=tbi',
+        )
 
         get_batch().write_output(job.output, str(output).removesuffix('.vcf.bgz'))
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -669,10 +669,11 @@ class SubsetMatrixTableToDatasetUsingHailQuery(DatasetStage):
             family_sg_ids = None
 
         # write a list of all the SG IDs to retain
+        # don't try and extract samples which didn't have a gVCF
         if not config_retrieve(['workflow', 'dry_run'], False):
             with outputs['id_file'].open('w') as f:
                 for sg in dataset.get_sequencing_groups():
-                    if (family_sg_ids is None) or sg.id in family_sg_ids:
+                    if ((family_sg_ids is None) or sg.id in family_sg_ids) and (sg.gvcf is not None):
                         f.write(f'{sg.id}\n')
 
         job = get_batch().new_job(self.name, self.get_job_attrs(dataset))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.17',
+    version='1.36.18',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In SV and CNV calling there's a possibility that samples in the cohort won't make it into the final callset due to quality filtering.

The issue here is that when generating a sample-specific subset, bcftools needs the `--force-samples` flag set to warn instead of fail when samples are missing.

For the small-variant combiner workflow, something similar - we don't combine samples without a gVCF, but they may end up in the cohorts. When their gVCFs are generated, they will be combined. Here the sample subsetting needs to only apply to samples which have gVCFs, so that we don't try and extract absent samples during subsetting