### PR TITLE
Feat: remove SGs from vds

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.25
+current_version = 1.36.26
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.25
+  VERSION: 1.36.26
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -80,6 +80,9 @@ def run(
             vds.write(output_vds_path)
             return
 
+        # we've changed the VDS base, so we need to force a new combiner plan
+        force_new_combiner = True
+
         # 1b. if there are samples to add, write this to a temporary path, set force to true, and then run the combiner
         vds_path = f'{tmp_prefix}/combiner_removal_temp.vds'
         logging.info(f'Writing with removed SGs to {vds_path}')

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -12,9 +12,10 @@ def run(
     genome_build: str,
     save_path: str | None,
     gvcf_paths: list[str] | None = None,
-    vds_paths: list[str] | None = None,
+    vds_path: str | None = None,
     specific_intervals: list[str] | None = None,
     force_new_combiner: bool = False,
+    sgs_to_remove: list[str] | None = None,
 ) -> None:
     """
     Runs the combiner
@@ -26,76 +27,79 @@ def run(
         genome_build (str): GRCh38
         save_path (str | None): where to store the combiner plan, or where to resume from
         gvcf_paths (list[str] | None): list of paths to GVCFs
-        vds_paths (list[str] | None): list of paths to VDSs
+        vds_path (str | None): a single VDS, or None - this is where a combiner can continue on from
         specific_intervals (list[str] | None): list of intervals to use for the combiner, if using non-standard
         force_new_combiner (bool): whether to force a new combiner run, or permit resume from a previous one
+        sgs_to_remove (list[str] | None): list of sample groups to remove from the combiner
     """
     import logging
 
     import hail as hl
-    from hail.vds.combiner.variant_dataset_combiner import VariantDatasetCombiner
 
     from cpg_utils.config import config_retrieve
     from cpg_utils.hail_batch import init_batch
-    from cpg_workflows.batch import override_jar_spec
 
     # set up a quick logger inside the job
     logging.basicConfig(level=logging.INFO)
 
     init_batch(
-        worker_memory=config_retrieve(['combiner', 'worker_memory'], 'highmem'),
-        driver_memory=config_retrieve(['combiner', 'driver_memory'], 'highmem'),
-        driver_cores=config_retrieve(['combiner', 'driver_cores'], 2),
+        worker_memory=config_retrieve(['combiner', 'worker_memory']),
+        driver_memory=config_retrieve(['combiner', 'driver_memory']),
+        driver_cores=config_retrieve(['combiner', 'driver_cores']),
     )
-    if jar_spec := config_retrieve(['workflow', 'jar_spec_revisions', 'combiner'], False):
-        override_jar_spec(jar_spec)
 
     # Load from save, if supplied (log correctly depending on force_new_combiner)
-    if save_path:
-        if force_new_combiner:
-            logging.info(f'Combiner plan {save_path} will be ignored/written new')
-        else:
-            logging.info(f'Resuming combiner plan from {save_path}')
+    if save_path and force_new_combiner:
+        logging.info(f'Combiner plan {save_path} will be ignored/written new')
+    elif save_path:
+        logging.info(f'Resuming combiner plan from {save_path}')
 
     if specific_intervals:
         logging.info(f'Using specific intervals: {specific_intervals}')
         intervals = hl.eval(
             [hl.parse_locus_interval(interval, reference_genome=genome_build) for interval in specific_intervals],
         )
-
     else:
         intervals = None
 
+    # logical steps -
+    # 1. if there are samples to remove, do that first
+    #   a. if there are no samples to add, just remove the samples and write to eventual output path
+    #   b. if there are samples to add, write this to a temporary path, set force to true, and then run the combiner
+    # 2. if there are samples to add, run the combiner with the final path as the output path
+
+    # 1 - do we need to do removal?
+    if vds_path and sgs_to_remove:
+        logging.info(f'Removing sample groups {sgs_to_remove} from {vds_path}')
+        vds = hl.vds.read_vds(vds_path)
+        vds = hl.vds.filter_samples(vds, samples=sgs_to_remove, keep=False, remove_dead_alleles=True)
+
+        # 1a. if there are no samples to add, just remove the samples and write to eventual output path
+        if not gvcf_paths:
+            logging.info(f'Writing to {output_vds_path}')
+            vds.write(output_vds_path)
+            return
+
+        # 1b. if there are samples to add, write this to a temporary path, set force to true, and then run the combiner
+        vds_path = f'{tmp_prefix}/combiner_removal_temp.vds'
+        logging.info(f'Writing with removed SGs to {vds_path}')
+        vds.write(output_vds_path)
+
+    # 2 - do we need to run the combiner?
     combiner = hl.vds.new_combiner(
         output_path=output_vds_path,
         save_path=save_path,
         gvcf_paths=gvcf_paths,
-        vds_paths=vds_paths,
+        vds_paths=[vds_path] if vds_path else None,
         reference_genome=genome_build,
         temp_path=tmp_prefix,
         use_exome_default_intervals=sequencing_type == 'exome',
         use_genome_default_intervals=sequencing_type == 'genome',
         intervals=intervals,
         force=force_new_combiner,
-        # we're defaulting to the protected class attributes here, which looks like a hack...
-        # for branch factor and target records, the argument uses a specific value as a default
-        # so if we don't find an entry in config, we can't pass None to the constructor...
-        # we either access the protected class attributes, hard-code the default on our side,
-        # or have two separate constructors depending on whether we override the default or not
-        branch_factor=config_retrieve(
-            ['combiner', 'branch_factor'],
-            VariantDatasetCombiner._default_branch_factor,
-        ),
-        target_records=config_retrieve(
-            ['combiner', 'target_records'],
-            VariantDatasetCombiner._default_target_records,
-        ),
-        # this argument does default to None, and will be set to the default values within the constructor
-        # so we're happy to pass None, no need to access the protected class attributes
-        gvcf_batch_size=config_retrieve(
-            ['combiner', 'gvcf_batch_size'],
-            None,
-        ),
+        branch_factor=config_retrieve(['combiner', 'branch_factor']),
+        target_records=config_retrieve(['combiner', 'target_records']),
+        gvcf_batch_size=config_retrieve(['combiner', 'gvcf_batch_size']),
     )
 
     combiner.run()

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -188,8 +188,10 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
         outputs = self.expected_outputs(multicohort)
 
-        # create these as empty lists instead of None, they have the same truthiness
+        # we only ever build on top of a single VDS, or start from scratch
         vds_path: str | None = None
+
+        # create these as empty sets
         sg_ids_in_vds: set[str] = set()
         sgs_to_remove: set[str] = set()
 

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -194,7 +194,7 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
         sgs_to_remove: set[str] = set()
 
         # check for a VDS by ID
-        if vds_id := config_retrieve(['workflow', 'use_specific_vds'], False):
+        if vds_id := config_retrieve(['workflow', 'use_specific_vds'], None):
             vds_result_or_none = query_for_specific_vds(vds_id)
             if vds_result_or_none is None:
                 raise ValueError(f'Specified VDS ID {vds_id} not found in Metamist')
@@ -203,7 +203,7 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
             vds_path, sg_ids_in_vds = vds_result_or_none
 
         # check for existing VDS by getting all and fetching latest
-        elif config_retrieve(['workflow', 'check_for_existing_vds'], True):
+        elif config_retrieve(['workflow', 'check_for_existing_vds']):
             get_logger(__file__).info('Checking for existing VDS')
             if existing_vds_analysis_entry := query_for_latest_vds(multicohort.analysis_dataset.name, 'combiner'):
                 vds_path = existing_vds_analysis_entry['output']
@@ -250,13 +250,13 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
         combiner_job = get_batch().new_python_job('CreateVdsFromGvcfsWithHailCombiner', {'stage': self.name})
         combiner_job.image(config_retrieve(['workflow', 'driver_image']))
-        combiner_job.memory(config_retrieve(['combiner', 'driver_memory'], 'highmem'))
+        combiner_job.memory(config_retrieve(['combiner', 'driver_memory']))
         combiner_job.storage(config_retrieve(['combiner', 'driver_storage']))
-        combiner_job.cpu(config_retrieve(['combiner', 'driver_cores'], 2))
+        combiner_job.cpu(config_retrieve(['combiner', 'driver_cores']))
 
         # set this job to be non-spot (i.e. non-preemptible)
         # previous issues with preemptible VMs led to multiple simultaneous QOB groups processing the same data
-        combiner_job.spot(config_retrieve(['combiner', 'preemptible_vms'], False))
+        combiner_job.spot(config_retrieve(['combiner', 'preemptible_vms']))
 
         # Default to GRCh38 for reference if not specified
         combiner_job.call(

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -204,13 +204,13 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
 
         # check for existing VDS by getting all and fetching latest
         elif config_retrieve(['workflow', 'check_for_existing_vds']):
-            get_logger(__file__).info('Checking for existing VDS')
+            get_logger().info('Checking for existing VDS')
             if existing_vds_analysis_entry := query_for_latest_vds(multicohort.analysis_dataset.name, 'combiner'):
                 vds_path = existing_vds_analysis_entry['output']
                 sg_ids_in_vds = {sg['id'] for sg in existing_vds_analysis_entry['sequencingGroups']}
 
         else:
-            get_logger(__file__).info('Not continuing from any previous VDS, creating new Combiner from gVCFs only')
+            get_logger().info('Not continuing from any previous VDS, creating new Combiner from gVCFs only')
 
         # quick check - if we found a VDS, guarantee it exists
         if vds_path and not exists(vds_path):
@@ -244,8 +244,8 @@ class CreateVdsFromGvcfsWithHailCombiner(MultiCohortStage):
                 get_logger().info(f'SGs to remove: {sgs_to_remove}')
 
         if not (new_sg_gvcfs or sgs_to_remove):
-            get_logger(__file__).info('No GVCFs to add to, or remove from, existing VDS')
-            get_logger(__file__).info(f'Checking if VDS exists: {outputs["vds"]}: {outputs["vds"].exists()}')
+            get_logger().info('No GVCFs to add to, or remove from, existing VDS')
+            get_logger().info(f'Checking if VDS exists: {outputs["vds"]}: {outputs["vds"].exists()}')  # type: ignore
             return self.make_outputs(multicohort, outputs)
 
         combiner_job = get_batch().new_python_job('CreateVdsFromGvcfsWithHailCombiner', {'stage': self.name})

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.25',
+    version='1.36.26',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #1065
Closes #1126 

Until now we haven't had a mechanic to remove withdrawn samples from the combiner workflow, they've just remained in the aggregate with more data combined on top.

This PR adds new functionality to remove any samples not in the current multicohort prior to combining additional samples. The logic is:

* get samples in the current VDS (where applicable)
* get samples in the current MultiCohort
* identify any samples in the VDS but not in the current MultiCohort - these need to be removed

Then in the combiner job:

1. determine if SGs need to be removed, if yes:
   a. if there are no SGs to `add`, remove samples and write directly to the output path
   b. if there are SGs to add, remove, write to a temp directory, then continue to combining. Do this combining with `force_new_combiner=True` so we don't re-use a previous plan
   
2. if there are SGs to add to the VDS, do that:
   a. if SGs were removed, combine additional samples on top of the temp VDS we just created
   b. if no SGs were removed, combine additional samples on top of the previous VDS path
   c. if there was no prior VDS, start a new one

---

General housekeeping - removes the default parameters using `config_retrieve`, every one of these is present in the default config TOML for the workflow, so we can use the run config as the absolute source of truth for all configurable options.