### PR TITLE
Highmem workers annotatecohort

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.36.34
+current_version = 1.36.35
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.36.34
+  VERSION: 1.36.35
 
 jobs:
   docker:

--- a/configs/defaults/long_read_snps_indels_annotation.toml
+++ b/configs/defaults/long_read_snps_indels_annotation.toml
@@ -5,7 +5,10 @@ status_reporter = 'metamist'
 vep_version = '110'
 
 [workflow.annotate_cohort]
-workers_use_highmem = false
+highmem_drivers = false
+highmem_workers = false
+# driver_cores = 2
+# worker_cores = 2
 
 [elasticsearch]
 # Configure access to ElasticSearch server

--- a/configs/defaults/long_read_snps_indels_annotation.toml
+++ b/configs/defaults/long_read_snps_indels_annotation.toml
@@ -4,6 +4,9 @@ ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapie
 status_reporter = 'metamist'
 vep_version = '110'
 
+[workflow.annotate_cohort]
+workers_use_highmem = false
+
 [elasticsearch]
 # Configure access to ElasticSearch server
 port = '9243'

--- a/cpg_workflows/jobs/seqr_loader_snps_indels.py
+++ b/cpg_workflows/jobs/seqr_loader_snps_indels.py
@@ -25,11 +25,19 @@ def annotate_cohort_jobs_snps_indels(
     """
     Annotate cohort VCF for seqr loader, SNPs and Indels.
     """
-    if config_retrieve(['workflow', 'annotate_cohort', 'workers_use_highmem'], False):
-        b = get_batch(worker_memory='highmem')
-    else:
-        b = get_batch()
-    j = b.new_job('Annotate cohort', job_attrs)
+    init_batch_args: dict[str, str | int] = {}
+    annotate_cohort_workflow = config_retrieve(['workflow', 'annotate_cohort'], {})
+
+    # Memory parameters
+    for config_key, batch_key in [('highmem_workers', 'worker_memory'), ('highmem_drivers', 'driver_memory')]:
+        if annotate_cohort_workflow.get(config_key):
+            init_batch_args[batch_key] = 'highmem'
+    # Cores parameter
+    for key in ['driver_cores', 'worker_cores']:
+        if annotate_cohort_workflow.get(key):
+            init_batch_args[key] = annotate_cohort_workflow[key]
+
+    j = get_batch().new_job('Annotate cohort', job_attrs)
     j.image(config_retrieve(['workflow', 'driver_image']))
     j.command(
         query_command(
@@ -40,8 +48,8 @@ def annotate_cohort_jobs_snps_indels(
             str(vep_ht_path),
             None,  # site_only_vqsr_vcf_path
             str(checkpoint_prefix),
-            True,  # long_read
             True,  # remove_invalid_contigs
+            init_batch_args=init_batch_args,
         ),
     )
     return j

--- a/cpg_workflows/jobs/seqr_loader_snps_indels.py
+++ b/cpg_workflows/jobs/seqr_loader_snps_indels.py
@@ -25,8 +25,11 @@ def annotate_cohort_jobs_snps_indels(
     """
     Annotate cohort VCF for seqr loader, SNPs and Indels.
     """
-
-    j = get_batch().new_job('Annotate cohort', job_attrs)
+    if config_retrieve(['workflow', 'annotate_cohort', 'workers_use_highmem'], False):
+        b = get_batch(worker_memory='highmem')
+    else:
+        b = get_batch()
+    j = b.new_job('Annotate cohort', job_attrs)
     j.image(config_retrieve(['workflow', 'driver_image']))
     j.command(
         query_command(

--- a/cpg_workflows/query_modules/seqr_loader.py
+++ b/cpg_workflows/query_modules/seqr_loader.py
@@ -20,7 +20,6 @@ def annotate_cohort(
     vep_ht_path: str,
     site_only_vqsr_vcf_path: str | None = None,
     checkpoint_prefix: str | None = None,
-    long_read: bool = False,
     remove_invalid_contigs: bool = False,
 ):
     """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.36.34',
+    version='1.36.35',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
After https://github.com/populationgenomics/production-pipelines/pull/1228 and https://github.com/populationgenomics/production-pipelines/pull/1229 failed to resolve the OOM issues in the annotate cohort QoB execution for the long reads pipeline, we should look into to increasing the memory used by the workers. 

According to the QoB playbook [here](https://github.com/populationgenomics/team-docs/blob/main/playbooks/hail_query_on_batch.md#out-of-memory), you can pass the arg `worker_memory='highmem'` to `init_batch()` and then any QoB workers used will be allocated 8GiB memory instead of 4. I'm assuming this argument works in the same way with the `cpg_utils.get_batch()` batch instantiation. 

With this PR, we will be able toggle highmem workers through a config option. Ugly implementation for now, will make it nicer in CPG flow.

- Also removes unused bool arg to the annotate_cohort job `long_read` - relic of an earlier pipeline iteration