### PR TITLE
Lrs checkpoint mt immediately2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.33
+current_version = 1.36.34
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.33
+  VERSION: 1.36.34
 
 jobs:
   docker:

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -48,7 +48,7 @@ def annotate_cohort(
         force_bgz=True,
         array_elements_required=False,
     )
-    mt.checkpoint(output=str(checkpoint_prefix) + 'mt-imported.mt', overwrite=True)
+    mt.checkpoint(output=str(checkpoint_prefix / 'mt-imported.mt'), overwrite=True)
     logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -48,7 +48,7 @@ def annotate_cohort(
         force_bgz=True,
         array_elements_required=False,
     )
-    mt = checkpoint_hail(mt, 'mt-imported-vcf.mt', checkpoint_prefix)
+    mt.checkpoint(output=checkpoint_prefix + 'mt-imported.mt', overwrite=True)
     logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -48,7 +48,7 @@ def annotate_cohort(
         force_bgz=True,
         array_elements_required=False,
     )
-    mt.checkpoint(output=checkpoint_prefix + 'mt-imported.mt', overwrite=True)
+    mt.checkpoint(output=str(checkpoint_prefix) + 'mt-imported.mt', overwrite=True)
     logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -48,7 +48,7 @@ def annotate_cohort(
         force_bgz=True,
         array_elements_required=False,
     )
-    mt.checkpoint(output=str(checkpoint_prefix / 'mt-imported.mt'), overwrite=True)
+    mt.checkpoint(output=str(checkpoint_prefix) + 'mt-imported.mt', overwrite=True)
     logging.info(f'Imported VCF {vcf_path} as {mt.n_partitions()} partitions')
 
     # Annotate VEP. Do it before splitting multi, because we run VEP on unsplit VCF,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.33',
+    version='1.36.34',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Follow up from https://github.com/populationgenomics/production-pipelines/pull/1228

Use `mt.checkpoint` rather than `cpg_workflows.utils.checkpoint_hail` method - which calls `mt.n_partitions()` before checkpointing (exactly what we wanted to avoid)