### PR TITLE
Adding default config for new prepare_browser_table workflow

### DIFF
--- a/configs/defaults/prepare_browser_table.toml
+++ b/configs/defaults/prepare_browser_table.toml
@@ -1,0 +1,16 @@
+
+[workflow]
+name = 'large_cohort'
+status_reporter = 'metamist'
+highmem_workers = true
+
+
+[large_cohort.output_versions]
+# If left empty, pipeline will default to building empty genome/exome variants browser table
+# frequencies_genome = ""
+# frequencies_exome = ""
+
+
+[hail]
+pool_label = 'large-cohort'
+delete_scratch_on_exit = false


### PR DESCRIPTION
Every workflow listed in `main.py` requires it's own default config file. When adding `prepare_browser_table` as a separate workflow, cpg_workflows requires the existence of `/production-pipelines/configs/defaults/prepare_browser_table.toml`. This PR adds this file. 