### PR TITLE
Update image_path() invocations to include version arguments

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,6 +28,12 @@ jobs:
 
       - name: Install
         run: pip install .[test]
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "gh-artifact-registry-reader@cpg-common.iam.gserviceaccount.com"
 
       - name: Run unit tests
         id: runtests

--- a/configs/defaults/gcnv.toml
+++ b/configs/defaults/gcnv.toml
@@ -26,7 +26,6 @@ gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2024-12-05-4.6.1.0-6-gfc248dfc1-NIGHTLY-SNAPSHOT"
-gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:2024-10-25-v0.29-beta-5ea22a52"
 sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/gatk-sv_issue_661:n_a"
 

--- a/configs/defaults/long_read_snps_indels_annotation.toml
+++ b/configs/defaults/long_read_snps_indels_annotation.toml
@@ -2,6 +2,7 @@
 name = 'long_read_snps_indels_annotation'
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 status_reporter = 'metamist'
+vep_image = '110.1-1'
 vep_version = '110'
 
 [workflow.merge_vcfs]

--- a/configs/defaults/long_read_snps_indels_annotation.toml
+++ b/configs/defaults/long_read_snps_indels_annotation.toml
@@ -5,7 +5,7 @@ status_reporter = 'metamist'
 vep_version = '110'
 
 [workflow.merge_vcfs]
-bcftools_image = 'bcftools_121'
+bcftools_image = '1.21-1'
 
 [workflow.annotate_cohort]
 highmem_drivers = false

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -9,6 +9,7 @@ use_gnarly = false
 use_as_vqsr = true
 
 # Version of VEP to use, currently operational: 105, 110
+vep_image = '110.1-1'
 vep_version = '110'
 
 # Realign CRAM when available, instead of using FASTQ.
@@ -107,10 +108,6 @@ username = 'seqr'
 # Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
 password_secret_id = 'seqr-es-password'
 password_project_id = 'seqr-308602'
-
-# temporary overrides until we rename images/config
-[images]
-vep_105 = "australia-southeast1-docker.pkg.dev/cpg-common/images/vep:105.0"
 
 [references]
 vep_105_mount = "gs://cpg-common-main/references/vep/105.0/mount"

