### PR TITLE
Truncate rsid and keep only first variant for colocated ones

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.23
+current_version = 1.36.24
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.23
+  VERSION: 1.36.24
 
 jobs:
   docker:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.23',
+    version='1.36.24',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Before exporting to elasticsearch, we need to make sure the rsid field is a reasonable length. The rsid field is populated before splitting and normalisation, so it can be a huge string of colocated variants.

This change will split the rsid on the ';' character to ensure it only contains the first variant, if there are multiple. Then, it will truncate the rsid to 512 characters at most. 

This change ran successfully in test for 6 individuals (2x trio VCFs)
https://batch.hail.populationgenomics.org.au/batches/594145

However, I'm not sure if this will ensure uniqueness, which is required for elasticsearch / seqr integration.