### PR TITLE
Cohort level crammultiqc

### DIFF
--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -16,9 +16,10 @@ from cpg_workflows.jobs.picard import picard_collect_metrics, picard_hs_metrics,
 from cpg_workflows.jobs.samtools import samtools_stats
 from cpg_workflows.jobs.verifybamid import verifybamid
 from cpg_workflows.stages.align import Align
-from cpg_workflows.targets import Dataset, SequencingGroup
+from cpg_workflows.targets import Cohort, Dataset, SequencingGroup
 from cpg_workflows.utils import exists
 from cpg_workflows.workflow import (
+    CohortStage,
     DatasetStage,
     SequencingGroupStage,
     StageInput,
@@ -305,3 +306,100 @@ class CramMultiQC(DatasetStage):
             extra_config=extra_config,
         )
         return self.make_outputs(dataset, data=self.expected_outputs(dataset), jobs=jobs)
+
+
+@stage(required_stages=[CramQC, SomalierPedigree], analysis_type='qc', analysis_keys=['json'])
+class CohortCramMultiQC(CohortStage):
+    """
+    Run MultiQC to aggregate CRAM QC stats across a Cohort, rather than a Dataset.
+    """
+
+    def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
+        """
+        Expected to produce an HTML and a corresponding JSON file.
+        """
+        if config_retrieve(['workflow', 'skip_qc'], False):
+            return {}
+
+        # get the unique hash for these Sequencing Groups
+        sg_hash = cohort.get_alignment_inputs_hash()
+        return {
+            'html': cohort.analysis_dataset.web_prefix() / 'qc' / 'cram' / sg_hash / 'multiqc.html',
+            'json': cohort.analysis_dataset.prefix() / 'qc' / 'cram' / sg_hash / 'multiqc_data.json',
+            'checks': cohort.analysis_dataset.prefix() / 'qc' / 'cram' / sg_hash / '.checks',
+        }
+
+    def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
+        """
+        Call a function from the `jobs` module using inputs from `cramqc`
+        and `somalier` stages.
+        """
+        if config_retrieve(['workflow', 'skip_qc'], False):
+            return self.make_outputs(cohort)
+
+        json_path = self.expected_outputs(cohort)['json']
+        html_path = self.expected_outputs(cohort)['html']
+        checks_path = self.expected_outputs(cohort)['checks']
+        if base_url := cohort.analysis_dataset.web_url():
+            html_url = str(html_path).replace(str(cohort.analysis_dataset.web_prefix()), base_url)
+        else:
+            html_url = None
+
+        paths = []
+        try:
+            somalier_samples = inputs.as_path(cohort, SomalierPedigree, key='samples')
+            somalier_pairs = inputs.as_path(cohort, SomalierPedigree, key='pairs')
+        except StageInputNotFoundError:
+            pass
+        else:
+            paths = [
+                somalier_samples,
+                somalier_pairs,
+            ]
+
+        ending_to_trim = set()  # endings to trim to get sample names
+        modules_to_trim_endings = set()
+
+        for sequencing_group in cohort.get_sequencing_groups():
+            for qc in qc_functions():
+                for key, out in qc.outs.items():
+                    if not out:
+                        continue
+                    try:
+                        path = inputs.as_path(sequencing_group, CramQC, key)
+                    except StageInputNotFoundError:  # allow missing inputs
+                        logging.warning(
+                            f'Output CramQc/"{key}" not found for {sequencing_group}, '
+                            f'it will be silently excluded from MultiQC',
+                        )
+                        continue
+                    modules_to_trim_endings.add(out.multiqc_key)
+                    paths.append(path)
+                    ending_to_trim.add(path.name.replace(sequencing_group.id, ''))
+
+        if not paths:
+            logging.warning('No CRAM QC found to aggregate with MultiQC')
+            return self.make_outputs(cohort)
+
+        send_to_slack = config_retrieve(['workflow', 'cram_multiqc', 'send_to_slack'], default=True)
+        extra_config = config_retrieve(['workflow', 'cram_multiqc', 'extra_config'], default={})
+        extra_config['table_columns_visible'] = {'FastQC': False}
+
+        jobs = multiqc(
+            get_batch(),
+            tmp_prefix=cohort.analysis_dataset.tmp_prefix() / 'multiqc' / 'cram',
+            paths=paths,
+            ending_to_trim=ending_to_trim,
+            modules_to_trim_endings=modules_to_trim_endings,
+            dataset=cohort.analysis_dataset,
+            out_json_path=json_path,
+            out_html_path=html_path,
+            out_html_url=html_url,
+            out_checks_path=checks_path,
+            job_attrs=self.get_job_attrs(cohort),
+            sequencing_group_id_map=cohort.analysis_dataset.rich_id_map(),
+            label='CRAM',
+            send_to_slack=send_to_slack,
+            extra_config=extra_config,
+        )
+        return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=jobs)

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -324,9 +324,9 @@ class CohortCramMultiQC(CohortStage):
         # get the unique hash for these Sequencing Groups
         sg_hash = cohort.get_alignment_inputs_hash()
         return {
-            'html': cohort.analysis_dataset.web_prefix() / 'qc' / 'cram' / sg_hash / 'multiqc.html',
-            'json': cohort.analysis_dataset.prefix() / 'qc' / 'cram' / sg_hash / 'multiqc_data.json',
-            'checks': cohort.analysis_dataset.prefix() / 'qc' / 'cram' / sg_hash / '.checks',
+            'html': cohort.analysis_dataset.web_prefix() / 'qc' / 'cram' / sg_hash / 'cohort_multiqc.html',
+            'json': cohort.analysis_dataset.prefix() / 'qc' / 'cram' / sg_hash / 'cohort_multiqc_data.json',
+            'checks': cohort.analysis_dataset.prefix() / 'qc' / 'cram' / sg_hash / '.cohort_checks',
         }
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from cpg_utils import to_path
 from cpg_utils.config import set_config_paths
 from cpg_workflows import defaults_config_path
 from cpg_workflows.stages.clinvarbitration import PackageForRelease
-from cpg_workflows.stages.cram_qc import CramMultiQC
+from cpg_workflows.stages.cram_qc import CohortCramMultiQC, CramMultiQC
 from cpg_workflows.stages.exomiser import ExomiserSeqrTSV, ExomiserVariantsTSV, RegisterSingleSampleExomiserResults
 from cpg_workflows.stages.fastqc import FastQCMultiQC
 from cpg_workflows.stages.fraser import Fraser
@@ -97,6 +97,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
         AncestryPlots,
         GvcfMultiQC,
         CramMultiQC,
+        CohortCramMultiQC,
     ],
     'prepare_browser_table': [
         PrepareBrowserTable,


### PR DESCRIPTION
Basically a duplicate of the `CramMultiQC` stage, but operates on a cohort instead of a dataset. This lets someone create a single MultiQC report for a cohort than contains sequencing groups from multiple datasets.