### PR TITLE
…

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -462,7 +462,7 @@ class Vqsr(CohortStage):
 
         # sed command to swap Float SB to Integer in-place and allow any length
         reheader_job.command(
-            fr"sed -i 's/<ID=SB,Number=1,Type=Float/<ID=SB,Number=.,Type=Integer/' {reheader_job.ofile}",
+            fr"sed -i 's/<ID=SB,Number=1,Type=Float/<ID=SB,Number=.,Type=String/' {reheader_job.ofile}",
         )
 
         b.write_output(


### PR DESCRIPTION
We had previously changed the SB field so that it could be an integer of any length to avoid Hail VCF parsing errors (https://github.com/populationgenomics/production-pipelines/pull/1205):
```
sed -i 's/<ID=SB,Number=1,Type=Float/<ID=SB,Number=.,Type=Integer/'
```

We are now changing the header of the SB field from a `float` to a `string` (instead of `float` to `integer`) because there are times when the SB field will have decimal points in it which will cause parsing errors.

See [this batch](https://batch.hail.populationgenomics.org.au/batches/595344/jobs/110):
```
hail.utils.java.FatalError: VCFParseError: error while parsing info field 'SB': invalid character '.' in integer literal

Java stack trace:
is.hail.utils.HailException: gs://cpg-tenk10k-main/large_cohort/tenk10k-genome-test-0-2/siteonly.vqsr.vcf.gz:offset 11865428815768: error while parsing line
chr1	125179952	.	A	C	.	VQSRTrancheSNP99.90to100.00+	AC=664;AC_raw=664;AS_FS=63.5801;AS_FilterStatus=VQSRTrancheSNP99.90to100.00+;AS_MQ=15.7442;AS_MQRankSum=-12.546;AS_QD=1.61106;AS_QUALapprox=2422051;AS_ReadPosRankSum=-0.672;AS_SB_TABLE=58156,107351|1167592,189464;AS_SOR=3.64469;AS_VQSLOD=-60.7244;AS_VarDP=1503392;AS_culprit=AS_FS;AS_pab_max=.;DP=1644730;FS=63.5801;MQ=15.7442;MQRankSum=-12.55;QD=1.61106;QUALapprox=2422051;ReadPosRankSum=-0.687;SB=58156,107351,1.16759e+06,189464;SOR=3.64469;VarDP=1503392
```

Changing the header field in the VCF file so that the SB field (see below) is parsed as a string fixes this parsing error:
```
##INFO=<ID=SB,Number=1,Type=Float,Description="Strand Bias">
```
to
```
##INFO=<ID=SB,Number=.,Type=String,Description="Strand Bias">
```