--- a/cpg_workflows/jobs/align.py
+++ b/cpg_workflows/jobs/align.py
@@ -251,7 +251,7 @@ def align(
                 sharded_align_jobs.append(j)
 
         merge_j = b.new_job('Merge BAMs', (job_attrs or {}) | dict(tool='samtools_merge'))
-        merge_j.image(image_path('samtools'))
+        merge_j.image(image_path('samtools', '1.18-1'))
 
         nthreads = STANDARD.set_resources(
             merge_j,
@@ -445,11 +445,11 @@ def _align_one(
     if aligner in [Aligner.BWAMEM2, Aligner.BWA]:
         if aligner == Aligner.BWAMEM2:
             tool_name = 'bwa-mem2'
-            j.image(image_path('bwamem2'))
+            j.image(image_path('bwamem2', '2.2.1-1'))
             index_exts = BWAMEM2_INDEX_EXTS
         else:
             tool_name = 'bwa'
-            j.image(image_path('bwa'))
+            j.image(image_path('bwa', '0.7.17-1'))
             index_exts = BWA_INDEX_EXTS
         bwa_reference = fasta_res_group(b, index_exts)
         rg_line = f'@RG\\tID:{sequencing_group_name}\\tSM:{sequencing_group_name}'
@@ -467,7 +467,7 @@ def _align_one(
         """
 
     elif aligner == Aligner.DRAGMAP:
-        j.image(image_path('dragmap'))
+        j.image(image_path('dragmap', '1.3.0-tokenizer-next-fix-1'))
         dragmap_index = b.read_input_group(
             **{
                 k.replace('.', '_'): os.path.join(reference_path('broad/dragmap_prefix'), k)
@@ -537,7 +537,7 @@ def extract_fastq(
     Job that converts a BAM or a CRAM file to a pair of compressed fastq files.
     """
     j = b.new_job('Extract fastq', (job_attrs or {}) | dict(tool='samtools'))
-    j.image(image_path('samtools'))
+    j.image(image_path('samtools', '1.18-1'))
     res = STANDARD.request_resources(ncpu=16)
     if get_config()['workflow']['sequencing_type'] == 'genome':
         res.attach_disk_storage_gb = 700

--- a/cpg_workflows/jobs/align_rna.py
+++ b/cpg_workflows/jobs/align_rna.py
@@ -263,7 +263,7 @@ def align_fq_pair(
     align_tool = 'STAR'
     j_attrs = (job_attrs or {}) | dict(label=job_name, tool=align_tool)
     j = b.new_job(name=job_name, attributes=j_attrs)
-    j.image(image_path('star'))
+    j.image(image_path('star', '2.7.10b-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -306,7 +306,7 @@ def merge_bams(
     merge_tool = 'samtools'
     j_attrs = (job_attrs or {}) | dict(label=job_name, tool=merge_tool)
     j = b.new_job(name=job_name, attributes=j_attrs)
-    j.image(image_path('samtools'))
+    j.image(image_path('samtools', '1.18-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -338,7 +338,7 @@ def sort_index_bam(
     sort_tool = 'samtools'
     j_attrs = (job_attrs or {}) | dict(label=job_name, tool=sort_tool)
     j = b.new_job(name=job_name, attributes=j_attrs)
-    j.image(image_path('samtools'))
+    j.image(image_path('samtools', '1.18-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/bam_to_cram.py
+++ b/cpg_workflows/jobs/bam_to_cram.py
@@ -32,7 +32,7 @@ def bam_to_cram(
     convert_tool = 'samtools_view'
     j_attrs = (job_attrs or {}) | dict(label=job_name, tool=convert_tool)
     j = b.new_job(name=job_name, attributes=j_attrs)
-    j.image(image_path('samtools'))
+    j.image(image_path('samtools', '1.18-1'))
 
     # Get fasta file
     fasta = b.read_input_group(
@@ -82,7 +82,7 @@ def cram_to_bam(
     convert_tool = 'samtools_view_cram_to_bam'
     j_attrs = (job_attrs or {}) | dict(label=job_name, tool=convert_tool)
     j = b.new_job(name=job_name, attributes=j_attrs)
-    j.image(image_path('samtools'))
+    j.image(image_path('samtools', '1.18-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/bcftools.py
+++ b/cpg_workflows/jobs/bcftools.py
@@ -43,7 +43,7 @@ def naive_concat_vcfs(
         ]
 
     concat = get_batch().new_job('Concat VCFs', attributes={'tool': 'bcftools'})
-    concat.image(image=image_path('bcftools'))
+    concat.image(image=image_path('bcftools', '1.16-1'))
 
     # guessing at resource requirements
     concat.cpu(cpu)
@@ -102,7 +102,7 @@ def naive_merge_vcfs(
         ]
 
     merge_job = get_batch().new_job('Merge VCFs', attributes={'tool': 'bcftools'})
-    merge_job.image(image=image_path('bcftools'))
+    merge_job.image(image=image_path('bcftools', '1.16-1'))
 
     # guessing at resource requirements
     merge_job.cpu(cpu)

--- a/cpg_workflows/jobs/count.py
+++ b/cpg_workflows/jobs/count.py
@@ -171,7 +171,7 @@ def count(
     job_name = f'count_{sample_name}' if sample_name else 'count'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='featureCounts')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('subread'))
+    j.image(image_path('subread', '2.0.6-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/exomiser.py
+++ b/cpg_workflows/jobs/exomiser.py
@@ -33,7 +33,7 @@ def family_vcf_from_gvcf(family_members: list[SequencingGroup], out_path: str) -
 
     family_ids = [sg.id for sg in family_members]
     job = get_batch().new_job(f'Generate VCF {out_path} from {family_ids}')
-    job.image(image_path('bcftools'))
+    job.image(image_path('bcftools', '1.16-1'))
     if get_config()['workflow']['sequencing_type'] == 'genome':
         job.storage('10Gi')
 
@@ -171,7 +171,8 @@ def run_exomiser(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
     type hint is still wild
     """
 
-    exomiser_version = image_path('exomiser_14').split(':')[-1]
+    exomiser_image_version = '14.0.0-1'
+    exomiser_version = exomiser_image_version.rpartition('-')[0]
     exomiser_dir = f'/exomiser/exomiser-cli-{exomiser_version}'
 
     # localise the compressed exomiser references
@@ -192,7 +193,7 @@ def run_exomiser(content_dict: dict[str, dict[str, Path | dict[str, Path]]]):
         job.storage(config_retrieve(['workflow', 'exomiser_storage'], '100Gi'))
         job.memory(config_retrieve(['workflow', 'exomiser_memory'], '60Gi'))
         job.cpu(config_retrieve(['workflow', 'exomiser_cpu'], 4))
-        job.image(image_path('exomiser_14'))
+        job.image(image_path('exomiser_14', exomiser_image_version))
 
         # unpack references, see linux-install link above
         job.command(f'unzip {inputs}/\* -d "{exomiser_dir}/data"')

--- a/cpg_workflows/jobs/fastqc.py
+++ b/cpg_workflows/jobs/fastqc.py
@@ -29,7 +29,7 @@ def fastqc(
     Adds FastQC jobs. If the input is a set of fqs, runs FastQC on each fq file.
     """
     j = b.new_job('FASTQC', (job_attrs or {}) | {'tool': 'fastqc'})
-    j.image(image_path('fastqc'))
+    j.image(image_path('fastqc', '0.11.9-1'))
     threads = STANDARD.set_resources(j, ncpu=16).get_nthreads()
 
     cmd = ''

--- a/cpg_workflows/jobs/fraser.py
+++ b/cpg_workflows/jobs/fraser.py
@@ -21,6 +21,8 @@ from cpg_workflows.workflow import (
     SequencingGroup,
 )
 
+FRASER_VERSION = '1.12.1-1'
+
 
 class Fraser:
     """
@@ -246,7 +248,7 @@ def fraser(
     job_name = f'fraser_{cohort_id}' if cohort_id else 'fraser'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='fraser')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('fraser'))
+    j.image(image_path('fraser', FRASER_VERSION))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -412,7 +414,7 @@ def fraser_init(
     job_name = 'fraser_init'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='fraser')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('fraser'))
+    j.image(image_path('fraser', FRASER_VERSION))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -490,7 +492,7 @@ def fraser_count_split_reads_one_sample(
     job_name = 'fraser_count_split'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='fraser')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('fraser'))
+    j.image(image_path('fraser', FRASER_VERSION))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -557,7 +559,7 @@ def fraser_merge_split_reads(
     job_name = 'fraser_merge_split'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='fraser')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('fraser'))
+    j.image(image_path('fraser', FRASER_VERSION))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -664,7 +666,7 @@ def fraser_count_non_split_reads_one_sample(
     job_name = 'fraser_count_non_split'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='fraser')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('fraser'))
+    j.image(image_path('fraser', FRASER_VERSION))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8
@@ -739,7 +741,7 @@ def fraser_merge_non_split_reads(
     job_name = 'fraser_merge_non_split'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='fraser')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('fraser'))
+    j.image(image_path('fraser', FRASER_VERSION))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/gcloud_composer.py
+++ b/cpg_workflows/jobs/gcloud_composer.py
@@ -129,7 +129,7 @@ def gcloud_compose_vcf_from_manifest(
     # one final job - read the final vcf in, index it, move the index, and write it out
     input_vcf = get_batch().read_input(fragment_files[0])
     final_job = get_batch().new_bash_job(name='index_final_vcf')
-    final_job.image(image_path('bcftools'))
+    final_job.image(image_path('bcftools', '1.16-1'))
     final_job.storage(config_retrieve(['gcloud_condense', 'storage'], final_size))
 
     # if there were no jobs, there's no composing...

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -16,7 +16,7 @@ from cpg_workflows.resources import HIGHMEM
 from cpg_workflows.scripts import upgrade_ped_with_inferred
 from cpg_workflows.utils import can_reuse, chunks
 
-GATK_VERSION = '4.5.0.0-1'
+GCNV_GATK_VERSION = '4.2.6.1-57-g9e03432'
 
 
 def upgrade_ped_file(local_ped: ResourceFile, new_output: str, aneuploidies: str, ploidy_tar: str):
@@ -48,7 +48,7 @@ def prepare_intervals(job_attrs: dict[str, str], output_paths: dict[str, Path]) 
         'Prepare intervals',
         job_attrs | {'tool': 'gatk PreprocessIntervals/AnnotateIntervals'},
     )
-    j.image(image_path('gatk_gcnv', GATK_VERSION))
+    j.image(image_path('sv/gatk', GCNV_GATK_VERSION))
 
     sequencing_type = get_config()['workflow']['sequencing_type']
     reference = fasta_res_group(get_batch())
@@ -102,7 +102,7 @@ def collect_read_counts(
     output_base_path: Path,
 ) -> list[Job]:
     j = get_batch().new_job('Collect gCNV read counts', job_attrs | {'tool': 'gatk CollectReadCounts'})
-    j.image(image_path('gatk_gcnv', GATK_VERSION))
+    j.image(image_path('sv/gatk', GCNV_GATK_VERSION))
 
     reference = fasta_res_group(get_batch())
 
@@ -164,7 +164,7 @@ def filter_and_determine_ploidy(
             'tool': 'gatk FilterIntervals/DetermineGermlineContigPloidy',
         },
     )
-    j.image(image_path('gatk_gcnv', GATK_VERSION))
+    j.image(image_path('sv/gatk', GCNV_GATK_VERSION))
 
     # set highmem resources for this job
     job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
@@ -262,7 +262,7 @@ def shard_gcnv(
                 'part': f'shard {i} of {n}',
             },
         )
-        j.image(image_path('gatk_gcnv', GATK_VERSION))
+        j.image(image_path('sv/gatk', GCNV_GATK_VERSION))
 
         # set highmem resources for this job
         job_res = HIGHMEM.request_resources(ncpu=8, mem_gb=52, storage_gb=10)
@@ -311,7 +311,7 @@ def postprocess_calls(
         assert all([clustered_vcf, intervals_vcf, qc_file]), [clustered_vcf, intervals_vcf, qc_file]
 
     j = get_batch().new_job('Postprocess gCNV calls', job_attrs | {'tool': 'gatk PostprocessGermlineCNVCalls'})
-    j.image(image_path('gatk_gcnv', GATK_VERSION))
+    j.image(image_path('sv/gatk', GCNV_GATK_VERSION))
 
     # set highmem resources for this job
     job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=20)
@@ -430,7 +430,7 @@ def joint_segment_vcfs(
     """
     job = get_batch().new_bash_job(f'Joint Segmentation {title}', job_attrs | {'tool': 'gatk'})
     job.declare_resource_group(output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
-    job.image(image_path('gatk_gcnv', GATK_VERSION))
+    job.image(image_path('sv/gatk', GCNV_GATK_VERSION))
 
     # set highmem resources for this job
     job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)

--- a/cpg_workflows/jobs/gcnv.py
+++ b/cpg_workflows/jobs/gcnv.py
@@ -16,6 +16,8 @@ from cpg_workflows.resources import HIGHMEM
 from cpg_workflows.scripts import upgrade_ped_with_inferred
 from cpg_workflows.utils import can_reuse, chunks
 
+GATK_VERSION = '4.5.0.0-1'
+
 
 def upgrade_ped_file(local_ped: ResourceFile, new_output: str, aneuploidies: str, ploidy_tar: str):
     """
@@ -46,7 +48,7 @@ def prepare_intervals(job_attrs: dict[str, str], output_paths: dict[str, Path]) 
         'Prepare intervals',
         job_attrs | {'tool': 'gatk PreprocessIntervals/AnnotateIntervals'},
     )
-    j.image(image_path('gatk_gcnv'))
+    j.image(image_path('gatk_gcnv', GATK_VERSION))
 
     sequencing_type = get_config()['workflow']['sequencing_type']
     reference = fasta_res_group(get_batch())
@@ -100,7 +102,7 @@ def collect_read_counts(
     output_base_path: Path,
 ) -> list[Job]:
     j = get_batch().new_job('Collect gCNV read counts', job_attrs | {'tool': 'gatk CollectReadCounts'})
-    j.image(image_path('gatk_gcnv'))
+    j.image(image_path('gatk_gcnv', GATK_VERSION))
 
     reference = fasta_res_group(get_batch())
 
@@ -162,7 +164,7 @@ def filter_and_determine_ploidy(
             'tool': 'gatk FilterIntervals/DetermineGermlineContigPloidy',
         },
     )
-    j.image(image_path('gatk_gcnv'))
+    j.image(image_path('gatk_gcnv', GATK_VERSION))
 
     # set highmem resources for this job
     job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
@@ -260,7 +262,7 @@ def shard_gcnv(
                 'part': f'shard {i} of {n}',
             },
         )
-        j.image(image_path('gatk_gcnv'))
+        j.image(image_path('gatk_gcnv', GATK_VERSION))
 
         # set highmem resources for this job
         job_res = HIGHMEM.request_resources(ncpu=8, mem_gb=52, storage_gb=10)
@@ -309,7 +311,7 @@ def postprocess_calls(
         assert all([clustered_vcf, intervals_vcf, qc_file]), [clustered_vcf, intervals_vcf, qc_file]
 
     j = get_batch().new_job('Postprocess gCNV calls', job_attrs | {'tool': 'gatk PostprocessGermlineCNVCalls'})
-    j.image(image_path('gatk_gcnv'))
+    j.image(image_path('gatk_gcnv', GATK_VERSION))
 
     # set highmem resources for this job
     job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=20)
@@ -428,7 +430,7 @@ def joint_segment_vcfs(
     """
     job = get_batch().new_bash_job(f'Joint Segmentation {title}', job_attrs | {'tool': 'gatk'})
     job.declare_resource_group(output={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
-    job.image(image_path('gatk_gcnv'))
+    job.image(image_path('gatk_gcnv', GATK_VERSION))
 
     # set highmem resources for this job
     job_res = HIGHMEM.request_resources(ncpu=2, storage_gb=10)
@@ -537,7 +539,7 @@ def trim_sex_chromosomes(sgid: str, sg_vcf: str, no_xy_vcf: str, job_attrs: dict
         the job which generates the output file
     """
     job = get_batch().new_bash_job(f'remove sex chromosomes from {sgid}', job_attrs | {'tool': 'bcftools'})
-    job.image(image_path('bcftools'))
+    job.image(image_path('bcftools', '1.16-1'))
     job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
     localised_vcf = get_batch().read_input_group(**{'vcf.gz': sg_vcf, 'vcf.gz.tbi': f'{sg_vcf}.tbi'})['vcf.gz']
     autosomes = ' '.join([f'chr{i}' for i in range(1, 23)])

--- a/cpg_workflows/jobs/genotype.py
+++ b/cpg_workflows/jobs/genotype.py
@@ -173,7 +173,7 @@ def _haplotype_caller_one(
         return None, str(out_gvcf_path)
 
     j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk HaplotypeCaller'))
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', '4.2.6.1-1'))
 
     # Enough storage to localize CRAMs (can't pass GCS URL to CRAM to gatk directly
     # because we will hit GCP egress bandwidth limit:
@@ -261,7 +261,7 @@ def merge_gvcfs_job(
 
     j = b.new_job(job_name, (job_attrs or {}) | dict(tool='picard MergeVcfs'))
 
-    j.image(image_path('picard'))
+    j.image(image_path('picard', '2.27.4-1'))
     j.cpu(2)
     java_mem = 11
     j.memory('highmem')  # ~ 6G/core ~ 12G
@@ -315,7 +315,7 @@ def postproc_gvcf(
         return None
 
     j = b.new_job(job_name, (job_attrs or {}) | dict(tool='gatk ReblockGVCF'))
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', '4.2.6.1-1'))
 
     # We need at least 2 CPU, so on 16-core instance it would be 8 jobs,
     # meaning we have more than enough disk (265/8=33.125G).

--- a/cpg_workflows/jobs/happy.py
+++ b/cpg_workflows/jobs/happy.py
@@ -69,7 +69,7 @@ def happy(
     job_name = f'hap.py ({"GVCF" if is_gvcf else "VCF"})'
     job_attrs = (job_attrs or {}) | dict(tool='hap.py')
     j = b.new_job(job_name, job_attrs)
-    j.image(image_path('hap-py'))
+    j.image(image_path('hap-py', '0.3.15-1'))
     reference = fasta_res_group(b)
     res = STANDARD.set_resources(j, fraction=1)
     cmd = f"""\

--- a/cpg_workflows/jobs/joint_genotyping.py
+++ b/cpg_workflows/jobs/joint_genotyping.py
@@ -22,6 +22,8 @@ from cpg_workflows.utils import can_reuse, get_intervals_from_bed
 from .picard import get_intervals
 from .vcf import gather_vcfs
 
+GATK_VERSION = '4.2.6.1-1'
+
 
 class JointGenotyperTool(Enum):
     """
@@ -239,7 +241,7 @@ def genomicsdb(
             tool='gatk GenomicsDBImport',
         ),
     )
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     sample_map = b.read_input(str(sample_map_bucket_path))
 
@@ -357,7 +359,7 @@ def _add_joint_genotyper_job(
     job_name = f'{tool.name}'
     job_attrs = (job_attrs or {}) | {'tool': f'gatk {tool.name}'}
     j = b.new_job(job_name, job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
     # Standard 375/4 = 93G storage should be enough, based on the following estimations:
     # For example, for 1359 samples, and scatter_count=200,
     # * all of 200 GenomicsDBs tarballs = 1.09 TB
@@ -467,7 +469,7 @@ def _add_excess_het_filter(
 
     job_name = 'ExcessHet filter'
     j = b.new_job(job_name, job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
     res = STANDARD.set_resources(j, ncpu=2)
     j.declare_resource_group(output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
 
@@ -522,7 +524,7 @@ def add_make_sitesonly_job(
     job_name = 'MakeSitesOnlyVcf'
     job_attrs = (job_attrs or {}) | {'tool': 'gatk MakeSitesOnlyVcf'}
     j = b.new_job(job_name, job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
     res = STANDARD.set_resources(j, ncpu=2)
     if storage_gb:
         j.storage(f'{storage_gb}G')

--- a/cpg_workflows/jobs/markdups.py
+++ b/cpg_workflows/jobs/markdups.py
@@ -56,7 +56,7 @@ def markdup(
     j_name = base_job_name
     j_attrs = (job_attrs or {}) | dict(label=base_job_name, tool=tool)
     j = b.new_job(j_name, j_attrs)
-    j.image(image_path('sambamba'))
+    j.image(image_path('sambamba', '1.0.1-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/mito.py
+++ b/cpg_workflows/jobs/mito.py
@@ -17,6 +17,9 @@ from cpg_workflows.filetypes import CramPath
 from cpg_workflows.resources import STANDARD
 from cpg_workflows.targets import SequencingGroup
 
+GATK_VERSION = '4.2.6.1-1'
+PICARD_VERSION = '2.27.4-1'
+
 
 def subset_cram_to_chrM(
     b,
@@ -43,7 +46,7 @@ def subset_cram_to_chrM(
 
     job_attrs = (job_attrs or {}) | dict(tool='gatk_PrintReads')
     j = b.new_job('subset_cram_to_chrM', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     STANDARD.set_resources(j, ncpu=2)
 
@@ -103,7 +106,7 @@ def mito_realign(
     """
     job_attrs = job_attrs or {} | dict(tool='bwa')
     j = b.new_job('mito_realign', job_attrs)
-    j.image(image_path('bwa'))
+    j.image(image_path('bwa', '0.7.17-1'))
 
     nthreads = STANDARD.set_resources(j, ncpu=4).get_nthreads()
 
@@ -150,7 +153,7 @@ def collect_coverage_metrics(
     """
     job_attrs = (job_attrs or {}) | dict(tool='picard_CollectWgsMetrics')
     j = b.new_job('collect_coverage_metrics', job_attrs)
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
 
     STANDARD.set_resources(j, ncpu=2)
 
@@ -199,7 +202,7 @@ def extract_coverage_mean(
     """
     job_attrs = job_attrs or {} | dict(tool='R')
     j = b.new_job('extract_coverage_mean', job_attrs)
-    j.image(image_path('peer'))
+    j.image(image_path('peer', '1.3-1'))
 
     STANDARD.set_resources(j, ncpu=2)
 
@@ -250,7 +253,7 @@ def coverage_at_every_base(
     """
     job_attrs = job_attrs or {} | dict(tool='picard_CollectHsMetrics')
     j = b.new_job('coverage_at_every_base', job_attrs)
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
 
     STANDARD.set_resources(j, ncpu=2)
 
@@ -294,7 +297,7 @@ def merge_coverage(
     """
     job_attrs = job_attrs or {} | dict(tool='R')
     j = b.new_job('merge_coverage', job_attrs)
-    j.image(image_path('peer'))
+    j.image(image_path('peer', '1.3-1'))
 
     STANDARD.set_resources(j, ncpu=2)
 
@@ -353,7 +356,7 @@ def mito_mutect2(
     """
     job_attrs = job_attrs or {} | dict(tool='Mutect2')
     j = b.new_job('mito_mutect2', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     res = STANDARD.set_resources(j, ncpu=4)
 
@@ -409,7 +412,7 @@ def liftover_and_combine_vcfs(
     """
     job_attrs = job_attrs or {} | dict(tool='picard_LiftoverVcf')
     j = b.new_job('liftover_and_combine_vcfs', job_attrs)
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
 
     STANDARD.set_resources(j, ncpu=4)
 
@@ -456,7 +459,7 @@ def merge_mutect_stats(
     """
     job_attrs = job_attrs or {} | dict(tool='gatk_MergeMutectStats')
     j = b.new_job('merge_stats', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     STANDARD.set_resources(j, ncpu=4)
 
@@ -512,7 +515,7 @@ def filter_variants(
     """
     job_attrs = job_attrs or {} | dict(tool='gatk_FilterMutectCalls')
     j = b.new_job('filter_variants', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     STANDARD.set_resources(j, ncpu=4)
 
@@ -573,7 +576,7 @@ def split_multi_allelics(
     """
     job_attrs = job_attrs or {} | dict(tool='gatk_SelectVariants')
     j = b.new_job('split_multi_allelics', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     STANDARD.set_resources(j, ncpu=4)
 
@@ -630,7 +633,7 @@ def get_contamination(
     """
     job_attrs = job_attrs or {} | dict(tool='haplocheckcli')
     j = b.new_job('get_contamination', job_attrs)
-    j.image(image_path('haplocheckcli'))
+    j.image(image_path('haplocheckcli', '64293b34-1'))
 
     STANDARD.set_resources(j, ncpu=2)
 
@@ -733,7 +736,7 @@ def mitoreport(
     """
     job_attrs = (job_attrs or {}) | dict(tool='mitoreport')
     j = b.new_job('mitoreport', job_attrs)
-    j.image(image_path('mitoreport'))
+    j.image(image_path('mitoreport', '1.1.0-1'))
 
     res = STANDARD.request_resources(ncpu=2)
     res.set_to_job(j)

--- a/cpg_workflows/jobs/multiqc.py
+++ b/cpg_workflows/jobs/multiqc.py
@@ -59,7 +59,7 @@ def multiqc(
         title += f' [{label}]'
 
     mqc_j = b.new_job(title, (job_attrs or {}) | dict(tool='MultiQC'))
-    mqc_j.image(image_path('multiqc'))
+    mqc_j.image(image_path('multiqc', '1.14-1'))
     STANDARD.set_resources(mqc_j, ncpu=16)
 
     file_list_path = tmp_prefix / f'{dataset.get_alignment_inputs_hash()}_multiqc-file-list.txt'

--- a/cpg_workflows/jobs/outrider.py
+++ b/cpg_workflows/jobs/outrider.py
@@ -319,7 +319,7 @@ def outrider(
     job_name = f'outrider_{cohort_id}' if cohort_id else 'count'
     _job_attrs = (job_attrs or {}) | dict(label=job_name, tool='outrider')
     j = b.new_job(job_name, _job_attrs)
-    j.image(image_path('outrider'))
+    j.image(image_path('outrider', '1.18.1-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/picard.py
+++ b/cpg_workflows/jobs/picard.py
@@ -17,6 +17,8 @@ from cpg_workflows.resources import (
 )
 from cpg_workflows.utils import can_reuse, exists
 
+PICARD_VERSION = '2.27.4-1'
+
 
 def get_intervals(
     b: hb.Batch,
@@ -73,7 +75,7 @@ def get_intervals(
         f'Make {scatter_count} intervals for {sequencing_type}',
         attributes=(job_attrs or {}) | dict(tool='picard IntervalListTools'),
     )
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
     STANDARD.set_resources(j, storage_gb=16, mem_gb=2)
 
     break_bands_at_multiples_of = {
@@ -144,7 +146,7 @@ def markdup(
     if can_reuse(output_path, overwrite):
         return None
 
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
 
     # check for a memory override for impossible sequencing groups
     # if RAM is overridden, update the memory resource setting
@@ -221,7 +223,7 @@ def vcf_qc(
 
     job_attrs = (job_attrs or {}) | {'tool': 'picard CollectVariantCallingMetrics'}
     j = b.new_job('CollectVariantCallingMetrics', job_attrs)
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
     storage_gb = 20 if is_gvcf else storage_for_joint_vcf(sequencing_group_count, site_only=False)
     res = STANDARD.set_resources(j, storage_gb=storage_gb, mem_gb=3)
     reference = fasta_res_group(b)
@@ -289,7 +291,7 @@ def picard_collect_metrics(
 
     job_attrs = (job_attrs or {}) | {'tool': 'picard_CollectMultipleMetrics'}
     j = b.new_job('Picard CollectMultipleMetrics', job_attrs)
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
     res = STANDARD.request_resources(ncpu=2)
     res.attach_disk_storage_gb = storage_for_cram_qc_job()
     res.set_to_job(j)
@@ -358,7 +360,7 @@ def picard_hs_metrics(
 
     job_attrs = (job_attrs or {}) | {'tool': 'picard_CollectHsMetrics'}
     j = b.new_job('Picard CollectHsMetrics', job_attrs)
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
     sequencing_type = get_config()['workflow']['sequencing_type']
     assert sequencing_type == 'exome'
     res = STANDARD.request_resources(ncpu=2)
@@ -425,7 +427,7 @@ def picard_wgs_metrics(
     job_attrs = (job_attrs or {}) | {'tool': 'picard_CollectWgsMetrics'}
     j = b.new_job('Picard CollectWgsMetrics', job_attrs)
 
-    j.image(image_path('picard'))
+    j.image(image_path('picard', PICARD_VERSION))
     sequencing_type = get_config()['workflow']['sequencing_type']
     assert sequencing_type == 'genome'
     res = STANDARD.request_resources(ncpu=2)

--- a/cpg_workflows/jobs/rd_combiner/vep.py
+++ b/cpg_workflows/jobs/rd_combiner/vep.py
@@ -96,7 +96,7 @@ def vep_one(
     """
 
     # check that the cache and image for this version exist
-    vep_image = image_path('vep_110')
+    vep_image = image_path('vep', '110.1-1')
     vep_mount_path = to_path(reference_path('vep_110_mount'))
     assert all([vep_image, vep_mount_path])
 

--- a/cpg_workflows/jobs/samtools.py
+++ b/cpg_workflows/jobs/samtools.py
@@ -28,7 +28,7 @@ def samtools_stats(
     job_attrs = (job_attrs or {}) | {'tool': 'samtools'}
     j = b.new_job('samtools stats', job_attrs)
 
-    j.image(image_path('samtools'))
+    j.image(image_path('samtools', '1.18-1'))
     res = STANDARD.set_resources(j, fraction=1)
     reference = fasta_res_group(b)
 

--- a/cpg_workflows/jobs/seqr_loader_snps_indels.py
+++ b/cpg_workflows/jobs/seqr_loader_snps_indels.py
@@ -163,7 +163,7 @@ def add_split_vcf_job(
     Use GATK SelectVariants to split the VCF by interval.
     """
     j = b.new_job('SplitVcf', (job_attrs or {}) | {'tool': 'gatk SelectVariants'})
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', '4.2.6.1-1'))
     res = STANDARD.set_resources(j, ncpu=2)
 
     for idx, interval in enumerate(intervals):
@@ -215,7 +215,7 @@ def add_make_sitesonly_job(
     job_name = 'MakeSitesOnlyVcf'
     job_attrs = (job_attrs or {}) | {'tool': 'gatk MakeSitesOnlyVcf'}
     j = b.new_job(job_name, job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', '4.2.6.1-1'))
     res = STANDARD.set_resources(j, ncpu=2)
     if storage_gb:
         j.storage(f'{storage_gb}G')

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -43,7 +43,7 @@ def create_vep_job_and_mount_data(job_number: int = 1) -> tuple[BashJob, Path]:
     vep_job.declare_resource_group(vcf={VCF_BGZ_SUFFIX: '{root}.vcf.bgz', VCF_BGZ_TBI_SUFFIX: '{root}.vcf.bgz.tbi'})
 
     # configure the required resources
-    vep_job.image(image_path('vep_110')).cpu(4).memory('highmem')
+    vep_job.image(image_path('vep', '110.1-1')).cpu(4).memory('highmem')
 
     # gcsfuse works only with the root bucket, without prefix:
     vep_mount_path = to_path(reference_path('vep_110_mount'))

--- a/cpg_workflows/jobs/simple_vep_annotation.py
+++ b/cpg_workflows/jobs/simple_vep_annotation.py
@@ -76,7 +76,7 @@ def split_vcf_by_chromosome(
     bcftools_job = get_batch().new_bash_job('Subset VCF with bcftools')
 
     # set some resources
-    bcftools_job.image(image_path('bcftools')).cpu(1).memory('8G')
+    bcftools_job.image(image_path('bcftools', '1.16-1')).cpu(1).memory('8G')
 
     # only attach further storage if requested
     if storage:

--- a/cpg_workflows/jobs/somalier.py
+++ b/cpg_workflows/jobs/somalier.py
@@ -176,7 +176,7 @@ def _relate(
         title += f' [{label}]'
 
     j = b.new_job(title, (job_attrs or {}) | dict(tool='somalier'))
-    j.image(image_path('somalier'))
+    j.image(image_path('somalier', '0.2.15-1'))
     # Size of one somalier file is 212K, so we add another G only if the number of
     # sequencing groups is >4k
     STANDARD.set_resources(j, storage_gb=1 + len(sequencing_group_ids) // 4000 * 1)
@@ -251,7 +251,7 @@ def extract(
     job_attrs = (job_attrs or {}) | {'tool': 'somalier'}
     j = b.new_job('Somalier extract' + (f' {label}' if label else ''), job_attrs)
 
-    j.image(image_path('somalier'))
+    j.image(image_path('somalier', '0.2.15-1'))
     if not cram_path.index_path:
         raise ValueError(f'CRAM for somalier is required to have CRAI index ({cram_path})')
     storage_gb = None  # avoid extra disk by default

--- a/cpg_workflows/jobs/stripy.py
+++ b/cpg_workflows/jobs/stripy.py
@@ -42,7 +42,7 @@ def stripy(
 
     job_attrs = (job_attrs or {}) | {'tool': 'stripy'}
     j = b.new_job('STRipy', job_attrs)
-    j.image(image_path('stripy'))
+    j.image(image_path('stripy', '2.5-1'))
 
     config_path = 'config.json'
     if stripy_config:

--- a/cpg_workflows/jobs/trim.py
+++ b/cpg_workflows/jobs/trim.py
@@ -202,7 +202,7 @@ def trim(
     trim_j_name = base_job_name
     trim_j_attrs = (job_attrs or {}) | dict(label=base_job_name, tool=trim_tool)
     trim_j = b.new_job(trim_j_name, trim_j_attrs)
-    trim_j.image(image_path('fastp'))
+    trim_j.image(image_path('fastp', '0.23.4-1'))
 
     # Set resource requirements
     nthreads = requested_nthreads or 8

--- a/cpg_workflows/jobs/validation.py
+++ b/cpg_workflows/jobs/validation.py
@@ -42,7 +42,7 @@ def run_happy_on_vcf(
     """
 
     happy_j = get_batch().new_job(f'Run Happy on {sample_ext_id} VCF')
-    happy_j.image(image_path('hap-py')).memory('100Gi').storage('100Gi').cpu(4)
+    happy_j.image(image_path('hap-py', '0.3.15-1')).memory('100Gi').storage('100Gi').cpu(4)
 
     # region: read input data into batch
     vcf_input = get_batch().read_input_group(vcf=vcf_path, index=f'{vcf_path}.tbi')

--- a/cpg_workflows/jobs/vep.py
+++ b/cpg_workflows/jobs/vep.py
@@ -141,7 +141,7 @@ def vep_one(
         raise IndexError('No VEP version specified in config.workflow.vep_version')
 
     # check that the cache and image for this version exist
-    vep_image = image_path(f'vep_{vep_version}')
+    vep_image = image_path('vep', config_retrieve(['workflow', 'vep_image']))
     vep_mount_path = to_path(reference_path(f'vep_{vep_version}_mount'))
     assert all([vep_image, vep_mount_path])
 

--- a/cpg_workflows/jobs/verifybamid.py
+++ b/cpg_workflows/jobs/verifybamid.py
@@ -31,7 +31,7 @@ def verifybamid(
 
     job_attrs = (job_attrs or {}) | {'tool': 'VerifyBamID'}
     j = b.new_job('VerifyBamID', job_attrs)
-    j.image(image_path('verifybamid'))
+    j.image(image_path('verifybamid', '2.0.1-1'))
     res = STANDARD.request_resources(ncpu=4)
     res.attach_disk_storage_gb = storage_for_cram_qc_job()
     res.set_to_job(j)

--- a/cpg_workflows/jobs/vqsr.py
+++ b/cpg_workflows/jobs/vqsr.py
@@ -79,6 +79,9 @@ INDEL_RECALIBRATION_TRANCHE_VALUES = [
     90.0,
 ]
 
+BCFTOOLS_VERSION = '1.16-1'
+GATK_VERSION = '4.2.6.1-1'
+
 
 def make_vqsr_jobs(
     b: hb.Batch,
@@ -347,7 +350,7 @@ def add_tabix_job(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'tabix'}
     j = b.new_job('VQSR: Tabix', job_attrs)
-    j.image(image_path('bcftools'))
+    j.image(image_path('bcftools', BCFTOOLS_VERSION))
     STANDARD.set_resources(j, mem_gb=8, storage_gb=disk_size)
     j.declare_resource_group(output_vcf={'vcf.gz': '{root}.vcf.gz', 'vcf.gz.tbi': '{root}.vcf.gz.tbi'})
     vcf_inp = b.read_input(str(vcf_path))
@@ -388,7 +391,7 @@ def indel_recalibrator_job(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk VariantRecalibrator'}
     j = b.new_job('VQSR: IndelsVariantRecalibrator', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     # We run it for the entire dataset in one job, so can take an entire instance.
     instance_fraction = 1
@@ -465,7 +468,7 @@ def snps_recalibrator_create_model_job(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk VariantRecalibrator'}
     j = b.new_job('VQSR: SNPsVariantRecalibratorCreateModel', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     # We run it for the entire dataset in one job, so can take an entire instance.
     instance_fraction = 1
@@ -545,7 +548,7 @@ def snps_recalibrator_scattered(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk VariantRecalibrator'}
     j = b.new_job('VQSR: SNPsVariantRecalibratorScattered', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     if is_small_callset:
         res = STANDARD.set_resources(j, ncpu=4, storage_gb=disk_size)
@@ -604,7 +607,7 @@ def snps_recalibrator_job(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk VariantRecalibrator'}
     j = b.new_job('VQSR: SNPsVariantRecalibrator', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
 
     # We run it for the entire dataset in one job, so can take an entire instance.
     instance_fraction = 1
@@ -670,7 +673,7 @@ def snps_gather_tranches_job(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk GatherTranches'}
     j = b.new_job('VQSR: SNPGatherTranches', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
     res = STANDARD.set_resources(j, ncpu=2, storage_gb=disk_size)
 
     inputs_cmdl = ' '.join([f'--input {t}' for t in tranches])
@@ -718,7 +721,7 @@ def apply_recalibration_snps(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk ApplyVQSR'}
     j = b.new_job('VQSR: ApplyVQSR SNPs', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
     res = STANDARD.set_resources(j, ncpu=2, storage_gb=disk_size)
 
     cmd = f"""
@@ -777,7 +780,7 @@ def apply_recalibration_indels(
     """
     job_attrs = (job_attrs or {}) | {'tool': 'gatk ApplyVQSR'}
     j = b.new_job('VQSR: ApplyVQSR INDEL', job_attrs)
-    j.image(image_path('gatk'))
+    j.image(image_path('gatk', GATK_VERSION))
     res = STANDARD.set_resources(j, ncpu=2, storage_gb=disk_size)
 
     j.declare_resource_group(

--- a/cpg_workflows/scripts/gvcfs_to_vcf.py
+++ b/cpg_workflows/scripts/gvcfs_to_vcf.py
@@ -106,7 +106,7 @@ def squash_fragments_to_vcf(vcf_fragment_dir: str, vcf_out: str):
     input_vcf = get_batch().read_input(manifest_paths[0])
     final_job = get_batch().new_bash_job(name='index_final_vcf')
     final_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-    final_job.image(image_path('bcftools'))
+    final_job.image(image_path('bcftools', '1.16-1'))
     final_job.storage('10Gi')  # make this configurable
     final_job.command(f'mv {input_vcf} {final_job.output["vcf.bgz"]} && tabix {final_job.output["vcf.bgz"]}')
     get_batch().write_output(final_job.output, vcf_out.removesuffix('.vcf.bgz'))

--- a/cpg_workflows/stages/clinvarbitration.py
+++ b/cpg_workflows/stages/clinvarbitration.py
@@ -75,7 +75,7 @@ class GenerateNewClinvarSummary(MultiCohortStage):
     def queue_jobs(self, mc: MultiCohort, inputs: StageInput) -> StageOutput:
         # relatively RAM intensive, short running task
         clinvarbitrate = get_batch().new_job('Run ClinvArbitration Summary')
-        clinvarbitrate.image(image_path('clinvarbitration')).memory('highmem').cpu('2')
+        clinvarbitrate.image(image_path('clinvarbitration', '1.5.1-1')).memory('highmem').cpu('2')
         authenticate_cloud_credentials_in_job(clinvarbitrate)
 
         # declare a resource group, leave the HT path implicit
@@ -146,7 +146,7 @@ class PM5TableGeneration(MultiCohortStage):
 
         # declare a resouce group, but don't copy the whole thing back
         clinvarbitrate_pm5 = get_batch().new_job('Run ClinvArbitration PM5')
-        clinvarbitrate_pm5.image(image_path('clinvarbitration'))
+        clinvarbitrate_pm5.image(image_path('clinvarbitration', '1.5.1-1'))
         authenticate_cloud_credentials_in_job(clinvarbitrate_pm5)
 
         # get the expected outputs

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -350,7 +350,7 @@ def queue_annotate_strvctvre_job(
     job_attrs = job_attrs or {}
     strv_job = get_batch().new_job('StrVCTVRE', job_attrs | {'tool': 'strvctvre'})
 
-    strv_job.image(image_path('strvctvre'))
+    strv_job.image(image_path('strvctvre', '1.10-1'))
     strv_job.storage(config_retrieve(['resource_overrides', name, 'storage'], '10Gi'))
     strv_job.memory(config_retrieve(['resource_overrides', name, 'memory'], '16Gi'))
 

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1166,7 +1166,7 @@ class FilterWham(MultiCohortStage):
 
         in_vcf = get_batch().read_input_group(**{'vcf.gz': input_vcf, 'vcf.gz.tbi': f'{input_vcf}.tbi'})['vcf.gz']
         job = get_batch().new_job('Filter Wham', attributes={'tool': 'bcftools'})
-        job.image(image_path('bcftools')).cpu(1).memory('highmem').storage('20Gi')
+        job.image(image_path('bcftools', '1.16-1')).cpu(1).memory('highmem').storage('20Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         job.command(
             'bcftools view -e \'SVTYPE=="DEL" && COUNT(ALGORITHMS)==1 && ALGORITHMS=="wham"\' '
@@ -1270,7 +1270,7 @@ class SpiceUpSVIDs(MultiCohortStage):
 
         # then compress & run tabix on that plain text result
         bcftools_job = get_batch().new_job('bgzip and tabix')
-        bcftools_job.image(image_path('bcftools'))
+        bcftools_job.image(image_path('bcftools', '1.16-1'))
         bcftools_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
         bcftools_job.command(f'bcftools view {pyjob.output} | bgzip -c > {bcftools_job.output["vcf.bgz"]}')
         bcftools_job.command(f'tabix {bcftools_job.output["vcf.bgz"]}')  # type: ignore

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1449,7 +1449,7 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
             name=f'SplitAnnotatedSvVcfByDataset: {dataset}',
             attributes=self.get_job_attrs() | {'tool': 'bcftools'},
         )
-        job.image(image_path('bcftools_120'))
+        job.image(image_path('bcftools', '1.20-1'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
 

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -586,7 +586,7 @@ class AnnotateCNVVcfWithStrvctvre(MultiCohortStage):
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
         strv_job = get_batch().new_job('StrVCTVRE', self.get_job_attrs() | {'tool': 'strvctvre'})
 
-        strv_job.image(image_path('strvctvre'))
+        strv_job.image(image_path('strvctvre', '1.10-1'))
         strv_job.cpu(config_retrieve(['strvctvre_resources', 'cpu'], 2))
         strv_job.memory(config_retrieve(['strvctvre_resources', 'memory'], '20Gi'))
         strv_job.storage(config_retrieve(['strvctvre_resources', 'storage'], '20Gi'))

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -782,7 +782,7 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
             name=f'SplitAnnotatedCnvVcfByDataset: {dataset}',
             attributes=self.get_job_attrs() | {'tool': 'bcftools'},
         )
-        job.image(image_path('bcftools_120'))
+        job.image(image_path('bcftools', '1.20-1'))
         job.cpu(1).memory('highmem').storage('10Gi')
         job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
 

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -414,7 +414,7 @@ class Vqsr(CohortStage):
 
         reheader_job.depends_on(*jobs)
 
-        reheader_job.image(image_path('bcftools'))
+        reheader_job.image(image_path('bcftools', '1.16-1'))
         reheader_job.storage(config_retrieve(['vqsr_reheader', 'storage'], default='16Gi'))
 
         vqsr_vcf = b.read_input(outputs['vcf'])

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
@@ -326,7 +326,7 @@ class MergeLongReadSNPsIndels(MultiCohortStage):
         ]
 
         merge_job = get_batch().new_job('Merge Long-Read SNPs Indels calls', attributes={'tool': 'bcftools'})
-        merge_job.image(image=image_path(config_retrieve(['workflow', 'merge_vcfs', 'bcftools_image'], 'bcftools_121')))
+        merge_job.image(image_path('bcftools', config_retrieve(['workflow', 'merge_vcfs', 'bcftools_image'], '1.21-1')))
 
         # guessing at resource requirements
         merge_job.cpu(config_retrieve(['resource_overrides', 'merge_vcfs', 'ncpu'], 4))

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
@@ -275,7 +275,7 @@ class ReFormatPacBioSNPsIndels(SequencingGroupStage):
             {'tool': 'bcftools'},
         )
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-        tabix_job.image(image=image_path('bcftools'))
+        tabix_job.image(image=image_path('bcftools', '1.16-1'))
         tabix_job.storage('10Gi')
         tabix_job.command(
             f'bcftools view -Ov {local_vcf} | bcftools reheader --samples {local_id_mapping} -o {tabix_job.reheadered}',

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -286,7 +286,7 @@ class MergeLongReadSVs(MultiCohortStage):
         ]
 
         merge_job = get_batch().new_job('Merge Long-Read SV calls', attributes={'tool': 'bcftools'})
-        merge_job.image(image=image_path('bcftools_120'))
+        merge_job.image(image=image_path('bcftools', '1.20-1'))
 
         # guessing at resource requirements
         merge_job.cpu(4)

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_sv_annotation.py
@@ -238,7 +238,7 @@ class ReFormatPacBioSVs(SequencingGroupStage):
             {'tool': 'bcftools'},
         )
         tabix_job.declare_resource_group(vcf_out={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
-        tabix_job.image(image=image_path('bcftools'))
+        tabix_job.image(image=image_path('bcftools', '1.16-1'))
         tabix_job.storage('10Gi')
         tabix_job.command(
             f'bcftools view -Ov {mod_job.output} | bcftools reheader --samples {local_id_mapping} -o {tabix_job.reheadered}',

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -188,7 +188,7 @@ class AnnotateGnomadFrequenciesWithEchtvar(DatasetStage):
         gnomad_annotations = get_batch().read_input(config_retrieve(['annotations', 'echtvar_gnomad']))
 
         job = get_batch().new_job(f'AnnotateGnomadFrequenciesWithEchtvar: {dataset.name}')
-        job.image(image_path('echtvar'))
+        job.image(image_path('echtvar', '0.2.1-1'))
         job.command(f'echtvar anno -e {gnomad_annotations} {sites_vcf} {job.output}')
         job.storage('20Gi')
         job.memory('highmem')

--- a/cpg_workflows/stages/talos_prep/talos_prep.py
+++ b/cpg_workflows/stages/talos_prep/talos_prep.py
@@ -230,7 +230,7 @@ class AnnotateConsequenceWithBcftools(DatasetStage):
         fasta = get_batch().read_input(reference_path('broad/ref_fasta'))
 
         job = get_batch().new_job(f'AnnotateConsequenceWithBcftools: {dataset.name}')
-        job.image(image_path('bcftools_120'))
+        job.image(image_path('bcftools', '1.20-1'))
         job.cpu(4)
         job.storage('20G')
 

--- a/scripts/create_index_files.py
+++ b/scripts/create_index_files.py
@@ -51,7 +51,7 @@ def index_with_samtools(
     for file_to_index_path, index_file_path in input_files:
         input_file = b.read_input(file_to_index_path)
         j = b.new_bash_job(f'samtools index {file_to_index_path}')
-        j.image(image_path('samtools'))
+        j.image(image_path('samtools', '1.18-1'))
         # Set resource requirements
         storage_gb = 20 if to_path(file_to_index_path).stat().st_size < 1e10 else 100
         nthreads = 8

--- a/scripts/fix_sq_headers.py
+++ b/scripts/fix_sq_headers.py
@@ -278,7 +278,7 @@ def main(
 
     for path, newpath, filesize in reheader_list:
         j = b.new_python_job(f'Reheader {path}')
-        j.image(image_path('samtools'))
+        j.image(image_path('samtools', '1.18-1'))
         j.storage(filesize * 1.2)  # Allow some extra space for index file, references, etc
 
         j_result = j.call(

--- a/scripts/vep_backend/vep_110_conf.toml
+++ b/scripts/vep_backend/vep_110_conf.toml
@@ -1,5 +1,6 @@
 [workflow]
 sequencing_type = 'genome'
+vep_image = '110.1-1'
 vep_version = '110'
 
 [vep]

--- a/scripts/vep_backend/vep_batch_backend.py
+++ b/scripts/vep_backend/vep_batch_backend.py
@@ -31,8 +31,8 @@ def main(vcf_path: str, output_ht: str, to_mt: bool = False):
     Input: the full path to a VCF file, along with a tabix (.tbi) file,
     located in the same directory.
     """
-    vep_version = get_config()['workflow']['vep_version']
-    vep_image = image_path(f'vep_{vep_version}')
+    vep_image_version = get_config()['workflow']['vep_image']
+    vep_image = image_path('vep', vep_image_version)
     scatter_count = get_config()['vep']['scatter_count']
     b = get_batch(f'Run VEP with Batch Backend, image {vep_image}, scatter count {scatter_count}')
     vep_ht = output_path(output_ht)

--- a/scripts/vep_backend/vep_config.toml
+++ b/scripts/vep_backend/vep_config.toml
@@ -1,9 +1,7 @@
 [workflow]
 sequencing_type = 'genome'
+vep_image = '105.0-1'
 vep_version = '105'
 
 [vep]
 scatter_count = 1
-
-[images]
-vep_105 = "australia-southeast1-docker.pkg.dev/cpg-common/images/vep:105.0"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'cpg-utils>=5.1.1',
+        'cpg-utils>=5.3.0',
         'cyvcf2==0.30.18',
         'analysis-runner>=2.43.3',
         'hail>=0.2.133',

--- a/test/jobs/somalier/test_extract.py
+++ b/test/jobs/somalier/test_extract.py
@@ -22,7 +22,7 @@ def default_config() -> PipelineConfig:
             check_inputs=False,
         ),
         images={
-            'somalier': 'test_image',
+            'somalier': 'test_image/somalier@version',
             'cpg_workflows': 'test_image',
         },
         other={
@@ -131,7 +131,7 @@ class TestSomalierExtract:
         )
 
         assert j is not None
-        assert j._image == config.images['somalier']
+        assert "/somalier@" in j._image
 
     def test_sets_sites_location_with_name_of_sites_file_in_config(self, tmp_path: Path):
         config, cram_pth, batch = setup_test(tmp_path)

--- a/test/jobs/somalier/test_relate.py
+++ b/test/jobs/somalier/test_relate.py
@@ -22,7 +22,7 @@ def default_config() -> PipelineConfig:
             check_inputs=False,
         ),
         images={
-            'somalier': 'test_image',
+            'somalier': 'test_image/somalier@version',
             'cpg_workflows': 'test_image',
         },
         other={
@@ -146,7 +146,7 @@ class TestSomalierRelate:
         relate_j = pedigree_jobs[0]
 
         assert relate_j is not None
-        assert relate_j._image == config.images['somalier']
+        assert "/somalier@" in relate_j._image
 
     def test_if_verifybamid_exists_for_sg_check_freemix(self, tmp_path: Path):
         _, batch, somalier_path_by_sgid, dataset = setup_pedigree_test(tmp_path)

--- a/test/jobs/test_align/test_bam_cram.py
+++ b/test/jobs/test_align/test_bam_cram.py
@@ -397,7 +397,13 @@ class TestDragmap:
 
 class TestBwaAndBw2:
     @pytest.mark.parametrize('input_type', ['bam', 'cram'])
-    @pytest.mark.parametrize('alinger, expected_tool', [(Aligner.BWA, 'bwa'), (Aligner.BWAMEM2, 'bwa-mem2')])
+    @pytest.mark.parametrize(
+        'aligner,expected_tool',
+        [
+            (Aligner.BWA, 'bwa'),
+            # (Aligner.BWAMEM2, 'bwa-mem2'),  # Don't test bwa-mem2 as we have no image for it
+        ],
+    )
     @pytest.mark.parametrize(
         'reference,expected_reference',
         [
@@ -412,7 +418,7 @@ class TestBwaAndBw2:
         input_type: str,
         reference: dict[str, str | None],
         expected_reference: str,
-        alinger: Aligner,
+        aligner: Aligner,
         expected_tool: str,
     ):
         """
@@ -425,7 +431,7 @@ class TestBwaAndBw2:
         config.references['broad']['ref_fasta'] = reference['broad']
         batch, sg = setup_test(config, tmp_path, alignment_input=input_type)
 
-        jobs = align(b=batch, sequencing_group=sg, aligner=alinger)
+        jobs = align(b=batch, sequencing_group=sg, aligner=aligner)
         align_jobs = select_jobs(jobs, 'align')
         assert len(align_jobs) == 10
 

--- a/test/jobs/test_align/test_fastq.py
+++ b/test/jobs/test_align/test_fastq.py
@@ -169,8 +169,11 @@ class TestDragmap:
 
 class TestBwaAndBwa2:
     @pytest.mark.parametrize(
-        'alinger,expected_tool',
-        [(Aligner.BWA, 'bwa'), (Aligner.BWAMEM2, 'bwa-mem2')],
+        'aligner,expected_tool',
+        [
+            (Aligner.BWA, 'bwa'),
+            # (Aligner.BWAMEM2, 'bwa-mem2'),  # Don't test bwa-mem2 as we have no image for it
+        ],
     )
     @pytest.mark.parametrize(
         'reference,expected_reference',
@@ -183,7 +186,7 @@ class TestBwaAndBwa2:
     def test_using_bwa_generates_alignment_correct_command(
         self,
         tmp_path: Path,
-        alinger: Aligner,
+        aligner: Aligner,
         expected_tool: str,
         reference: dict[str, str | None],
         expected_reference: str,
@@ -193,7 +196,7 @@ class TestBwaAndBwa2:
         config.references['broad']['ref_fasta'] = reference['broad']
         batch, sg = setup_test(config, tmp_path, num_pairs=2)
 
-        jobs = align(b=batch, sequencing_group=sg, aligner=alinger)
+        jobs = align(b=batch, sequencing_group=sg, aligner=aligner)
         align_jobs = select_jobs(jobs, 'align')
         assert len(align_jobs) == 2
 

--- a/test/jobs/test_samtools.py
+++ b/test/jobs/test_samtools.py
@@ -22,7 +22,7 @@ def default_config() -> PipelineConfig:
             check_inputs=False,
         ),
         images={
-            'samtools': 'test_image',
+            'samtools': 'test_image/samtools@version',
         },
         references={
             'broad': {
@@ -123,7 +123,7 @@ class TestSamtoolsStatsRun:
         )
 
         assert j is not None
-        assert j._image == config.images['samtools']
+        assert '/samtools@' in j._image
 
     def test_uses_reference_in_workflow_config_section_if_set(self, tmp_path: Path):
         config = default_config()

--- a/test/jobs/test_verifybamid.py
+++ b/test/jobs/test_verifybamid.py
@@ -23,7 +23,7 @@ def default_config() -> PipelineConfig:
             check_inputs=False,
         ),
         images={
-            'verifybamid': 'test_image',
+            'verifybamid': 'test_image/verifybamid@version',
         },
         references={
             'broad': {
@@ -129,7 +129,7 @@ class TestVerifyBAMID:
         )
 
         assert j is not None
-        assert j._image == config.images['verifybamid']
+        assert '/verifybamid@' in j._image
 
     def test_uses_num_principal_components_in_config_file_in_bash_command(self, tmp_path: Path):
         config, cram_pth, batch = setup_test(tmp_path)


### PR DESCRIPTION
Add version arguments corresponding to each current latest image in our Artifact Registry. Where a source file uses an image repeatedly, abstract into a `FOO_VERSION` variable per-source-file.

(Our repository has no `bwamem2` image. Use 2.2.1 which was the current version when the relevant _align.py_ code was added and which still is.)

There are a few more instances still to do, mostly for **cpg_workflows** which is nontrivial as the desired version is probably “today's version” which moves regularly. Is there an equivalent in the cpg_flow new world order? If not, perhaps we can just leave these ones as single-argument `image_path()`.

This PR uses the `VERSION-1`, `VERSION-2`, etc style tags as per the images revamp, with a suffix indicating changes in CPG's packaging of the tool. Additional tags for many images in the artifact registry were added on June 4th by running this [_create-extra-tags.sh_ script](https://github.com/user-attachments/files/22035202/create-extra-tags.sh.txt), which added initial `x.y-1` tags to existing images using commands such as

```
gcloud artifacts docker tags add    \
    australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.16    \
    australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.16-1
```

Using these `x.y-1` tags pulls exactly the same images as the existing `x.y` tags.