### PR TITLE
Register reheadered nagim crams

### DIFF
--- a/scripts/register_reheadered_nagim_crams.py
+++ b/scripts/register_reheadered_nagim_crams.py
@@ -122,14 +122,12 @@ def main(
     gcs_prefix: str,
     dry_run: bool,
 ):
-    # config = get_config(True)
+    config = get_config(True)
 
-    # dataset = config['workflow']['dataset']
-    # if config['workflow']['access_level'] == 'test' and not dataset.endswith('-test'):
-    #     dataset = f'{dataset}-test'
+    dataset = config['workflow']['dataset']
+    if config['workflow']['access_level'] == 'test' and not dataset.endswith('-test'):
+        dataset = f'{dataset}-test'
     coloredlogs.install(level=logging.INFO)
-
-    dataset = 'tob-wgs-test'
 
     project_analyses = query(FIND_ANALYSES, {'project': dataset})['project']['analyses']
     analysis_by_path = {analysis['output']: analysis for analysis in project_analyses if 'nagim' in analysis['output']}

--- a/scripts/register_reheadered_nagim_crams.py
+++ b/scripts/register_reheadered_nagim_crams.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+"""
+Register reheadered NAGIM CRAM files into Metamist
+
+Typical usage:
+
+analysis-runner ... scripts/register_reheadered_nagim_crams.py
+  --gcs-prefix gs://.../reheadered/
+  --dry-run (optional)
+"""
+
+import datetime
+import logging
+import subprocess
+from typing import Any
+
+import click
+import coloredlogs
+
+from cpg_utils import to_path
+from cpg_utils.config import get_config
+from metamist import models
+from metamist.apis import AnalysisApi
+from metamist.graphql import gql, query
+
+FIND_ANALYSES = gql(
+    """
+query AnalysesQuery($project: String!) {
+  project(name: $project) {
+    analyses(type: {eq: "cram"}, active: {eq: true}) {
+      id
+      meta
+      output
+      sequencingGroups {
+        sample {
+          id
+        }
+        id
+      }
+      status
+      type
+    }
+  }
+}
+""",
+)
+
+FIND_SAMPLES = gql(
+    """
+query SamplesQuery($project: String!) {
+  project(name: $project) {
+    samples {
+      id
+      sequencingGroups {
+        id
+        analyses(type: {eq: "cram"}, active: {eq: true}) {
+          id
+          output
+          status
+        }
+      }
+    }
+  }
+}
+""",
+)
+
+MUTATION_QUERY = gql(
+    """
+    mutation MyMutation($Content: String!, $Id: String!) {
+      sequencingGroup {
+        addComment(content: $Content, id: $Id) {
+          content
+          id
+        }
+      }
+    }
+    """,
+)
+
+
+# Precomputed hashes (as per classify_SQ()) for common reference sets
+KNOWN_REFS = {
+    '49f7a7583b832aed0104b1901f9cf5fd': 'Homo_sapiens_assembly38_masked',
+    '760a471d32c9a356ffb37f632bebfea3': 'Homo_sapiens_assembly38[unmasked]',
+}
+
+
+def do_metamist_update(
+    dry_run: bool,
+    dataset: str,
+    activeseqgroup: str,
+    oldanalysis: dict[str, Any],
+    oldpath: str,
+    newpath: str,
+):
+    aapi = AnalysisApi()
+
+    newmeta: dict[str, str] = oldanalysis['meta']
+    newmeta['source'] = f'Reheadered NAGIM from {oldpath}'
+
+    newanalysis = models.Analysis(
+        type=oldanalysis['type'],
+        status=models.AnalysisStatus(oldanalysis['status'].lower()),
+        output=str(newpath),
+        sequencing_group_ids=[activeseqgroup],
+        meta=newmeta,
+    )
+    if dry_run:
+        logging.info('Going to register the following new analysis:')
+        logging.info(f'{newanalysis}')
+        logging.info(f'Will add the following comment to the sequencing group: {activeseqgroup}:')
+        logging.info(
+            f'The reheadered NAGIM CRAM {newpath} has been registered as the latest analysis on {datetime.datetime.today()}, replacing the older Dragmap CRAM. A new Dragen 3_7_8 CRAM will replace this at a later date.',
+        )
+    else:
+        aid = aapi.create_analysis(dataset, newanalysis)
+        logging.info(f'Created Analysis(id={aid}, output={newpath}) in {dataset}')
+
+        reheadered_comment = f'The reheadered NAGIM CRAM {newpath} has been registered as the latest analysis on {datetime.datetime.today()}, replacing the older Dragmap CRAM. A new Dragen 3_7_8 CRAM will replace this at a later date.'
+        mutation_result = query(MUTATION_QUERY, variables={'Content': reheadered_comment, 'Id': activeseqgroup})
+
+
+@click.command()
+@click.option('--gcs-prefix', help='Prefix in GCP to the files to be registered.')
+@click.option('--dry-run', is_flag=True, help='Display information only without making changes')
+def main(
+    gcs_prefix: str,
+    dry_run: bool,
+):
+    config = get_config(True)
+
+    dataset = config['workflow']['dataset']
+    if config['workflow']['access_level'] == 'test' and not dataset.endswith('-test'):
+        dataset = f'{dataset}-test'
+    coloredlogs.install(level=logging.INFO)
+
+    project_analyses = query(FIND_ANALYSES, {'project': dataset})['project']['analyses']
+    analysis_by_path = {analysis['output']: analysis for analysis in project_analyses if 'nagim' in analysis['output']}
+    project_samples = query(FIND_SAMPLES, {'project': dataset})['project']['samples']
+    sample_by_id = {sample['id']: sample['sequencingGroups'][0]['id'] for sample in project_samples}
+
+    cram_list = analysis_by_path.keys()
+
+    flist = (
+        subprocess.run(['gcloud', 'storage', 'ls', f'{gcs_prefix}*.cram'], capture_output=True)
+        .stdout.decode(
+            'utf-8',
+        )
+        .strip()
+        .split('\n')
+    )
+
+    logging.info(f'Total reheadered NAGIM CRAM file entries found: {len(cram_list)}')
+
+    for fname in cram_list:
+        path = to_path(fname)
+        reheadered_path = path.parent / 'reheadered' / path.name
+        if str(reheadered_path) not in flist:
+            continue
+        real_sequnging_group: str = sample_by_id[analysis_by_path[fname]['sequencingGroups'][0]['sample']['id']]
+        do_metamist_update(
+            dry_run=dry_run,
+            dataset=dataset,
+            activeseqgroup=real_sequnging_group,
+            oldanalysis=analysis_by_path[fname],
+            oldpath=fname,
+            newpath=str(reheadered_path),
+        )
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter  # click will add the arguments

