### PR TITLE
Somalierpedigree output location

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.30
+current_version = 1.36.31
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.30
+  VERSION: 1.36.31
 
 jobs:
   docker:

--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -157,11 +157,12 @@ class SomalierPedigree(DatasetStage):
             return {}
 
         prefix = dataset.prefix() / 'somalier' / 'cram' / dataset.get_alignment_inputs_hash()
+        web_prefix = dataset.web_prefix() / 'somalier' / 'cram' / dataset.get_alignment_inputs_hash()
         return {
             'samples': prefix / f'{dataset.name}.samples.tsv',
             'expected_ped': prefix / f'{dataset.name}.expected.ped',
             'pairs': prefix / f'{dataset.name}.pairs.tsv',
-            'html': dataset.web_prefix() / 'cram-somalier-pedigree.html',
+            'html': web_prefix / 'cram-somalier-pedigree.html',
             'checks': prefix / f'{dataset.name}-checks.done',
         }
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.30',
+    version='1.36.31',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Resolves https://github.com/populationgenomics/production-pipelines/issues/974

Instead of saving to:
```
gs://cpg-dataset-main-web/cram-somalier-pedigree.html
gs://cpg-dataset-main-web/exome/cram-somalier-pedigree.html
```

It will now save to:
```
gs://cpg-dataset-main-web/somalier/cram/<sg_hash>/cram-somalier-pedigree.html
gs://cpg-dataset-main-web/exome/somalier/cram/<sg_hash>/cram-somalier-pedigree.html
```

Which is in line with how we save other DatasetStage / CohortStage results. This will prevent the report html being overwritten with every run. 