### PR TITLE
Use allele-specific vqsr filters

### DIFF
--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -363,6 +363,7 @@ def prepare_gnomad_v4_variants_helper(ds_path: str | None, exome_or_genome: str)
     filters = {
         "InbreedingCoeff": ds.inbreeding_coeff[0] < inbreeding_coeff_cutoff,
         "AC0": ds.expanded_freq.all.ac == 0,
+        "AS_lowqual": ds.AS_lowqual,
         "AS_VQSR": ds.as_vqsr_filters != "PASS",
     }
     ds = ds.annotate(filters=add_filters_expr(filters=filters))

--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -363,7 +363,7 @@ def prepare_gnomad_v4_variants_helper(ds_path: str | None, exome_or_genome: str)
     filters = {
         "InbreedingCoeff": ds.inbreeding_coeff[0] < inbreeding_coeff_cutoff,
         "AC0": ds.expanded_freq.all.ac == 0,
-        "AS_VQSR": hl.len(ds.vqsr_filters) > 0,
+        "AS_VQSR": ds.as_vqsr_filters != "PASS",
     }
     ds = ds.annotate(filters=add_filters_expr(filters=filters))
 

--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -386,6 +386,10 @@ def prepare_gnomad_v4_variants_helper(ds_path: str | None, exome_or_genome: str)
     ds = ds.select('variant_id', 'rsids', 'summary')
     ds = ds.rename({'summary': exome_or_genome})
 
+    globals_dict = ds.globals.collect()[0]
+    ds = ds.select_globals()
+    ds = ds.annotate_globals(**{f"{exome_or_genome}_{k}": v for k, v in globals_dict.items()})
+
     return ds
 
 

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -31,7 +31,6 @@ def run(
     vds_path: str,
     sample_qc_ht_path: str,
     relateds_to_drop_ht_path: str,
-    site_only_ht_path: str,
     vqsr_ht_path: str,
     out_ht_path: str,
 ):
@@ -44,11 +43,10 @@ def run(
     vds = hl.vds.read_vds(str(vds_path))
     sample_qc_ht = hl.read_table(str(sample_qc_ht_path))
     relateds_to_drop_ht = hl.read_table(str(relateds_to_drop_ht_path))
-    site_only_ht = hl.read_table(str(site_only_ht_path))
     vqsr_ht = hl.read_table(str(vqsr_ht_path))
 
     logging.info('Generating frequency annotations...')
-    freq_ht = frequency_annotations(vds, sample_qc_ht, relateds_to_drop_ht, site_only_ht, vqsr_ht)
+    freq_ht = frequency_annotations(vds, sample_qc_ht, relateds_to_drop_ht, vqsr_ht)
     logging.info(f'Writing out frequency data to {out_ht_path}...')
     freq_ht.write(str(out_ht_path), overwrite=True)
 
@@ -57,7 +55,6 @@ def frequency_annotations(
     vds: hl.vds.VariantDataset,
     sample_qc_ht: hl.Table,
     relateds_to_drop_ht: hl.Table,
-    site_only_ht: hl.Table,
     vqsr_ht: hl.Table,
 ) -> hl.Table:
     """

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -96,6 +96,7 @@ def frequency_annotations(
 
     logging.info('Allele-specific statistics...')
     mt = mt.annotate_rows(info=vqsr_ht[mt.row_key].info)
+    mt = mt.annotate_rows(AS_lowqual=vqsr_ht[mt.row_key].AS_lowqual)
 
     logging.info('Inbreeding coefficient...')
     mt = mt.annotate_rows(inbreeding_coeff=hl.array([bi_allelic_site_inbreeding_expr(mt.GT)]))

--- a/cpg_workflows/large_cohort/frequencies.py
+++ b/cpg_workflows/large_cohort/frequencies.py
@@ -98,16 +98,14 @@ def frequency_annotations(
     mt = hl.variant_qc(mt)
 
     logging.info('Allele-specific statistics...')
-    # PLACEHOLDER UNTIL VQSR STAGE IS FIXED
-    # Because the site_only_ht is not split, this info will not be correctly populated for multiallelic
-    # variants until this is resolved.
     mt = mt.annotate_rows(info=vqsr_ht[mt.row_key].info)
 
     logging.info('Inbreeding coefficient...')
     mt = mt.annotate_rows(inbreeding_coeff=hl.array([bi_allelic_site_inbreeding_expr(mt.GT)]))
 
     logging.info('VQSR filters...')
-    mt = mt.annotate_rows(vqsr_filters=vqsr_ht[mt.row_key].filters)
+    mt = mt.annotate_rows(site_vqsr_filters=vqsr_ht[mt.row_key].filters)
+    mt = mt.annotate_rows(as_vqsr_filters=vqsr_ht[mt.row_key].info.AS_FilterStatus)
 
     logging.info('Region flags...')
     mt = mt.annotate_rows(

--- a/cpg_workflows/large_cohort/load_vqsr.py
+++ b/cpg_workflows/large_cohort/load_vqsr.py
@@ -6,7 +6,7 @@ import hail as hl
 from cpg_utils.hail_batch import genome_build
 from cpg_workflows.utils import can_reuse
 from gnomad.utils.annotations import annotate_allele_info
-from gnomad.utils.sparse_mt import split_info_annotation
+from gnomad.utils.sparse_mt import split_info_annotation, split_lowqual_annotation
 
 
 def run(
@@ -22,9 +22,9 @@ def split_info(info_ht: hl.Table) -> hl.Table:
     """
     Splits multi-allelic sites in the provided info Table.
 
-    This function is adapted from `gnomad_methods` (`gnomad.utils.sparse_mt`) to handle
-    multi-allelic sites in the info Table. The `AS_lowqual` annotation splitting is
-    omitted as it is not used in the VQSR pipeline.
+    This function is taken from `gnomad_qc`
+    (`gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`) to handle
+    multi-allelic sites in the info Table.
 
     The `annotate_allele_info` function from `gnomad_methods` is used to split
     multi-allelic sites before splitting the `info` annotation. This ensures that
@@ -50,8 +50,7 @@ def split_info(info_ht: hl.Table) -> hl.Table:
             )
             for a in info_annotations_to_split
         },
