### PR TITLE
Stop stages saving primary output to tmp

### DIFF
--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -20,7 +20,7 @@ def run(
     sample_qc_ht_path: str,
     relateds_to_drop_ht_path: str,
     out_vcf_path: str,
-    tmp_prefix: str,
+    out_ht_path: str,
 ):
     if jar_spec := config_retrieve(['workflow', 'jar_spec_revision'], False):
         override_jar_spec(jar_spec)
@@ -29,7 +29,7 @@ def run(
     sample_qc_ht = hl.read_table(str(sample_qc_ht_path))
     relateds_to_drop_ht = hl.read_table(str(relateds_to_drop_ht_path))
 
-    site_only_ht_path = to_path(tmp_prefix) / 'siteonly.ht'
+    site_only_ht_path = to_path(out_ht_path) / 'siteonly.ht'
     site_only_ht = vds_to_site_only_ht(
         vds=vds,
         sample_qc_ht=sample_qc_ht,

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -334,9 +334,15 @@ class AncestryPlots(CohortStage):
 @stage(required_stages=[Combiner, SampleQC, Relatedness])
 class MakeSiteOnlyVcf(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        if site_only_version := config_retrieve(['large_cohort', 'output_versions', 'makesiteonly'], default=None):
+            site_only_version = slugify(site_only_version)
+
+        site_only_version = site_only_version or get_workflow().output_version
+
         return {
-            'vcf': self.tmp_prefix / 'siteonly.vcf.bgz',
-            'tbi': self.tmp_prefix / 'siteonly.vcf.bgz.tbi',
+            'vcf': cohort.analysis_dataset.prefix() / get_workflow().name / site_only_version / 'siteonly.vcf.bgz',
+            'tbi': cohort.analysis_dataset.prefix() / get_workflow().name / site_only_version / 'siteonly.vcf.bgz.tbi',
+            'ht': cohort.analysis_dataset.prefix() / get_workflow().name / site_only_version / 'siteonly.ht',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -368,7 +374,7 @@ class MakeSiteOnlyVcf(CohortStage):
                 str(inputs.as_path(cohort, SampleQC)),
                 str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
                 str(self.expected_outputs(cohort)['vcf']),
-                str(self.tmp_prefix),
+                str(self.expected_outputs(cohort)['ht']),
                 init_batch_args=init_batch_args,
                 setup_gcp=True,
             ),
@@ -380,9 +386,13 @@ class MakeSiteOnlyVcf(CohortStage):
 @stage(required_stages=MakeSiteOnlyVcf)
 class Vqsr(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        if vqsr_version := config_retrieve(['large_cohort', 'output_versions', 'vqsr'], default=None):
+            vqsr_version = slugify(vqsr_version)
+
+        vqsr_version = vqsr_version or get_workflow().output_version
         return {
-            'vcf': self.tmp_prefix / 'siteonly.vqsr.vcf.gz',
-            'tbi': self.tmp_prefix / 'siteonly.vqsr.vcf.gz.tbi',
+            'vcf': cohort.analysis_dataset.prefix() / get_workflow().name / vqsr_version / 'siteonly.vqsr.vcf.gz',
+            'tbi': cohort.analysis_dataset.prefix() / get_workflow().name / vqsr_version / 'siteonly.vqsr.vcf.gz.tbi',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
@@ -405,7 +415,11 @@ class Vqsr(CohortStage):
 @stage(required_stages=Vqsr)
 class LoadVqsr(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return get_workflow().prefix / 'vqsr.ht'
+        if load_vqsr_version := config_retrieve(['large_cohort', 'output_versions', 'loadvqsr'], default=None):
+            load_vqsr_version = slugify(load_vqsr_version)
+
+        load_vqsr_version = load_vqsr_version or get_workflow().output_version
+        return cohort.analysis_dataset.prefix() / get_workflow().name / load_vqsr_version / 'vqsr.ht'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
         from cpg_workflows.large_cohort import load_vqsr
@@ -432,7 +446,11 @@ class LoadVqsr(CohortStage):
 @stage(required_stages=[Combiner, SampleQC, Relatedness])
 class Frequencies(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
-        return get_workflow().prefix / 'frequencies.ht'
+        if frequencies_version := config_retrieve(['large_cohort', 'output_versions', 'frequencies'], default=None):
+            frequencies_version = slugify(frequencies_version)
+
+        frequencies_version = frequencies_version or get_workflow().output_version
+        return cohort.analysis_dataset.prefix() / get_workflow().name / frequencies_version / 'frequencies.ht'
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
         from cpg_workflows.large_cohort import frequencies

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -285,7 +285,7 @@ def test_site_only(mocker: MockFixture, tmp_path: Path):
         sample_qc_ht_path=str(tmp_path / 'sample_qc.ht'),
         relateds_to_drop_ht_path=str(tmp_path / 'relateds_to_drop.ht'),
         out_vcf_path=str(siteonly_vcf_path),
-        tmp_prefix=str(tmp_path / 'tmp'),
+        out_ht_path=str(tmp_path / 'tmp'),
     )
 
     # do some testing here


### PR DESCRIPTION
Stages `MakeSiteOnlyVcf` and `Vqsr` were saving their primary outputs to the `tmp` bucket which could cause issues when wanting to investigate outputs. This PR changes this behaviour so that the above stages are saving to non-tmp buckets.

Additionally adding more granular version control of outputs via config parameters as is used in other stages.