### PR TITLE
Add support for computing true AS annotations alongside quasi AS to evaluate downstream VQSR impact

### DIFF
--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -20,9 +20,7 @@ def extract_as_pls(
     allele_idx: hl.expr.Int32Expression,
 ) -> hl.expr.ArrayExpression:
     """
-    Function pulled from `gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`:
-        - CPG's `gnomad_methods` submodule is pinned to a commit that pre-dates this function
-        and thus cannot import it directly.
+    Function pulled from `gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`.
 
     Extract PLs for a specific allele from an LPL array expression.
 

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -231,6 +231,10 @@ def vds_to_site_only_ht(
     )
 
     logging.info(f'Writing site-only HT to {out_ht_path}')
+    # write out one quasi vcf file and one AS vcf then have a Hail table with both fields
+    # TODO: use the correct_mt to pass to default_compute_info (the quasi calculation of default_compute_info does not use AS fields)
+    # but also pass as_annotations=True to get the true AS annotations. Then we just write out two VCFs:
+    # one with the true AS annotations and one with the quasi annotations, but both have the site-level annotations.
     info_ht.write(str(out_ht_path), overwrite=True)
     return info_ht
 

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -51,9 +51,7 @@ def extract_as_pls(
 
 def recompute_as_qualapprox_from_lpl(mt: hl.MatrixTable) -> hl.expr.ArrayExpression:
     """
