### PR TITLE
Fix sparkDriver initialisation failure that's breaking all tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,8 +28,10 @@ jobs:
       - name: Run unit tests
         id: runtests
         timeout-minutes: 20
+        env:
+          PYTHONPATH: ${{ github.workspace }}/gnomad_methods:${{ github.workspace }}/seqr-loading-pipelines
+          SPARK_LOCAL_IP: localhost
         run: |
-          PYTHONPATH=$PWD/gnomad_methods:$PWD/seqr-loading-pipelines \
           coverage run -m pytest -n auto test --junitxml=test-execution.xml
 
           rc=$?


### PR DESCRIPTION
Currently all tests are failing (see e.g. PR #1210's [test run](https://github.com/populationgenomics/production-pipelines/actions/runs/15008044673/job/42171333047)):

```
E  py4j.protocol.Py4JJavaError: An error occurred while calling z:is.hail.backend.spark.SparkBackend.apply.
E  : java.net.BindException: Cannot assign requested address: Service 'sparkDriver' failed after
   16 retries (on a random free port)! Consider explicitly setting the appropriate binding address
   for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the
   correct binding address.
E 	at java.base/sun.nio.ch.Net.bind0(Native Method)
E 	at java.base/sun.nio.ch.Net.bind(Net.java:555)
```

I don't know why this has started failing now or really understand what's going on here, but `SPARK_LOCAL_IP` is the environment variable equivalent of `spark.driver.bindAddress` and the Internet recommends setting it to `localhost` to avoid encountering this error due to vagaries of GH Actions runners' virtual network interface set up. 🤷 