-        # Vqsr info_ht has no field AS_lowqual
-        # AS_lowqual=split_lowqual_annotation(info_ht.AS_lowqual, info_ht.a_index),
+        AS_lowqual=split_lowqual_annotation(info_ht.AS_lowqual, info_ht.a_index),
     )
 
     return info_ht
@@ -87,6 +86,7 @@ def load_vqsr(
         info=ht_unsplit.info.annotate(
             AS_SB_TABLE=pre_vcf_adjusted_ht[ht_unsplit.key].info.AS_SB_TABLE,
         ),
+        AS_lowqual=pre_vcf_adjusted_ht[ht_unsplit.key].AS_lowqual,
     )
 
     unsplit_count = ht_unsplit.count()

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -506,7 +506,7 @@ class LoadVqsr(CohortStage):
         return self.make_outputs(cohort, data=self.expected_outputs(cohort), jobs=[j])
 
 
-@stage(required_stages=[Combiner, Relatedness, Ancestry, MakeSiteOnlyVcf, LoadVqsr])
+@stage(required_stages=[Combiner, Relatedness, Ancestry, LoadVqsr])
 class Frequencies(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Path]:
         if frequencies_version := config_retrieve(['large_cohort', 'output_versions', 'frequencies'], default=None):
@@ -541,7 +541,6 @@ class Frequencies(CohortStage):
                 str(inputs.as_path(cohort, Combiner, key='vds')),
                 str(inputs.as_path(cohort, Ancestry, key='sample_qc_ht')),
                 str(inputs.as_path(cohort, Relatedness, key='relateds_to_drop')),
-                str(inputs.as_path(cohort, MakeSiteOnlyVcf, key='ht')),
                 str(inputs.as_path(cohort, LoadVqsr)),
                 str(self.expected_outputs(cohort)),
                 init_batch_args=init_batch_args,


### PR DESCRIPTION
Refine the variant filtering to:
- Bring through the AS_lowqual filter into the final VQSR and frequencies hail tables
- Filter variants that fail on this AS_lowqual flag, or that fail on the allele-specific (as opposed to site-specific) VQSR filters

With VQSR now working correctly to bring in the allele-specific statistics, we can now also drop the dependency on the sites-only hail table.