### PR TITLE
Update our cpg_workflows entry in images.toml directly

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,9 +20,6 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
@@ -30,6 +27,7 @@ jobs:
       IMAGE_NAME: cpg_workflows
       DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
       DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images
+      CONFIG_DESTINATION: gs://cpg-config/templates/images/images.toml
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +60,19 @@ jobs:
           docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:latest
           docker push $DOCKER_MAIN/$IMAGE_NAME:$VERSION
           docker push $DOCKER_MAIN/$IMAGE_NAME:latest
+
+      - name: update ${{ env.IMAGE_NAME }} version in cloud images.toml
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          gcloud storage cp $CONFIG_DESTINATION images.orig.toml
+          sed "/^$IMAGE_NAME *=/s/:[^:\"]*/:$VERSION/" images.orig.toml > images.toml
+          diff -u images.orig.toml images.toml
+
+      # The images repo no longer updates images.toml, so it is safe to do it directly here
+      - name: deploy cloud images.toml
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          gcloud storage cp images.toml $CONFIG_DESTINATION
 
       - name: manually triggered build
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' }}


### PR DESCRIPTION
Previously cpg_workflows was a special case in the images repo's deployment workflows, which had explicit code to add an entry for cpg_workflows. The images repo had a monopoly on updating the GCS bucket images.toml file to avoid race conditions.

Due to the images revamp, the images repo no longer updates images.toml. In the new world order, the only entry that we'll keep updating (for now) is cpg_workflows, so it is now safe to do that here directly after we build and upload the docker image.

Remove [shell override so we use the default](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell) which includes `-e`, so we avoid overwriting the cloud images.toml when things go wrong.