### PR TITLE
Ensure parallel prep writes throughout Talos_prep

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.20
+current_version = 1.36.21
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.20
+  VERSION: 1.36.21
 
 jobs:
   docker:

--- a/configs/defaults/talos.toml
+++ b/configs/defaults/talos.toml
@@ -74,11 +74,7 @@ small_variants = 'highmem'
 
 [RunHailFiltering.storage]
 sv = 10
-
-[RunHailFiltering.timeouts]
-# timeouts for the Hail Batch jobs, cancels the job if it hangs
-small_variants = 15000
-sv = 3600
+small_variants = 50
 
 [categories]
 1 = 'ClinVar Pathogenic'

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -173,7 +173,7 @@ class AnnotateGnomadFrequenciesWithEchtvar(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return self.tmp_prefix / 'gnomad_frequency_annotated.vcf.bgz'
+        return self.tmp_prefix / f'{dataset.name}_gnomad_frequency_annotated.vcf.bgz'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         outputs = self.expected_outputs(dataset)
@@ -207,7 +207,7 @@ class AnnotateConsequenceWithBcftools(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return self.tmp_prefix / 'consequence_annotated.vcf.bgz'
+        return self.tmp_prefix / f'{dataset.name}_consequence_annotated.vcf.bgz'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         output = self.expected_outputs(dataset)
@@ -306,7 +306,7 @@ class ProcessAnnotatedSitesOnlyVcfIntoHt(DatasetStage):
             f'--gene_bed {gene_roi} '
             f'--am {alphamissense} '
             f'--mane {mane_json} '
-            f'--checkpoint_dir {str(self.tmp_prefix / "annotation_checkpoint")} ',
+            f'--checkpoint_dir {str(self.tmp_prefix / f"{dataset.name}_annotation_checkpoint")} ',
         )
 
         return self.make_outputs(dataset, data=output, jobs=job)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.20',
+    version='1.36.21',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Another few instances of separate projects writing to the same location in the talos_prep workflow. Pretty embarrassing one. None of the mangled data affected by this bug has carried through to reports - the vcfs were all truncated causing subsequent stages to fail.

This covers all problem writes - every instance of `prefix` in the workflow is accompanied by a dataset.name, either in the path or filename