### PR TITLE
Stripy config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.25
+current_version = 1.36.26
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.25
+  VERSION: 1.36.26
 
 jobs:
   docker:

--- a/cpg_workflows/defaults.toml
+++ b/cpg_workflows/defaults.toml
@@ -159,6 +159,13 @@ STARD7,TBP,TBX1,TCF4,TNRC6A,VWA1,XYLT1,YEATS2,ZFHX3,ZIC2,ZIC3"""
 custom_loci_path = ""
 # Change the path the stripy report is saved to, useful when testing novel loci
 output_prefix = "stripy"
+# Update the stripy config.json file, default found here:
+# https://gitlab.com/andreassh/stripy-pipeline/-/blob/main/config.json?ref_type=heads
+[stripy.config]
+log_flag_threshold = -1
+output_json = true
+verbose = true
+
 
 # Add in specific multiQC report config options
 # See https://multiqc.info/docs/getting_started/config for more details

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -7,7 +7,7 @@ See https://gitlab.com/andreassh/stripy-pipeline
 from typing import Any
 
 from cpg_utils import Path
-from cpg_utils.config import config_retrieve, get_config
+from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import get_batch
 from cpg_workflows.filetypes import CramPath
 from cpg_workflows.jobs import stripy
@@ -82,12 +82,13 @@ class Stripy(SequencingGroupStage):
             b=get_batch(),
             sequencing_group=sequencing_group,
             cram_path=CramPath(cram_path, crai_path),
-            target_loci=get_config()['stripy']['target_loci'],
+            target_loci=config_retrieve(['stripy', 'target_loci']),
+            custom_loci_path=config_retrieve(['stripy', 'custom_loci_path']),
+            analysis_type=config_retrieve(['stripy', 'analysis_type']),
+            stripy_config=config_retrieve(['stripy', 'config']),
             log_path=self.expected_outputs(sequencing_group)['stripy_log'],
-            analysis_type=get_config()['stripy']['analysis_type'],
             out_path=self.expected_outputs(sequencing_group)['stripy_html'],
             json_path=self.expected_outputs(sequencing_group)['stripy_json'],
-            custom_loci_path=get_config()['stripy']['custom_loci_path'],
             job_attrs=self.get_job_attrs(sequencing_group),
         )
         jobs.append(j)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.25',
+    version='1.36.26',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a new argument to the stripy stage and job, `stripy_config`. This is a dict that can be modified when invoking the workflow via analysis-runner, and is used to update the `config.json` file that is pulled with the stripy image (see https://gitlab.com/andreassh/stripy-pipeline/-/blob/main/config.json?ref_type=heads)

Defaults have been added to the `defaults.toml` that replace the use of `sed` to modify the json file, which was done in the job as a quick and dirty method of updating. 

This change will allow us to completely customise the stripy config.json through the config toml used in the analysis-runner submission. 

e.g. If we want to limit the number of nucleotides extracted before and after a locus, we can set the config as
```toml
[stripy.config]
fregion_length_bp = 60
```
