### PR TITLE
Prepend global variants with sequencing type

### DIFF
--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -386,6 +386,10 @@ def prepare_gnomad_v4_variants_helper(ds_path: str | None, exome_or_genome: str)
     ds = ds.select('variant_id', 'rsids', 'summary')
     ds = ds.rename({'summary': exome_or_genome})
 
+    globals_dict = ds.globals.collect()[0]
+    ds = ds.select_globals()
+    ds = ds.annotate_globals(**{f"{exome_or_genome}_{k}": v for k, v in globals_dict.items()})
+
     return ds
 
 


### PR DESCRIPTION
Prepend all global variables in the variants table with 'exome_' or 'genome_' as appropriate.