### PR TITLE
Revert addition of worker_cores arg in combiner init_batch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.2
+current_version = 1.37.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.2
+  VERSION: 1.37.3
 
 jobs:
   docker:

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -53,7 +53,7 @@ driver_cores = 2
 # highem, standard, or a string, e.g. "4Gi"
 worker_memory = "highmem"
 # integer
-worker_cores = 2
+worker_cores = 1
 # if false, use non-preemptible VMs
 preemptible_vms = false
 

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -52,6 +52,8 @@ driver_storage = "10Gi"
 driver_cores = 2
 # highem, standard, or a string, e.g. "4Gi"
 worker_memory = "highmem"
+# integer
+worker_cores = 2
 # if false, use non-preemptible VMs
 preemptible_vms = false
 

--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -52,8 +52,6 @@ driver_storage = "10Gi"
 driver_cores = 2
 # highem, standard, or a string, e.g. "4Gi"
 worker_memory = "highmem"
-# integer
-worker_cores = 1
 # if false, use non-preemptible VMs
 preemptible_vms = false
 

--- a/cpg_workflows/jobs/rd_combiner/combiner.py
+++ b/cpg_workflows/jobs/rd_combiner/combiner.py
@@ -52,7 +52,6 @@ def run(
 
     init_batch(
         worker_memory=config_retrieve(['combiner', 'worker_memory']),
-        worker_cores=config_retrieve(['combiner', 'worker_cores']),
         driver_memory=config_retrieve(['combiner', 'driver_memory']),
         driver_cores=config_retrieve(['combiner', 'driver_cores']),
     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.2',
+    version='1.37.3',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Reverts https://github.com/populationgenomics/production-pipelines/pull/1235/files

Removes the combiner.worker_cores config arg to init_batch in combiner.py, because it's not used and causes error on startup. More detail in @MattWellie's comment below.

~Sets the worker cores in the rd_combiner stage to 1, which is [the hail default](https://github.com/populationgenomics/hail/blob/main/hail/python/hail/context.py#L319).~

~Without the worker cores in the default config, the combiner will fail to start unless the user adds it to their custom config included in their analysis-runner submission.~

e.g. https://batch.hail.populationgenomics.org.au/batches/616323/jobs/1
```
Traceback (most recent call last):
  File "<string>", line 32, in <module>
  File "/cpg_workflows/jobs/rd_combiner/combiner.py", line 55, in run
    worker_cores=config_retrieve(['combiner', 'worker_cores']),
  File "/usr/local/lib/python3.10/site-packages/cpg_utils/config.py", line 253, in config_retrieve
    raise ConfigError(message)
cpg_utils.config.ConfigError: Key "worker_cores" not found in {'force_new_combiner': False,  ...
```