### PR TITLE
Long read skip splitvcf

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.29
+current_version = 1.36.30
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.29
+  VERSION: 1.36.30
 
 jobs:
   docker:

--- a/cpg_workflows/jobs/seqr_loader_snps_indels.py
+++ b/cpg_workflows/jobs/seqr_loader_snps_indels.py
@@ -98,13 +98,17 @@ def split_merged_vcf_and_get_sitesonly_vcfs_for_vep(
     ]
     siteonly_vcfs: list[hb.ResourceGroup] = []
 
-    split_vcf_j = add_split_vcf_job(
-        b=b,
-        input_vcf=merged_vcf,
-        intervals=intervals,
-        output_vcf_paths=split_vcfs_paths,
-        job_attrs=(job_attrs or {}) | dict(part='all'),
-    )
+    # Only create the split VCF job if we are not reusing the output paths
+    if can_reuse(split_vcfs_paths + [to_path(f'{p}.tbi') for p in split_vcfs_paths]):
+        split_vcf_j = None
+    else:
+        split_vcf_j = add_split_vcf_job(
+            b=b,
+            input_vcf=merged_vcf,
+            intervals=intervals,
+            output_vcf_paths=split_vcfs_paths,
+            job_attrs=(job_attrs or {}) | dict(part='all'),
+        )
 
     for idx in range(scatter_count):
         if out_siteonly_vcf_part_paths:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.29',
+    version='1.36.30',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The SplitVcf job always runs when re-running this pipeline, even if it has completed in a previous run and it's outputs exist.
E.g. https://batch.hail.populationgenomics.org.au/batches/615409

This change checks if the output paths all exist, and if they do, skips the splitvcf job. 