### PR TITLE
Add train gcnv stage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.2
+current_version = 1.37.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.2
+  VERSION: 1.37.3
 
 jobs:
   docker:

--- a/configs/defaults/gatk_sv_multisample.toml
+++ b/configs/defaults/gatk_sv_multisample.toml
@@ -12,6 +12,9 @@ gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
 # Create Seqr ElasticSearch indices for these datasets. Required for the MtToEsSv stage.
 # create_es_index_for_datasets = []
 
+# number of Model Tar files expected/generated in TrainGCNV
+model_tar_count = 290
+
 # switches to deactivate all Metrics workflows. We ran into some resourcing issues when our total
 # cohort size approached ~1600. Response when raised with GATK team:
 #
@@ -22,6 +25,7 @@ gencode_gtf_file = 'gs://cpg-common-main/references/hg38/v0/gencode_47.gtf.gz'
 # on each output of the stage, producing output files containing a count/distribution of different variants
 # and sizes. The workflow files we are using as Stages do not always capture these results as top-level outputs,
 # so we have no reliable method to extract these files into permanent storage.
+
 [resource_overrides.GatherBatchEvidence]
 run_matrix_qc = false
 run_module_metrics = false
@@ -44,6 +48,10 @@ n_RD_genotype_bins = 100000
 
 [resource_overrides.MakeCohortVcf]
 run_module_metrics = false
+
+[resource_overrides.MakeCohortVcf.runtime_override_plot_qc_per_family]
+mem_gb = 32
+disk_gb = 250
 
 [resource_overrides.FilterGenotypes]
 run_qc = false

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -52,7 +52,6 @@ def run(
 
     init_batch(
         worker_memory=config_retrieve(['combiner', 'worker_memory']),
-        worker_cores=config_retrieve(['combiner', 'worker_cores']),
         driver_memory=config_retrieve(['combiner', 'driver_memory']),
         driver_cores=config_retrieve(['combiner', 'driver_cores']),
     )

--- a/cpg_workflows/scripts/talos_prep/extract_fragmented_vcf_from_mt.py
+++ b/cpg_workflows/scripts/talos_prep/extract_fragmented_vcf_from_mt.py
@@ -114,7 +114,13 @@ def main(
     sites_only_ht = hl.read_matrix_table(output_mt).rows()
 
     get_logger().info('Writing sites-only VCF in fragments, header-per-shard')
-    hl.export_vcf(sites_only_ht, output_sites_only, tabix=True, parallel='separate_header', metadata=VQSR_FILTERS,)
+    hl.export_vcf(
+        sites_only_ht,
+        output_sites_only,
+        tabix=True,
+        parallel='separate_header',
+        metadata=VQSR_FILTERS,
+    )
 
 
 def cli_main():

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_common.py
@@ -208,33 +208,6 @@ def add_gatk_sv_jobs(
     return [submit_j, copy_j]
 
 
-def get_ref_panel(keys: list[str] | None = None) -> dict:
-    # mandatory config entry
-    ref_panel_samples = config_retrieve(['sv_ref_panel', 'ref_panel_samples'])
-    return {
-        k: v
-        for k, v in {
-            'ref_panel_samples': ref_panel_samples,
-            'ref_panel_bincov_matrix': reference_path('broad/ref_panel_bincov_matrix'),
-            'contig_ploidy_model_tar': reference_path('gatk_sv/contig_ploidy_model_tar'),
-            'gcnv_model_tars': [
-                str(reference_path('gatk_sv/model_tar_tmpl')).format(shard=i)
-                for i in range(config_retrieve(['sv_ref_panel', 'model_tar_cnt']))
-            ],
-            'ref_panel_PE_files': [
-                reference_path('gatk_sv/ref_panel_PE_file_tmpl').format(sample=s) for s in ref_panel_samples
-            ],
-            'ref_panel_SR_files': [
-                reference_path('gatk_sv/ref_panel_SR_file_tmpl').format(sample=s) for s in ref_panel_samples
-            ],
-            'ref_panel_SD_files': [
-                reference_path('gatk_sv/ref_panel_SD_file_tmpl').format(sample=s) for s in ref_panel_samples
-            ],
-        }.items()
-        if not keys or k in keys
-    }
-
-
 def clean_ped_family_ids(ped_line: str) -> str:
     """
     Takes each line in the pedigree and cleans it up

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -5,13 +5,13 @@ All post-batching stages of the GATK-SV workflow
 from collections import defaultdict
 from functools import cache
 from itertools import combinations
-from typing import Any
 from random import sample
+from typing import Any
 
 from google.api_core.exceptions import PermissionDenied
 
 from cpg_utils import Path, to_path
-from cpg_utils.config import AR_GUID_NAME, config_retrieve, image_path, try_get_ar_guid, reference_path
+from cpg_utils.config import AR_GUID_NAME, config_retrieve, image_path, reference_path, try_get_ar_guid
 from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, get_batch
 from cpg_workflows.jobs import ploidy_table_from_ped
 from cpg_workflows.jobs.gatk_sv import rename_sv_ids

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.2',
+    version='1.37.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Back-port the TrainGCNV stage implementation from https://github.com/populationgenomics/cpg-flow-gatk-sv

- removes the `get_ref_panel` method (which was only called once, and now needs to do a bit less)
- uses a randomly sampled subset of the Cohort samples to train a gCNV model
- extracts 290 TAR files based on test runs (will keep an eye on the Cromwell outputs to make sure this number is a correct choice)
- feeds those TAR files (plus one contig ploidy model) into GatherBatchEvidence