### PR TITLE
Hide test/test_size.py from pytest

### DIFF
--- a/test/test_size.py
+++ b/test/test_size.py
@@ -1,7 +1,7 @@
 import hailtop.batch as hb
 
 
-def test_python_function(*values):
+def python_test_function(*values):
     # making this smaller with 101 jobs means it passes
     print(*values)
     h = hash(values)
@@ -22,6 +22,6 @@ if __name__ == '__main__':
     # 101 submits, 102 fails
     for i in range(102):
         j = b.new_python_job(f'Function call {i+1}')
-        j.call(test_python_function, i + 1)
+        j.call(python_test_function, i + 1)
 
     submitted = b.run(wait=False)


### PR DESCRIPTION
I don't know why [this has recently started failing](https://github.com/populationgenomics/production-pipelines/actions/workflows/test.yaml), but the truth is _test_size.py_ is some sort of standalone manually executed test script; its `test_python_function()` is not a test case that should be picked up by `pytest`. Renaming the function prevents that.