### PR TITLE
Add custom resourcing to seqr_loader_long_read merge vcfs job

### DIFF
--- a/configs/defaults/seqr_loader_long_read.toml
+++ b/configs/defaults/seqr_loader_long_read.toml
@@ -14,3 +14,8 @@ snps_indels_callers = ['deeptrio', 'deepvariant']
 [resource_overrides.bam_to_cram]
 nthreads = 1
 storage_gb = 50
+
+[resource_overrides.merge_vcfs]
+ncpu = 4
+mem_gb = 16
+storage_gb = 50

--- a/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
+++ b/cpg_workflows/stages/seqr_loader_long_read/long_read_snps_indels_annotation.py
@@ -329,9 +329,9 @@ class MergeLongReadSNPsIndels(MultiCohortStage):
         merge_job.image(image=image_path('bcftools_120'))
 
         # guessing at resource requirements
-        merge_job.cpu(4)
-        merge_job.memory('16Gi')
-        merge_job.storage('50Gi')
+        merge_job.cpu(config_retrieve(['resource_overrides', 'merge_vcfs', 'ncpu'], 4))
+        merge_job.memory(str(config_retrieve(['resource_overrides', 'merge_vcfs', 'mem_gb'], '16')) + 'Gi')
+        merge_job.storage(str(config_retrieve(['resource_overrides', 'storage_gb'], '50')) + 'Gi')
         merge_job.declare_resource_group(output={'vcf.bgz': '{root}.vcf.bgz', 'vcf.bgz.tbi': '{root}.vcf.bgz.tbi'})
 
         # option breakdown:


### PR DESCRIPTION
Adds config options for the resources allocated to the merge VCFs job.

Originally made this PR because I assumed this job would fail https://batch.hail.populationgenomics.org.au/batches/615350/jobs/14

However it looks like it scraped by with just enough disk space. Any more vcfs and it probably would have failed.