### PR TITLE
Lrs checkpoint mt immediately

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.32
+current_version = 1.36.33
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.32
+  VERSION: 1.36.33
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -48,6 +48,7 @@ def annotate_cohort(
         force_bgz=True,
         array_elements_required=False,
     )
+    mt = checkpoint_hail(mt, 'mt-imported-vcf.mt', checkpoint_prefix)
     logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.32',
+    version='1.36.33',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a checkpointing step to the LRS annotation pipeline, immediately after the merged VCF has been imported. 

This is to address OOM issues when the number of partitions of the MatrixTable is evaluated on the following line. See [this Slack thread](https://centrepopgen.slack.com/archives/C082NA58R7S/p1747872704048229) for a discussion.