--- a/scripts/register_reheadered_nagim_crams.py
+++ b/scripts/register_reheadered_nagim_crams.py
@@ -153,14 +153,14 @@ def main(
         if str(reheadered_path) not in flist:
             continue
         try:
-            real_sequnging_group: str = sample_by_id[analysis_by_path[fname]['sequencingGroups'][0]['sample']['id']]
+            real_sequncing_group: str = sample_by_id[analysis_by_path[fname]['sequencingGroups'][0]['sample']['id']]
         except KeyError:
             logging.info(f'The sample {analysis_by_path[fname]["sequencingGroups"][0]["sample"]["id"]} is not active.')
             continue
         do_metamist_update(
             dry_run=dry_run,
             dataset=dataset,
-            activeseqgroup=real_sequnging_group,
+            activeseqgroup=real_sequncing_group,
             oldanalysis=analysis_by_path[fname],
             oldpath=fname,
             newpath=str(reheadered_path),

--- a/scripts/register_reheadered_nagim_crams.py
+++ b/scripts/register_reheadered_nagim_crams.py
@@ -80,13 +80,6 @@ MUTATION_QUERY = gql(
 )
 
 
-# Precomputed hashes (as per classify_SQ()) for common reference sets
-KNOWN_REFS = {
-    '49f7a7583b832aed0104b1901f9cf5fd': 'Homo_sapiens_assembly38_masked',
-    '760a471d32c9a356ffb37f632bebfea3': 'Homo_sapiens_assembly38[unmasked]',
-}
-
-
 def do_metamist_update(
     dry_run: bool,
     dataset: str,


### PR DESCRIPTION
Register the reheadered NAGIM CRAMs in Metamist and add a comment to the sequencing group that the reheadered CRAM is now the latest analysis, up until the time that the CRAMs are realigned with Dragen 3.7.8.

The following example analysis entry is created

```
{'meta': {'archive': 'False',
          'project': 'tob-wgs',
          'sequence_type': 'genome',
          'sequencing_type': 'genome',
          'size': 22866202841,
          'source': 'Reheadered NAGIM from '
                    'gs://.../xxx.cram',
          'staging': 'False',
          'upload': 'False'},
 'output': 'gs://.../reheadered/xxx.cram',
 'sequencing_group_ids': ['xxx'],
 'status': 'completed',
 'type': 'cram'}
```