### PR TITLE
Ignore the exit status from diff

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           gcloud storage cp $CONFIG_DESTINATION images.orig.toml
           sed "/^$IMAGE_NAME *=/s/:[^:\"]*/:$VERSION/" images.orig.toml > images.toml
-          diff -u images.orig.toml images.toml
+          diff -u images.orig.toml images.toml || true
 
       # The images repo no longer updates images.toml, so it is safe to do it directly here
       - name: deploy cloud images.toml


### PR DESCRIPTION
Oops… the previous [action run failed](https://github.com/populationgenomics/production-pipelines/actions/runs/15153626802/job/42604175711) due to the `diff` command.

The `diff(1)` command exits with status 1 when the two files differ. We expect images.orig.toml and images.toml to differ and want the workflow to continue regardless.