### PR TITLE
A truly spectacular error

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.19
+current_version = 1.36.20
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.19
+  VERSION: 1.36.20
 
 jobs:
   docker:

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -157,7 +157,7 @@ class ConcatenateSitesOnlyVcfFragments(DatasetStage):
 
         jobs = gcloud_compose_vcf_from_manifest(
             manifest_path=sites_manifest,
-            intermediates_path=str(self.prefix / dataset.name / 'sites_temporary_compose_intermediates'),
+            intermediates_path=str(self.tmp_prefix / dataset.name / 'sites_temporary_compose_intermediates'),
             output_path=str(output),
             job_attrs={'stage': self.name},
             final_size='10Gi',

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -157,7 +157,7 @@ class ConcatenateSitesOnlyVcfFragments(DatasetStage):
 
         jobs = gcloud_compose_vcf_from_manifest(
             manifest_path=sites_manifest,
-            intermediates_path=str(self.tmp_prefix / 'sites_temporary_compose_intermediates'),
+            intermediates_path=str(self.prefix / dataset.name / 'sites_temporary_compose_intermediates'),
             output_path=str(output),
             job_attrs={'stage': self.name},
             final_size='10Gi',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.19',
+    version='1.36.20',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
To preface this PR: The Talos_prep workflow is grand, and it works perfectly with Talos. Previously I built talos_prep from cohort stages, and ran them one cohort at a time. That was a tragic amount of micromanagement, so it's been swapped to dataset stages. That also works fine when it's run one at a time.

However... Today I tried to multiplex a ton of runs together for the first time, chaos ensued. 

Benchmarking the latest Talos results for Acute-Care genomes it found basically none of the expected results.

After a lot of panicked clicking around I discovered that the VCF being extracted and annotated during a good workflow (e.g. [here](https://batch.hail.populationgenomics.org.au/batches/592271)) should have been around 1.6GB prior to annotations, and 6GB after.

The VCF I was getting in the latest run was about 80MB to start off with, rising to 400MB with annotations... (e.g [here](https://batch.hail.populationgenomics.org.au/batches/593127/jobs/53)) Most variants were missing...

I've tracked the issue to the temporary path in the `ConcatenateSitesOnlyVcfFragments` Stage. This process takes fragments of the VCF and does a rolling merge, eventually forming a single VCF. This happens in blocks of 32 VCF fragments (a gcloud limitation), writing intermediates to a generic name like `gs://cpg-seqr-main-tmp/talos_prep/8c874ea4d21293f4bebeb9c1ab5201f831ffeb_3079/ConcatenateSitesOnlyVcfFragments/sites_temporary_compose_intermediates/temp_chunk_2/chunk_1.vcf.bgz`

THE ISSUE!

Every separate dataset was writing to the same location. This strategy works fine for the RD_Combiner which happens once per MultiCohort, but breaks here where 20 runs in parallel write the same temporary filenames to the same directory. 

This change makes sure each set of temp files is written completely in parallel. 