### PR TITLE
Withdrawals in combiner

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.31
+current_version = 1.36.32
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,8 @@
 [bumpversion]
-current_version = 1.36.29
+current_version = 1.36.30
 commit = True
 tag = False
+allow_dirty = True
 
 [bumpversion:file:setup.py]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,6 @@
 current_version = 1.36.30
 commit = True
 tag = False
-allow_dirty = True
 
 [bumpversion:file:setup.py]
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.29
+  VERSION: 1.36.30
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.31
+  VERSION: 1.36.32
 
 jobs:
   docker:

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -76,12 +76,12 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     gvcf_external_header: str | None = None
     sequencing_group_names: list[str] | None = None
 
-    if combiner_config.get('vds_analysis_ids', None) is not None:
-        for vds_id in combiner_config['vds_analysis_ids']:
-            tmp_query_res, tmp_sg_ids_in_vds = get_vds_ids_output(vds_id)
-            vds_paths.append(tmp_query_res)
-            sg_ids_in_vds = sg_ids_in_vds + tmp_sg_ids_in_vds
-            sgs_for_withdrawal = [sg for sg in sg_ids_in_vds if sg not in cohort_sg_ids]
+    for vds_id in config_retrieve(['combiner', 'vds_analysis_ids'], []):
+        tmp_query_res, tmp_sg_ids_in_vds = get_vds_ids_output(vds_id)
+        vds_paths.append(tmp_query_res)
+        sg_ids_in_vds = sg_ids_in_vds + tmp_sg_ids_in_vds
+    
+    sgs_for_withdrawal = [sg for sg in sg_ids_in_vds if sg not in cohort_sg_ids]
 
     if combiner_config.get('merge_only_vds', False) is not True:
         # Get SG IDs from the cohort object itself, rather than call Metamist.

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -103,7 +103,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
         _run,
         output_vds_path=output_vds_path,
         sequencing_type=workflow_config['sequencing_type'],
