### PR TITLE
Set job dirname to truncated version

### DIFF
--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -805,6 +805,7 @@ class ExportMtAsEsIndex(DatasetStage):
         flag_name = str(outputs['done_flag'])
 
         job = get_batch().new_bash_job(f'Generate {index_name} from {mt_path}')
+        job._dirname = f'{index_name}-{job._token}'
         if config_retrieve(['workflow', 'es_index', 'spot_instance'], default=True) is False:
             # Use a non-preemptible instance if spot_instance is False in the config
             job = job.spot(is_spot=False)


### PR DESCRIPTION
Hotfix for the `rd_combiner` workflow `ExportMtAsEsIndex` stage. 

This change sets the job directory name to a truncated version of the job name through the `job._dirname` attribute for the job submitted by this stage.

Reason being - for some indexes, the job name, which is re-used as the disk dirname, becomes too long and we encounter a filesystem error. 

See https://centrepopgen.slack.com/archives/C030X7WGFCL/p1746665311772719