-    Function pulled from `gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`:
-        - CPG's `gnomad_methods` submodule is pinned to a commit that pre-dates this function
-        and thus cannot import it directly.
+    Function pulled from `gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`.
 
     Recompute AS_QUALapprox from LPL.
 

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -113,9 +113,7 @@ def correct_as_annotations(
     set_to_missing: bool = False,
 ) -> hl.expr.StructExpression:
     """
-    Function pulled from `gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`:
-        - CPG's `gnomad_methods` submodule is pinned to a commit that pre-dates this function
-        and thus cannot import it directly.
+    Function pulled from `gnomad_qc/v4/annotations/generate_variant_qc_annotations.py`.
 
     Correct allele specific annotations that are longer than the length of LA.
 

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -159,7 +159,8 @@ def run(
     vds_path: str,
     sample_qc_ht_path: str,
     relateds_to_drop_ht_path: str,
-    out_vcf_path: str,
+    out_as_vcf_path: str,
+    out_quasi_vcf_path: str,
     out_ht_path: str,
     out_ht_pre_vcf_adjusted_path: str,
 ):
@@ -177,10 +178,11 @@ def run(
         out_ht_path=out_ht_path,
         out_ht_pre_vcf_adjusted_path=out_ht_pre_vcf_adjusted_path,
     )
-    logging.info(f'Writing site-only VCF to {out_vcf_path}')
-    assert to_path(out_vcf_path).suffix == '.bgz'
-    hl.export_vcf(as_info_ht, str(out_vcf_path), tabix=True)
-    hl.export_vcf(quasi_info_ht, str(out_vcf_path), tabix=True)
+    logging.info(f'Writing AS VCF to {out_as_vcf_path} and quasi-AS VCF to {out_quasi_vcf_path}')
+    assert to_path(out_as_vcf_path).suffix == '.bgz'
+    assert to_path(out_quasi_vcf_path).suffix == '.bgz'
+    hl.export_vcf(as_info_ht, str(out_as_vcf_path), tabix=True)
+    hl.export_vcf(quasi_info_ht, str(out_quasi_vcf_path), tabix=True)
 
 
 def build_info_ht(ht: hl.Table, extra_field: str) -> hl.Table:

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -215,7 +215,7 @@ def vds_to_site_only_ht(
     correct_mt = _filter_rows_and_add_tags(correct_mt)
     # TODO: Figure out the right output pathing function for this checkpoint
     correct_mt = correct_mt.checkpoint(
-        dataset_path('corrected.mt', category='tmp'),
+        dataset_path('MakeSiteOnly/corrected.mt', category='tmp'),
         overwrite=True,
     )
     info_ht: hl.Table = _create_info_ht(correct_mt, n_partitions=mt.n_partitions())

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -234,7 +234,7 @@ def vds_to_site_only_ht(
         return hl.read_table(str(out_ht_path))
 
     # Passing un-densified MatrixTable to default_compute_info
-    mt = hl.vds.to_dense_mt(vds)
+    mt = vds.variant_data
 
     mt = mt.filter_cols(hl.len(sample_qc_ht[mt.col_key].filters) > 0, keep=False)
     mt = mt.filter_cols(hl.is_defined(relateds_to_drop_ht[mt.col_key]), keep=False)

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -8,11 +8,151 @@ import logging
 import hail as hl
 
 from cpg_utils import Path, to_path
-from cpg_utils.config import config_retrieve
+from cpg_utils.config import config_retrieve, dataset_path, output_path
 from cpg_workflows.batch import override_jar_spec
 from cpg_workflows.utils import can_reuse
-from gnomad.utils.sparse_mt import default_compute_info
+from gnomad.utils.sparse_mt import AS_INFO_AGG_FIELDS, default_compute_info, get_as_info_expr, split_lowqual_annotation
 from gnomad.utils.vcf import adjust_vcf_incompatible_types
+
+
+def extract_as_pls(
+    lpl_expr: hl.expr.ArrayExpression,
+    allele_idx: hl.expr.Int32Expression,
+) -> hl.expr.ArrayExpression:
+    """
+    Extract PLs for a specific allele from an LPL array expression.
+
+    PL/LPL represents the normalized Phred-scaled likelihoods of the possible
+    genotypes from all considered alleles (or local alleles).
+
+    If three alleles are considered, LPL genotype indexes are:
+    [0/0, 0/1, 1/1, 0/2, 1/2, 2/2].
+
+    If we want to extract the PLs for each alternate allele, we need to extract:
+        - allele 1: [0/0, 0/1, 1/1]
+        - allele 2: [0/0, 0/2, 2/2]
+
+    Example:
+        - LPL: [138, 98, 154, 26, 0, 14]
+        - Extract allele 1 PLs: [0/0, 0/1, 1/1] -> [138, 98, 154]
+        - Extract allele 2 PLs: [0/0, 0/2, 2/2] -> [138, 26, 14]
+
+    :param lpl_expr: LPL ArrayExpression.
+    :param allele_idx: The index of the alternate allele to extract PLs for.
+    :return: ArrayExpression of PLs for the specified allele.
+    """
+    calls_to_keep = hl.array(
+        [hl.call(0, 0), hl.call(0, allele_idx), hl.call(allele_idx, allele_idx)],
+    )
+    return calls_to_keep.map(lambda c: lpl_expr[c.unphased_diploid_gt_index()])
+
+
+def recompute_as_qualapprox_from_lpl(mt: hl.MatrixTable) -> hl.expr.ArrayExpression:
+    """
+    Recompute AS_QUALapprox from LPL.
+
+    QUALapprox is the (Phred-scaled) probability that all reads at the site are hom-ref,
+    so QUALapprox is PL[0]. To get the QUALapprox for just one allele, pull out the
+    PLs for just that allele, then normalize by subtracting the smallest element from
+    all the entries (so the best genotype is 0) and then use the normalized PL[0]
+    value for that allele's QUALapprox.
+
+    .. note::
+
+        - The first element of AS_QUALapprox is always None.
+        - If the allele is a star allele, we set QUALapprox for that allele to 0.
+        - If GQ == 0 and PL[0] for the allele == 1, we set QUALapprox for the allele
+          to 0.
+
+    Example:
+        Starting Values:
+            - alleles: [‘G’, ‘*’, ‘A’, ‘C’, ‘GCTT’, ‘GT’, ‘T’]
+            - LGT: 1/2
+            - LA: [0, 1, 6]
+            - LPL: [138, 98, 154, 26, 0, 14]
+            - QUALapprox: 138
+
+        Use `extract_as_pls` to get PLs for each allele:
+            - allele 1: [138, 98, 154]
+            - allele 2: [138, 26, 14]
+
+        Normalize PLs by subtracting the smallest element from all the PLs:
+            - allele 1: [138-98, 98-98, 154-98] -> [40, 0, 56]
+            - allele 2: [138-14, 26-14, 14-14] -> [124, 12, 0]
+
+        Use the first element of the allele specific PLs to generate AS_QUALapprox:
+        [None, 40, 124]
+
+        Set QUALapprox to 0 for the star allele: [None, 0, 124]
+
+    :param mt: Input MatrixTable.
+    :return: AS_QUALapprox ArrayExpression recomputed from LPL.
+    """
+    return hl.enumerate(mt.LA).map(
+        lambda i: (
+            hl.case()
+            .when(mt.alleles[i[1]] == "*", 0)
+            .when(
+                i[0] > 0,
+                hl.bind(
+                    lambda pl_0: hl.if_else((mt.GQ == 0) & (pl_0 == 1), 0, pl_0),
+                    hl.bind(lambda x: x[0] - hl.min(x), extract_as_pls(mt.LPL, i[0])),
+                ),
+            )
+            .or_missing()
+        ),
+    )
+
+
+def correct_as_annotations(
+    mt: hl.MatrixTable,
+    set_to_missing: bool = False,
+) -> hl.expr.StructExpression:
+    """
+    Correct allele specific annotations that are longer than the length of LA.
+
+    For some entries in the MatrixTable, the following annotations are longer than LA,
+    when they should be the same length as LA:
+
+        - AS_SB_TABLE
+        - AS_RAW_MQ
+        - AS_RAW_ReadPosRankSum
+        - AS_RAW_MQRankSum
+
+    This function corrects these annotations by either dropping the alternate allele
+    with the index corresponding to the min value of AS_RAW_MQ, or setting them to
+    missing if `set_to_missing` is True.
+
+    :param mt: Input MatrixTable.
+    :param set_to_missing: Whether to set the annotations to missing instead of
+        correcting them.
+    :return: StructExpression with corrected allele specific annotations.
+    """
+    annotations_to_correct = [
+        "AS_SB_TABLE",
+        "AS_RAW_MQ",
+        "AS_RAW_ReadPosRankSum",
+        "AS_RAW_MQRankSum",
+    ]
+    annotations_to_correct_dict = {a: mt.gvcf_info[a] for a in annotations_to_correct}
+
+    # Identify index corresponding to min of AS_RAW_MQ, skipping the reference allele.
+    as_raw_mq_no_ref = mt.gvcf_info.AS_RAW_MQ[1:]
+    idx_remove = as_raw_mq_no_ref.index(hl.min(as_raw_mq_no_ref)) + 1
+
+    corrected_annotations = {
+        a: hl.if_else(
+            hl.len(expr) > hl.len(mt.LA),
+            hl.or_missing(
+                not set_to_missing,
+                expr[:idx_remove].extend(expr[idx_remove + 1 :]),
+            ),
+            expr,
+        )
+        for a, expr in annotations_to_correct_dict.items()
+    }
+
+    return hl.struct(**corrected_annotations)
 
 
 def run(
@@ -55,13 +195,26 @@ def vds_to_site_only_ht(
     if can_reuse(out_ht_path):
         return hl.read_table(str(out_ht_path))
 
-    mt = hl.vds.to_dense_mt(vds)
+    # passing un-densified MatrixTable to default_compute_info
+    mt = vds.variant_data
 
-    mt = mt.filter_cols(hl.len(sample_qc_ht[mt.col_key].filters) > 0, keep=False)
-    mt = mt.filter_cols(hl.is_defined(relateds_to_drop_ht[mt.col_key]), keep=False)
+    correct_mt = mt.annotate_entries(
+        gvcf_info=mt.gvcf_info.annotate(
+            AS_QUALapprox=recompute_as_qualapprox_from_lpl(mt),
+            **correct_as_annotations(mt),
+        ),
+    )
 
-    mt = _filter_rows_and_add_tags(mt)
-    var_ht = _create_info_ht(mt, n_partitions=mt.n_partitions())
+    correct_mt = correct_mt.filter_cols(hl.len(sample_qc_ht[correct_mt.col_key].filters) > 0, keep=False)
+    correct_mt = correct_mt.filter_cols(hl.is_defined(relateds_to_drop_ht[correct_mt.col_key]), keep=False)
+
+    correct_mt = _filter_rows_and_add_tags(correct_mt)
+    # TODO: Figure out the right output pathing function for this checkpoint
+    correct_mt = correct_mt.checkpoint(
+        dataset_path('corrected.mt', category='tmp'),
+        overwrite=True,
+    )
+    var_ht: hl.Table = _create_info_ht(correct_mt, n_partitions=mt.n_partitions())
     var_ht = var_ht.checkpoint(out_ht_pre_vcf_adjusted_path, overwrite=True)
     var_ht = adjust_vcf_incompatible_types(
         var_ht,
@@ -96,8 +249,27 @@ def _filter_rows_and_add_tags(mt: hl.MatrixTable) -> hl.MatrixTable:
     return mt.annotate_rows(ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2)
 
 
-def _create_info_ht(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
+def _create_info_ht(correct_mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
     """Create info table from vcf matrix table"""
-    info_ht = default_compute_info(mt, site_annotations=True, n_partitions=n_partitions)
-    info_ht = info_ht.annotate(info=info_ht.info.annotate(DP=mt.rows()[info_ht.key].site_dp))
+    # Using corrected_mt for all instances of info_ht in this function
+    # Do we want to keep the quasi annotations? We still need to run default_compute_info
+    # to generate site_annotations (are they already in gvcf_info?) and gnomAD's run_compute_info
+    # already generates AS_ annotations separately via `get_as_info_expr`.
+    ht: hl.Table = default_compute_info(correct_mt, site_annotations=True, n_partitions=n_partitions)
+
+    # TODO: Check output_path is correct
+    # quasi_info_ht = ht.checkpoint(output_path('quasi_info_ht.ht', category='tmp'), overwrite=True)
+
+    ht = correct_mt.select_rows(
+        **get_as_info_expr(
+            correct_mt,
+            # Use global AS_INFO_AGG_FIELDS for sum_agg_fields, int32_sum_agg_fields,
+            # median_agg_fields, and array_sum_agg_fields parameters.
+            **AS_INFO_AGG_FIELDS,
+            treat_fields_as_allele_specific=True,
+        ),
+    ).rows()
+
+    info_ht = ht.checkpoint()
+    info_ht = info_ht.annotate(info=info_ht.info.annotate(DP=correct_mt.rows()[info_ht.key].site_dp))
     return info_ht

--- a/cpg_workflows/large_cohort/site_only_vcf.py
+++ b/cpg_workflows/large_cohort/site_only_vcf.py
@@ -234,7 +234,7 @@ def vds_to_site_only_ht(
         return hl.read_table(str(out_ht_path))
 
     # Passing un-densified MatrixTable to default_compute_info
-    mt = vds.variant_data
+    mt = hl.vds.to_dense_mt(vds)
 
     mt = mt.filter_cols(hl.len(sample_qc_ht[mt.col_key].filters) > 0, keep=False)
     mt = mt.filter_cols(hl.is_defined(relateds_to_drop_ht[mt.col_key]), keep=False)

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -360,7 +360,7 @@ class Vqsr(CohortStage):
         vqsr_version = vqsr_version or get_workflow().output_version
         as_or_quasi = config_retrieve(
             ['large_cohort', 'vqsr_input_vcf'],
-            default='as',
+            default='quasi',
         )
         return {
             'vcf': cohort.analysis_dataset.prefix()
@@ -383,7 +383,7 @@ class Vqsr(CohortStage):
         vcf_path = inputs.as_path(
             cohort,
             MakeSiteOnlyVcf,
-            key=config_retrieve(['large_cohort', 'vqsr_input_vcf'], default='as'),
+            key=config_retrieve(['large_cohort', 'vqsr_input_vcf'], default='quasi'),
         )
         jobs = vqsr.make_vqsr_jobs(
             b=get_batch(),

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -288,7 +288,8 @@ def test_site_only(mocker: MockFixture, tmp_path: Path):
         [compressed_sample_qc_ht_path, compressed_vds_path, compressed_relateds_to_drop_ht_path],
     )
 
-    siteonly_vcf_path = tmp_path / 'siteonly.vcf.bgz'
+    as_siteonly_vcf_path = tmp_path / 'as_siteonly.vcf.bgz'
+    quasi_siteonly_vcf_path = tmp_path / 'quasi_siteonly.vcf.bgz'
     site_only_vcf.run(
         vds_path=str(tmp_path / 'v01.vds'),
         sample_qc_ht_path=str(tmp_path / 'sample_qc.ht'),
@@ -300,7 +301,8 @@ def test_site_only(mocker: MockFixture, tmp_path: Path):
     )
 
     # do some testing here
-    assert exists_not_cached(siteonly_vcf_path)
+    assert exists_not_cached(as_siteonly_vcf_path)
+    assert exists_not_cached(quasi_siteonly_vcf_path)
 
 
 def test_ancestry(tmp_path: Path):

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -286,7 +286,8 @@ def test_site_only(mocker: MockFixture, tmp_path: Path):
         vds_path=str(tmp_path / 'v01.vds'),
         sample_qc_ht_path=str(tmp_path / 'sample_qc.ht'),
         relateds_to_drop_ht_path=str(tmp_path / 'relateds_to_drop.ht'),
-        out_vcf_path=str(siteonly_vcf_path),
+        out_as_vcf_path=str(tmp_path / 'as_siteonly.vcf.bgz'),
+        out_quasi_vcf_path=str(tmp_path / 'quasi_siteonly.vcf.bgz'),
         out_ht_path=str(tmp_path / 'siteonly.ht'),
         out_ht_pre_vcf_adjusted_path=str(tmp_path / 'siteonly_pre_vcf_adjusted.ht'),
     )

--- a/test/test_large_cohort.py
+++ b/test/test_large_cohort.py
@@ -272,6 +272,13 @@ def test_relatedness(mocker: MockFixture, tmp_path: Path):
 
 
 def test_site_only(mocker: MockFixture, tmp_path: Path):
+    conf = create_config(tmp_path)
+    set_config(
+        conf,
+        tmp_path / 'config.toml',
+        merge_with=[DEFAULT_CONFIG, LARGE_COHORT_CONFIG],
+    )
+
     # skip can_reuse, implicit skip of existence checks
     mocker.patch('cpg_workflows.large_cohort.site_only_vcf.can_reuse', lambda x: False)
 


### PR DESCRIPTION
This PR extends our MakeSiteOnlyVcf workflow to support generating both quasi and true allele-specific (AS) annotations so that we can systematically evaluate the differences in variant filtering and downstream VQSR performance across the two methods. These changes aim to give us the flexibility to reproduce gnomAD-style quasi-AS processing while optionally incorporating corrected AS metrics as described in their internal fixes.

## Context
In our variant QC pipeline, we filter variants using several criteria, including:

1. AS_lowqual:

- Remove SNVs with `AS_QUALapprox < 60` and indels with `AS_QUALapprox < 70`.
- These values combine thresholds from `get_lowqual_expr` (e.g., `snv_phred_threshold` + `snv_phred_het_prior = 30 + 30 = 60` for SNVs).

2. AS_VQSR:

- Remove variants with `AS_VQSLOD < args.snv_score_cutoff` or `args.indel_score_cutoff`.

3. Other filters (not changed in this PR): `AC0` filter, `InbreedingCoeff` filter, etc.

While gnomAD v4 uses quasi-AS annotations (i.e. per-allele summaries of non-AS gVCF INFO fields), they also discovered issues with the raw `AS_QUALapprox` values due to inconsistencies between the `LPL` and local alleles (e.g. when `*` alleles are present). To correct this, they implemented a fix that recomputes `AS_QUALapprox` directly from the `LPL` field. However, they continued to apply the `AS_lowqual` filter using the uncorrected values from `quasi_info`.

Our goal is to:

- Maintain compatibility with this quasi-AS behaviour.
- Optionally generate and filter on fully corrected AS annotations (including true `AS_QUALapprox`, `AS_SB_TABLE`, `AS_RAW_MQ`, etc.), allowing us to decide which performs better in our cohorts.

## Code Changes

- Added: `extract_as_pls()` and `recompute_as_qualapprox_from_lpl()` utilities to support recomputation of true `AS_QUALapprox` from `LPL` arrays.
- Will Enable: Optionally switching between quasi_info and true-AS compute_info strategies by toggling compute_info_method, consistent with gnomAD but extensible for our use cases.


## To do:

- Run the initial variant QC process for our first release cohort using both approaches.
- Compare variant filtering outcomes and VQSR sensitivity/specificity downstream.