### PR TITLE
Frequencies and browser prep refactor

### DIFF
--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -133,7 +133,7 @@ array<
 
 
 def _nullify_nan(value):
-    return hl.if_else(hl.is_nan(value), hl.null(value.dtype), value)
+    return hl.if_else(hl.is_nan(value), hl.missing(value.dtype), value)
 
 
 def _normalized_contig(contig: hl.expr.StringExpression) -> hl.expr.StringExpression:

--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -347,7 +347,7 @@ def prepare_gnomad_v4_variants_helper(ds_path: str, exome_or_genome: str) -> hl.
     flags = [
         hl.or_missing(ds.region_flags.lcr, "lcr"),
         hl.or_missing(ds.region_flags.segdup, "segdup"),
-        hl.or_missing(ds.region_flags.non_par, "segdup"),
+        hl.or_missing(ds.region_flags.non_par, "non_par"),
         hl.or_missing(
             ((ds.locus.contig == "chrX") & ds.locus.in_x_par()) | ((ds.locus.contig == "chrY") & ds.locus.in_y_par()),
             "par",

--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -166,7 +166,7 @@ def _freq_index_key(subset=None, pop=None, sex=None, raw=False):
 
 
 def _freq(ds, *args, **kwargs):
-    return ds.freq[g.freq_index_dict[_freq_index_key(*args, **kwargs)]]
+    return ds.freq[ds.freq_index_dict[_freq_index_key(*args, **kwargs)]]
 
 
 def _subset_filter(subset):

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -89,6 +89,8 @@ def frequency_annotations(
         adj=get_adj_expr(mt.GT, mt.GQ, mt.DP, mt.AD),
     )
 
+    mt = mt.checkpoint(output_path('filtered_checkpoint.mt', category='tmp'), overwrite=True)
+
     # Annotate variant QC metrics.
     logging.info('Annotating variant QC metrics...')
     logging.info('Base variant QC...')
@@ -111,6 +113,8 @@ def frequency_annotations(
         ),
     )
 
+    mt = mt.checkpoint(output_path('variant_qc_checkpoint.mt', category='tmp'), overwrite=True)
+
     # Compute allele frequencies, stratified by genetic ancestry, sex, and data subset (if applicable).
     logging.info('Computing stratified allele frequencies...')
     mt = annotate_freq(
@@ -123,7 +127,7 @@ def frequency_annotations(
             {'subset': mt.subset, 'pop': mt.gen_anc, 'sex': mt.sex},
         ],
     )
-    mt = mt.checkpoint(output_path('mt_stratified_frequencies.mt', category='tmp'), overwrite=True)
+    mt = mt.checkpoint(output_path('stratified_frequencies.mt', category='tmp'), overwrite=True)
     mt = mt.annotate_globals(freq_index_dict=make_freq_index_dict_from_meta(mt.freq_meta))
     mt = _compute_filtering_af_and_popmax(mt)
     mt = mt.annotate_rows(monoallelic=(mt.freq[0].AC > 0) & (mt.freq[1].AF == 1))

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -97,6 +97,9 @@ def frequency_annotations(
     mt = hl.variant_qc(mt)
 
     logging.info('Allele-specific statistics...')
+    # PLACEHOLDER UNTIL VQSR STAGE IS FIXED
+    # Because the site_only_ht is not split, this info will not be correctly populated for multiallelic
+    # variants until this is resolved. 
     mt = mt.annotate_rows(info=site_only_ht[mt.row_key].info)
 
     logging.info('Inbreeding coefficient...')

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -6,7 +6,6 @@ from cpg_utils import Path
 from cpg_utils.config import config_retrieve, output_path
 from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import can_reuse
-from gnomad.resources.grch38.gnomad import POPS_TO_REMOVE_FOR_POPMAX
 from gnomad.resources.grch38.reference_data import (
     lcr_intervals,
     seg_dup_intervals,
@@ -14,7 +13,6 @@ from gnomad.resources.grch38.reference_data import (
 from gnomad.sample_qc.sex import adjusted_sex_ploidy_expr
 from gnomad.utils.annotations import (
     age_hists_expr,
-    annotate_adj,
     annotate_freq,
     bi_allelic_site_inbreeding_expr,
     faf_expr,
@@ -24,14 +22,15 @@ from gnomad.utils.annotations import (
     qual_hist_expr,
     region_flag_expr,
 )
-from gnomad.utils.release import make_faf_index_dict, make_freq_index_dict, make_freq_index_dict_from_meta
+from gnomad.utils.release import make_faf_index_dict, make_freq_index_dict_from_meta
+
+POPS_TO_REMOVE_FOR_POPMAX = {'Unclassified'}
 
 
 def run(
     vds_path: str,
     sample_qc_ht_path: str,
     relateds_to_drop_ht_path: str,
-    infer_pop_ht_path: str,
     site_only_ht_path: str,
     vqsr_ht_path: str,
     out_ht_path: str,
@@ -45,20 +44,11 @@ def run(
     vds = hl.vds.read_vds(str(vds_path))
     sample_qc_ht = hl.read_table(str(sample_qc_ht_path))
     relateds_to_drop_ht = hl.read_table(str(relateds_to_drop_ht_path))
-    inferred_pop_ht = hl.read_table(str(infer_pop_ht_path))
     site_only_ht = hl.read_table(str(site_only_ht_path))
     vqsr_ht = hl.read_table(str(vqsr_ht_path))
 
     logging.info('Generating frequency annotations...')
-    freq_ht = frequency_annotations(
-        vds,
-        sample_qc_ht,
-        relateds_to_drop_ht,
-        inferred_pop_ht,
-        site_only_ht,
-        vqsr_ht,
-        out_ht_path,
-    )
+    freq_ht = frequency_annotations(vds, sample_qc_ht, relateds_to_drop_ht, site_only_ht, vqsr_ht)
     logging.info(f'Writing out frequency data to {out_ht_path}...')
     freq_ht.write(str(out_ht_path), overwrite=True)
 
@@ -67,78 +57,80 @@ def frequency_annotations(
     vds: hl.vds.VariantDataset,
     sample_qc_ht: hl.Table,
     relateds_to_drop_ht: hl.Table,
-    inferred_pop_ht: hl.Table,
     site_only_ht: hl.Table,
     vqsr_ht: hl.Table,
-    out_ht_path: str,
 ) -> hl.Table:
     """
     Generate frequency annotations (AF, AC, AN, InbreedingCoeff)
     """
 
-    logging.info('Reading full sparse MT and metadata table...')
-
-    logging.info('Splitting multiallelics')
+    # Prepare the dense matrix table.
+    logging.info('Splitting multiallelics...')
     vds = hl.vds.split_multi(vds, filter_changed_loci=True)
 
     logging.info('Densifying...')
-    # The reason is that sparse matrix table has got NA records representing
-    # the reference blocks, which affects the calculation of frequencies.
-    # That's why we need to convert it to a "dense" representation, effectively
-    # dropping reference blocks.
     mt = hl.vds.to_dense_mt(vds)
 
-    mt = mt.filter_rows(hl.len(mt.alleles) > 1)
-
-    # Filter samples
+    # Filter and annotate samples.
+    logging.info('Removing filtered samples...')
     mt = mt.filter_cols(hl.len(sample_qc_ht[mt.col_key].filters) > 0, keep=False)
     mt = mt.filter_cols(hl.is_defined(relateds_to_drop_ht[mt.col_key]), keep=False)
 
-    logging.info('Computing adj and sex adjusted genotypes...')
+    logging.info('Annotating sample metadata...')
+    mt = mt.annotate_cols(
+        gen_anc=sample_qc_ht[mt.s].population,
+        sex=sample_qc_ht[mt.s].sex_karyotype,
+        subset=sample_qc_ht[mt.s].subset if "subset" in list(sample_qc_ht.row) else hl.missing('str'),
+    )
+
+    logging.info('Computing quality and sex adjusted genotypes...')
     mt = mt.annotate_entries(
         GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, sample_qc_ht[mt.col_key].sex_karyotype),
         adj=get_adj_expr(mt.GT, mt.GQ, mt.DP, mt.AD),
     )
-    logging.info('Computing adj call rates...')
-    mt_adj = mt.filter_entries(mt.adj)
-    info_ht = mt_adj.annotate_rows(adj_gt_stats=hl.agg.call_stats(mt_adj.GT, mt_adj.alleles)).rows()
 
-    logging.info('Generating frequency data...')
+    # Annotate variant QC metrics.
+    logging.info('Annotating variant QC metrics...')
+    logging.info('Base variant QC...')
     mt = hl.variant_qc(mt)
 
-    logging.info('Calculating InbreedingCoeff...')
-    # NOTE: This is not the ideal location to calculate this, but added here
-    # to avoid another densify.
-    # The algorithm assumes all samples are unrelated:
+    logging.info('Allele-specific statistics...')
+    mt = mt.annotate_rows(info=site_only_ht[mt.row_key].info)
+
+    logging.info('Inbreeding coefficient...')
     mt = mt.annotate_rows(InbreedingCoeff=hl.array([bi_allelic_site_inbreeding_expr(mt.GT)]))
 
-    # Annotate pop and sex labels
-    mt = mt.annotate_cols(gen_anc=inferred_pop_ht[mt.s].pop)
+    logging.info('VQSR filters...')
+    mt = mt.annotate_rows(vqsr_filters=vqsr_ht[mt.row_key].filters)
 
-    mt = mt.annotate_cols(sex=sample_qc_ht[mt.s].sex_karyotype)
+    logging.info('Region flags...')
+    mt = mt.annotate_rows(
+        region_flags=region_flag_expr(
+            mt,
+            prob_regions={'lcr': lcr_intervals.ht(), 'segdup': seg_dup_intervals.ht()},
+        ),
+    )
 
-    # Annotate frequency strata
-    # Forcing annotate_freq to use 'gen_anc' as the pop label here
-    # The ordering of freq_meta is important for the downstream faf and popmax code and
-    # could be a potential source of bugs if the ordering of additional_strata_expr is changed
+    # Compute allele frequencies, stratified by genetic ancestry, sex, and data subset (if applicable).
+    logging.info('Computing stratified allele frequencies...')
     mt = annotate_freq(
         mt,
         sex_expr=mt.sex,
+        pop_expr=mt.gen_anc,
         additional_strata_expr=[
-            {'gen_anc': mt.gen_anc},
-            {'gen_anc': mt.gen_anc, 'sex': mt.sex},
+            {'subset': mt.subset},
+            {'subset': mt.subset, 'pop': mt.gen_anc},
+            {'subset': mt.subset, 'pop': mt.gen_anc, 'sex': mt.sex},
         ],
     )
-
-    mt = _compute_filtering_af_and_popmax(mt)
-
-    mt = mt.checkpoint(output_path('mt_faf_popmax.mt', category='tmp'), overwrite=True)
-
-    # Currently have no Hail Tables with age data annotated on them, so unable to calculate age histograms
-    # mt = _compute_age_hists(mt, sample_qc_ht) # <-- Discuss
+    mt = mt.checkpoint(output_path('mt_stratified_frequencies.mt', category='tmp'), overwrite=True)
     mt = mt.annotate_globals(freq_index_dict=make_freq_index_dict_from_meta(mt.freq_meta))
+    mt = _compute_filtering_af_and_popmax(mt)
+    mt = mt.annotate_rows(monoallelic=(mt.freq[0].AC > 0) & (mt.freq[1].AF == 1))
 
-    # Annotate quality metrics histograms
+    # Compute variant histograms.
+    logging.info('Computing variant histograms...')
+    mt = _compute_age_hists(mt, sample_qc_ht)
     qual_hist_ht = _annotate_quality_metrics_hist(mt)
     mt = mt.annotate_rows(
         histograms=hl.struct(
@@ -147,36 +139,11 @@ def frequency_annotations(
         ),
     )
 
-    freq_ht = mt.rows()
-
-    # Annotate freq_ht with the 'filters' field from VQSR
-    freq_ht = freq_ht.annotate(filters=vqsr_ht[freq_ht.key].filters)
-
-    freq_ht = freq_ht.annotate(info=site_only_ht[freq_ht.key].info)
-
-    freq_ht = freq_ht.annotate(
-        info=freq_ht.info.annotate(InbreedingCoeff=freq_ht.InbreedingCoeff),
-    )
-
-    freq_ht = freq_ht.annotate(
-        region_flags=region_flag_expr(
-            freq_ht,
-            prob_regions={'lcr': lcr_intervals.ht(), 'segdup': seg_dup_intervals.ht()},
-        ),
-    )
-
-    mono_allelic_flag_expr = (freq_ht.freq[0].AC > 0) & (freq_ht.freq[1].AF == 1)
-    freq_ht = freq_ht.annotate(info=freq_ht.info.annotate(monoallelic=mono_allelic_flag_expr))
-
-    freq_ht = freq_ht.annotate(**freq_ht.variant_qc)
-
-    freq_ht = freq_ht.annotate(**info_ht[freq_ht.locus, freq_ht.alleles].select('adj_gt_stats'))
-
-    return freq_ht
+    return mt.rows()
 
 
 def _compute_age_hists(mt: hl.MatrixTable, sample_qc_ht: hl.Table) -> hl.MatrixTable:
-    logging.info('Computing age histograms for each variant...')
+    logging.info('Computing carrier age histograms for each variant...')
     try:
         mt = mt.annotate_cols(age=hl.float64(sample_qc_ht[mt.col_key].age))
     except AttributeError:
@@ -205,15 +172,13 @@ def _compute_age_hists(mt: hl.MatrixTable, sample_qc_ht: hl.Table) -> hl.MatrixT
 
 def _compute_filtering_af_and_popmax(mt: hl.MatrixTable) -> hl.MatrixTable:
     logging.info('Computing filtering allele frequencies and popmax...')
-    faf, faf_meta = faf_expr(mt.freq, mt.freq_meta, mt.locus, POPS_TO_REMOVE_FOR_POPMAX, pop_label='gen_anc')
-    mt = mt.select_rows(
-        'InbreedingCoeff',
-        'freq',
-        'rsid',
-        'variant_qc',
+    faf, faf_meta = faf_expr(mt.freq, mt.freq_meta, mt.locus, POPS_TO_REMOVE_FOR_POPMAX, pop_label='pop')
+    popmax = pop_max_expr(mt.freq, mt.freq_meta, POPS_TO_REMOVE_FOR_POPMAX, pop_label='pop')
+    mt = mt.annotate_rows(
         faf=faf,
-        popmax=pop_max_expr(mt.freq, mt.freq_meta, POPS_TO_REMOVE_FOR_POPMAX, pop_label='gen_anc'),
+        popmax=popmax,
     )
+
     mt = mt.annotate_globals(
         faf_meta=faf_meta,
         faf_index_dict=make_faf_index_dict(
@@ -221,19 +186,25 @@ def _compute_filtering_af_and_popmax(mt: hl.MatrixTable) -> hl.MatrixTable:
             pops=list(mt.aggregate_cols(hl.agg.collect_as_set(mt.gen_anc))),  # unique pop labels,
         ),
     )
+
     mt = mt.annotate_rows(
+        fafmax=gen_anc_faf_max_expr(faf=mt.faf, faf_meta=mt.faf_meta, pop_label='pop'),
         popmax=mt.popmax.annotate(
-            # Order of strata dictionaries in faf_meta affects data returned by lambda function
-            faf95=mt.faf[mt.faf_meta.index(lambda x: x.values() == [mt.popmax.gen_anc, 'adj'])].faf95,
+            faf95=mt.faf[
+                mt.faf_meta.index(
+                    lambda x: (
+                        (x.key_set() == hl.set(['group', 'pop'])) & (x['group'] == 'adj') & (x['pop'] == mt.popmax.pop)
+                    ),
+                )
+            ].faf95,
         ),
     )
-    mt = mt.annotate_rows(fafmax=gen_anc_faf_max_expr(faf=mt.faf, faf_meta=mt.faf_meta, pop_label='gen_anc'))
 
     return mt
 
 
 def _annotate_quality_metrics_hist(mt: hl.MatrixTable) -> hl.Table:
-    logging.info('Annotating quality metrics histograms...')
+    logging.info('Computing variant quality metrics histograms...')
     # NOTE: these are performed here as the quality metrics histograms
     # also require densifying
     mt = mt.annotate_rows(qual_hists=qual_hist_expr(mt.GT, mt.GQ, mt.DP, mt.AD, mt.adj))

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -99,7 +99,7 @@ def frequency_annotations(
     logging.info('Allele-specific statistics...')
     # PLACEHOLDER UNTIL VQSR STAGE IS FIXED
     # Because the site_only_ht is not split, this info will not be correctly populated for multiallelic
-    # variants until this is resolved. 
+    # variants until this is resolved.
     mt = mt.annotate_rows(info=site_only_ht[mt.row_key].info)
 
     logging.info('Inbreeding coefficient...')

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -443,7 +443,7 @@ class LoadVqsr(CohortStage):
         return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=[j])
 
 
-@stage(required_stages=[Combiner, SampleQC, Relatedness, Ancestry, MakeSiteOnlyVcf, LoadVqsr])
+@stage(required_stages=[Combiner, Relatedness, Ancestry, MakeSiteOnlyVcf, LoadVqsr])
 class Frequencies(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         if frequencies_version := config_retrieve(['large_cohort', 'output_versions', 'frequencies'], default=None):
@@ -476,9 +476,8 @@ class Frequencies(CohortStage):
                 frequencies,
                 frequencies.run.__name__,
                 str(inputs.as_path(cohort, Combiner, key='vds')),
-                str(inputs.as_path(cohort, SampleQC)),
+                str(inputs.as_path(cohort, Ancestry, key='sample_qc_ht')),
                 str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
-                str(inputs.as_path(cohort, Ancestry, key='inferred_pop')),
                 str(inputs.as_path(cohort, MakeSiteOnlyVcf, key='ht')),
                 str(inputs.as_path(cohort, LoadVqsr)),
                 str(self.expected_outputs(cohort)),

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -286,7 +286,6 @@ def test_site_only(mocker: MockFixture, tmp_path: Path):
         relateds_to_drop_ht_path=str(tmp_path / 'relateds_to_drop.ht'),
         out_vcf_path=str(siteonly_vcf_path),
         out_ht_path=str(tmp_path / 'siteonly.ht'),
-        tmp_prefix=str(tmp_path / 'tmp'),
     )
 
     # do some testing here


### PR DESCRIPTION
Key changes:
- Refactor frequencies to group related functions together (filtering, variant QC, frequency estimation, histogram creation)
- Adding checkpoints to force periodic evaluation
- Including functionality to compute allele frequencies by subset
- Remove the need to calculate AC_raw for stratified allele frequencies, as we don't need this annotation downstream and it makes computation more complex
- Defining a default empty table to return from the browser prep function when no frequency data is passed for a given datatype (exome or genome).
- Adding variant filter flags (VQSR, InbreedingCoefficient, AC0)
- Simplifying the computation of co-located variants