-        tmp_prefix=f'{cohort.analysis_dataset.tmp_prefix()}/combiner_temp_dir',
+        tmp_prefix=f'{cohort.analysis_dataset.tmp_prefix()}combiner_temp_dir',
         genome_build=genome_build(),
         save_path=save_path,
         force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -178,8 +178,6 @@ def _run(
         # We have some SGs to withdrawal
         else:
             combiner_vds_output_path = tmp_prefix_for_withdrawals
-            logging.info(f'There are {len(sgs_for_withdrawal)} sequencing groups to remove.')
-            logging.info(f'Removing: {" ".join(sgs_for_withdrawal)}')
 
         combiner: VariantDatasetCombiner = new_combiner(
             output_path=combiner_vds_output_path,
@@ -210,6 +208,8 @@ def _run(
         combiner.run()
 
         if sgs_for_withdrawal:
+            logging.info(f'There are {len(sgs_for_withdrawal)} sequencing groups to remove.')
+            logging.info(f'Removing: {" ".join(sgs_for_withdrawal)}')
             logging.info('Removing samples from VDS')
             filtered_vds: VariantDataset = hl.vds.filter_samples(
                 vds=hl.vds.read_vds(tmp_prefix_for_withdrawals),

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -199,6 +199,8 @@ def _run(
 
             combiner.run()
         else:
+            logging.info(f'There are {len(sgs_for_withdrawl)} sequencing groups to remove.')
+            logging.info(f'Removing: {" ".join(sgs_for_withdrawl)}')
             combiner = new_combiner(
                 output_path=tmp_prefix_for_withdrawals,
                 save_path=save_path,

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -212,7 +212,7 @@ def _run(
         if sgs_for_withdrawal:
             logging.info('Removing samples from VDS')
             filtered_vds: VariantDataset = hl.vds.filter_samples(
-                vds=tmp_prefix_for_withdrawals,
+                vds=hl.vds.read_vds(tmp_prefix_for_withdrawals),
                 samples=sgs_for_withdrawal,
                 keep=False,
                 remove_dead_alleles=True,

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -64,7 +64,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     combiner_config = config_retrieve('combiner')
 
     tmp_prefix_for_withdrawals: str = slugify(
-        f'{cohort.analysis_dataset.tmp_prefix()}/{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
+        f'{cohort.analysis_dataset.tmp_prefix()}{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
     )
 
     vds_paths: list[str] = []

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -153,7 +153,7 @@ def _run(
     # set up a quick logger inside the job
     logging.basicConfig(level=logging.INFO)
 
-    if not can_reuse(to_path(output_vds_path)) or sgs_for_withdrawal:
+    if not can_reuse(to_path(output_vds_path)):
         init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
 
         if specific_intervals:

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -64,7 +64,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     combiner_config = config_retrieve('combiner')
 
     tmp_prefix_for_withdrawals: str = slugify(
-        f'{cohort.analysis_dataset.tmp_prefix}/{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
+        f'{cohort.analysis_dataset.tmp_prefix()}/{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
     )
 
     vds_paths: list[str] = []

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -74,6 +74,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
     cohort_sg_ids: list[str] = cohort.get_sequencing_group_ids(only_active=True)
     gvcf_external_header: str | None = None
+    sequencing_group_names: list[str] | None = None
 
     if combiner_config.get('vds_analysis_ids', None) is not None:
         for vds_id in combiner_config['vds_analysis_ids']:
@@ -88,13 +89,12 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
         new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
         if new_sg_gvcfs:
             gvcf_external_header = new_sg_gvcfs[0]
+            sequencing_group_names = [
+                str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds
+            ]
 
     # if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1:
     #     raise Exception
-
-    sequencing_group_names: list[str] = [
-        str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds
-    ]
 
     combiner_job: PythonJob = _initalise_combiner_job(cohort=cohort)
 

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -69,7 +69,6 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
 
     vds_paths: list[str] = []
     sg_ids_in_vds: list[str] = []
-    sgs_for_withdrawal: list[str] = []
     new_sg_gvcfs: list[str] = []
     cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
     cohort_sg_ids: list[str] = cohort.get_sequencing_group_ids(only_active=True)
@@ -80,8 +79,8 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
         tmp_query_res, tmp_sg_ids_in_vds = get_vds_ids_output(vds_id)
         vds_paths.append(tmp_query_res)
         sg_ids_in_vds = sg_ids_in_vds + tmp_sg_ids_in_vds
-    
-    sgs_for_withdrawal = [sg for sg in sg_ids_in_vds if sg not in cohort_sg_ids]
+
+    sgs_for_withdrawal: list[str] = [sg for sg in sg_ids_in_vds if sg not in cohort_sg_ids]
 
     if not config_retrieve(['combiner', 'merge_only_vds'], False):
         # Get SG IDs from the cohort object itself, rather than call Metamist.
@@ -93,8 +92,8 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
                 str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds
             ]
 
-    # if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1:
-    #     raise Exception
+    if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1 and not sgs_for_withdrawal:
+        raise Exception
 
     combiner_job: PythonJob = _initalise_combiner_job(cohort=cohort)
 

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -120,7 +120,7 @@ def _run(
     tmp_prefix: str,
     genome_build: str,
     save_path: str | None,
-    sgs_for_withdrawl: list[str] | None,
+    sgs_for_withdrawal: list[str] | None,
     tmp_prefix_for_withdrawals: str,
     force_new_combiner: bool = False,
     sequencing_group_names: list[str] | None = None,
@@ -150,7 +150,7 @@ def _run(
     # set up a quick logger inside the job
     logging.basicConfig(level=logging.INFO)
 
-    if not can_reuse(to_path(output_vds_path)) or sgs_for_withdrawl:
+    if not can_reuse(to_path(output_vds_path)) or sgs_for_withdrawal:
         init_batch(worker_memory='highmem', driver_memory='highmem', driver_cores=4)
 
         if specific_intervals:
@@ -163,7 +163,7 @@ def _run(
         else:
             intervals = None
 
-        if not sgs_for_withdrawl:
+        if not sgs_for_withdrawal:
             # Load from save, if supplied
             if save_path:
                 if force_new_combiner:
@@ -199,8 +199,8 @@ def _run(
 
             combiner.run()
         else:
-            logging.info(f'There are {len(sgs_for_withdrawl)} sequencing groups to remove.')
-            logging.info(f'Removing: {" ".join(sgs_for_withdrawl)}')
+            logging.info(f'There are {len(sgs_for_withdrawal)} sequencing groups to remove.')
+            logging.info(f'Removing: {" ".join(sgs_for_withdrawal)}')
             combiner = new_combiner(
                 output_path=tmp_prefix_for_withdrawals,
                 save_path=save_path,
@@ -231,7 +231,7 @@ def _run(
 
             filtered_vds: VariantDataset = hl.vds.filter_samples(
                 vds=tmp_prefix_for_withdrawals,
-                samples=sgs_for_withdrawl,
+                samples=sgs_for_withdrawal,
                 keep=False,
                 remove_dead_alleles=True,
             )

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -86,10 +86,11 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
         # Get SG IDs from the cohort object itself, rather than call Metamist.
         # Get VDS IDs first and filter out from this list
         new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
-        gvcf_external_header = new_sg_gvcfs[0]
+        if new_sg_gvcfs:
+            gvcf_external_header = new_sg_gvcfs[0]
 
-    if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1:
-        raise Exception
+    # if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1:
+    #     raise Exception
 
     sequencing_group_names: list[str] = [
         str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -210,6 +210,7 @@ def _run(
         combiner.run()
 
         if sgs_for_withdrawal:
+            logging.info('Removing samples from VDS')
             filtered_vds: VariantDataset = hl.vds.filter_samples(
                 vds=tmp_prefix_for_withdrawals,
                 samples=sgs_for_withdrawal,

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -63,7 +63,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     combiner_config = config_retrieve('combiner')
 
     tmp_prefix_for_withdrawals: str = slugify(
-        f'{cohort.analysis_dataset.tmp_prefix}/{workflow_config["cohort"]}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
+        f'{cohort.analysis_dataset.tmp_prefix}/{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
     )
 
     vds_paths: list[str] = []

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -83,7 +83,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     
     sgs_for_withdrawal = [sg for sg in sg_ids_in_vds if sg not in cohort_sg_ids]
 
-    if combiner_config.get('merge_only_vds', False) is not True:
+    if not config_retrieve(['combiner', 'merge_only_vds'], False):
         # Get SG IDs from the cohort object itself, rather than call Metamist.
         # Get VDS IDs first and filter out from this list
         new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Final, Tuple
 from cpg_utils import Path
 from cpg_utils.config import config_retrieve, genome_build, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
+from cpg_workflows.large_cohort.combiner import combiner
 from cpg_workflows.targets import Cohort, SequencingGroup
 from cpg_workflows.utils import slugify
 from cpg_workflows.workflow import (
@@ -13,13 +14,9 @@ from cpg_workflows.workflow import (
     get_workflow,
     stage,
 )
-from metamist.graphql import gql, query
 
 if TYPE_CHECKING:
-    from graphql import DocumentNode
-
     from hailtop.batch.job import PythonJob
-
 
 HAIL_QUERY: Final = 'hail query'
 
@@ -31,7 +28,7 @@ class Combiner(CohortStage):
         workflow_config = config_retrieve('workflow')
         combiner_config = config_retrieve('combiner')
         output_vds_name: str = slugify(
-            f"{cohort.name}-{workflow_config['sequencing_type']}-{combiner_config['vds_version']}",
+            f'{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
         )
 
         # include the list of all VDS IDs in the plan name
@@ -45,80 +42,13 @@ class Combiner(CohortStage):
             'combiner_plan': str(self.get_stage_cohort_prefix(cohort, 'tmp') / f'{combiner_plan_name}.json'),
         }
 
-    def get_vds_ids_output(self, vds_id: int) -> Tuple[str, list[str]]:
-        get_vds_analysis_query: DocumentNode = gql(
-            """
-            query getVDSByAnalysisIds($vds_id: Int!) {
-                analyses(id: {eq: $vds_id}) {
-                    output
-                    sequencingGroups {
-                        id
-                    }
-                }
-            }
-        """,
-        )
-        query_results: dict[str, Any] = query(get_vds_analysis_query, variables={'vds_id': vds_id})
-        vds_path: str = query_results['analyses'][0]['output']
-        vds_sgids: list[str] = [sg['id'] for sg in query_results['analyses'][0]['sequencingGroups']]
-        return (vds_path, vds_sgids)
-
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput | None:
-        # Can't import it before all configs are set:
-        from cpg_workflows.large_cohort import combiner
-
-        workflow_config = config_retrieve('workflow')
-        combiner_config = config_retrieve('combiner')
-
         output_paths = self.expected_outputs(cohort)
-        tmp_prefix = slugify(
-            f"{self.tmp_prefix}/{workflow_config['cohort']}-{workflow_config['sequencing_type']}-{combiner_config['vds_version']}",
-        )
 
-        # create these as empty lists instead of None, they have the same truthiness
-        vds_paths: list[str] = []
-        sg_ids_in_vds: list[str] = []
-        new_sg_gvcfs: list[str] = []
-
-        if combiner_config.get('vds_analysis_ids', None) is not None:
-            for vds_id in combiner_config['vds_analysis_ids']:
-                tmp_query_res, tmp_sg_ids_in_vds = self.get_vds_ids_output(vds_id)
-                vds_paths.append(tmp_query_res)
-                sg_ids_in_vds = sg_ids_in_vds + tmp_sg_ids_in_vds
-
-        if combiner_config.get('merge_only_vds', False) is not True:
-            # Get SG IDs from the cohort object itself, rather than call Metamist.
-            # Get VDS IDs first and filter out from this list
-            cohort_sgs: list[SequencingGroup] = cohort.get_sequencing_groups(only_active=True)
-            new_sg_gvcfs = [str(sg.gvcf) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds]
-
-        if new_sg_gvcfs and len(new_sg_gvcfs) == 0 and len(vds_paths) <= 1:
-            return self.make_outputs(cohort, output_paths)
-
-        j: PythonJob = get_batch().new_python_job('Combiner', (self.get_job_attrs() or {}) | {'tool': HAIL_QUERY})
-        j.image(config_retrieve(['workflow', 'driver_image']))
-        j.memory(combiner_config.get('memory'))
-        j.storage(combiner_config.get('storage'))
-
-        # set this job to be non-spot (i.e. non-preemptible)
-        # previous issues with preemptible VMs led to multiple simultaneous QOB groups processing the same data
-        j.spot(config_retrieve(['combiner', 'preemptible_vms'], False))
-
-        # Default to GRCh38 for reference if not specified
-        j.call(
-            combiner.run,
+        j: PythonJob = combiner(
+            cohort=cohort,
             output_vds_path=str(output_paths['vds']),
-            sequencing_type=workflow_config['sequencing_type'],
-            tmp_prefix=tmp_prefix,
-            genome_build=genome_build(),
             save_path=output_paths['combiner_plan'],
-            force_new_combiner=config_retrieve(['combiner', 'force_new_combiner']),
-            sequencing_group_names=[
-                str(sg.id) for sg in cohort_sgs if sg.gvcf is not None and sg.id not in sg_ids_in_vds
-            ],
-            gvcf_external_header=new_sg_gvcfs[0],
-            gvcf_paths=new_sg_gvcfs,
-            vds_paths=vds_paths,
         )
 
         return self.make_outputs(cohort, output_paths, [j])
@@ -462,7 +392,7 @@ class Vqsr(CohortStage):
 
         # sed command to swap Float SB to Integer in-place and allow any length
         reheader_job.command(
-            fr"sed -i 's/<ID=SB,Number=1,Type=Float/<ID=SB,Number=.,Type=Integer/' {reheader_job.ofile}",
+            rf"sed -i 's/<ID=SB,Number=1,Type=Float/<ID=SB,Number=.,Type=Integer/' {reheader_job.ofile}",
         )
 
         b.write_output(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.29',
+    version='1.36.30',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.31',
+    version='1.36.32',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -169,7 +169,7 @@ def test_combiner(mocker: MockFixture, tmp_path: Path):
     vds_path = str(tmp_path / 'v01.vds')
 
     # we're passing a specific minority of intervals here, to test that the combiner works on a timely test case
-    combiner.run(
+    combiner._run(
         output_vds_path=vds_path,
         sequencing_type=conf['workflow']['sequencing_type'],
         tmp_prefix=str(tmp_path / 'tmp'),
@@ -179,6 +179,8 @@ def test_combiner(mocker: MockFixture, tmp_path: Path):
         save_path=None,
         specific_intervals=conf['large_cohort']['combiner']['intervals'],
         force_new_combiner=conf['large_cohort']['combiner']['force_new_combiner'],
+        tmp_prefix_for_withdrawals=str(tmp_path / 'tmp_withdrawals'),
+        sgs_for_withdrawal=None,
     )
 
     # do some testing here


### PR DESCRIPTION
Implement a method to withdrawal samples in the combiner stage.

This is not the best implementation, as it creates the full VDS first, and then removes samples from it. However, this lets us keep the ability to merge multiple VDS together, which would otherwise become very complicated.

Also refactor the code into a more cpg_flow style, separating the logic out of the stage and into the job files.
