### PR TITLE
Remove sequencing type from combiner name

### DIFF
--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from hail.vds.combiner.variant_dataset_combiner import VariantDatasetCombiner
     from hail.vds.variant_dataset import VariantDataset
 
+    import cpg_utils
+
 
 def _initalise_combiner_job(cohort: Cohort) -> PythonJob:
     j: PythonJob = get_batch().new_python_job('Combiner', (cohort.get_job_attrs() or {}) | {'tool': 'hail query'})  # type: ignore[reportUnknownArgumentType]
@@ -63,9 +65,14 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     workflow_config = config_retrieve('workflow')
     combiner_config = config_retrieve('combiner')
 
-    tmp_prefix_for_withdrawals: str = slugify(
-        f'{cohort.analysis_dataset.tmp_prefix()}{cohort.id}-{cohort.name}-{combiner_config["vds_version"]}',
+    combiner_tmp_path: cpg_utils.Path = (
+        cohort.analysis_dataset.tmp_prefix()
+        / 'vds'
+        / f'{cohort.name}'
+        / f'{cohort.id}-{combiner_config["vds_version"]}'
     )
+
+    tmp_prefix_for_withdrawals: str = slugify(str(combiner_tmp_path))
 
     vds_paths: list[str] = []
     sg_ids_in_vds: list[str] = []

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -64,7 +64,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     combiner_config = config_retrieve('combiner')
 
     tmp_prefix_for_withdrawals: str = slugify(
-        f'{cohort.analysis_dataset.tmp_prefix()}{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
+        f'{cohort.analysis_dataset.tmp_prefix()}{cohort.name}-{combiner_config["vds_version"]}',
     )
 
     vds_paths: list[str] = []
@@ -227,7 +227,6 @@ def _run(
 
     # do we need to run filter_samples?
     if sgs_for_withdrawal:
-
         # select which path to filter samples from - either the temp path if combining has occurred, or the only VDS
         path_to_read_from = tmp_prefix_for_withdrawals if combining_to_do else vds_paths[0]
 

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -64,7 +64,7 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
     combiner_config = config_retrieve('combiner')
 
     tmp_prefix_for_withdrawals: str = slugify(
-        f'{cohort.analysis_dataset.tmp_prefix()}{cohort.name}-{combiner_config["vds_version"]}',
+        f'{cohort.analysis_dataset.tmp_prefix()}{cohort.id}-{cohort.name}-{combiner_config["vds_version"]}',
     )
 
     vds_paths: list[str] = []

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -27,7 +27,7 @@ class Combiner(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Any]:
         combiner_config = config_retrieve('combiner')
         output_vds_name: str = slugify(
-            f'{cohort.name}-{combiner_config["vds_version"]}',
+            f'{cohort.id}-{cohort.name}-{combiner_config["vds_version"]}',
         )
 
         # include the list of all VDS IDs in the plan name

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -25,10 +25,9 @@ HAIL_QUERY: Final = 'hail query'
 @stage(analysis_type='combiner', analysis_keys=['vds'])
 class Combiner(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Any]:
-        workflow_config = config_retrieve('workflow')
         combiner_config = config_retrieve('combiner')
         output_vds_name: str = slugify(
-            f'{cohort.name}-{workflow_config["sequencing_type"]}-{combiner_config["vds_version"]}',
+            f'{cohort.name}-{combiner_config["vds_version"]}',
         )
 
         # include the list of all VDS IDs in the plan name

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -1,11 +1,10 @@
-import logging
-from typing import TYPE_CHECKING, Any, Final, Tuple
+from typing import TYPE_CHECKING, Any, Final
 
 from cpg_utils import Path
-from cpg_utils.config import config_retrieve, genome_build, get_config, image_path
+from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
 from cpg_workflows.large_cohort.combiner import combiner
-from cpg_workflows.targets import Cohort, SequencingGroup
+from cpg_workflows.targets import Cohort
 from cpg_workflows.utils import slugify
 from cpg_workflows.workflow import (
     CohortStage,
@@ -27,7 +26,7 @@ class Combiner(CohortStage):
     def expected_outputs(self, cohort: Cohort) -> dict[str, Any]:
         combiner_config = config_retrieve('combiner')
         output_vds_name: str = slugify(
-            f'{cohort.id}-{cohort.name}-{combiner_config["vds_version"]}',
+            f'{cohort.id}-{combiner_config["vds_version"]}',
         )
 
         # include the list of all VDS IDs in the plan name
@@ -37,7 +36,7 @@ class Combiner(CohortStage):
         else:
             combiner_plan_name = f'combiner-{cohort.name}'
         return {
-            'vds': cohort.analysis_dataset.prefix() / 'vds' / f'{output_vds_name}.vds',
+            'vds': cohort.analysis_dataset.prefix() / 'vds' / f'{cohort.name}' / f'{output_vds_name}.vds',
             'combiner_plan': str(self.get_stage_cohort_prefix(cohort, 'tmp') / f'{combiner_plan_name}.json'),
         }
 


### PR DESCRIPTION
Remove the sequencing type from the VDS name produced by the combiner, and add in the cohort ID.