### PR TITLE
VDS re-code: 133 in 134 out

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.3
+current_version = 1.37.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.3
+  VERSION: 1.37.4
 
 jobs:
   docker:

--- a/cpg_workflows/scripts/rewrite_vds_on_hail_134.py
+++ b/cpg_workflows/scripts/rewrite_vds_on_hail_134.py
@@ -1,0 +1,24 @@
+"""
+Hail 0.2.134 is highly problematic - it has the glaring limitation that it cannot combine data into any VDS created
+before Hail 134, which at the moment is almost all our data.
+
+This script takes a path to a VDS on 133, writes a copy to a given location. That location can be passed to a new
+combiner run, which will then be able to combine data into it.
+"""
+
+import argparse
+
+import hail as hl
+
+from cpg_utils import hail_batch
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Write Hail 0.2.133 VDS as 0.2.134, so that it can be used to combine')
+    parser.add_argument('vds_path', type=str, help='Path to the VDS to swap out')
+    parser.add_argument('tmp_path', type=str, help='Temporary path to write the swapped VDS to')
+    args = parser.parse_args()
+
+    hail_batch.init_batch()
+
+    vds = hl.vds.read_vds(args.vds_path)
+    vds.write(args.tmp_path, overwrite=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.3',
+    version='1.37.4',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Due to Hail 134 issues, any pre-134 VDSs being used in combining must first be written back out in 134 format, then combined. 

There's a range of possible actions here, from re-combining everything on 134, to overwriting all extant 133 data as 134 and then combining on top. 

This straddles the middle -
- reads in 133 data, and writes to a new location using 134. Importantly the existing 133 data is unmodified, so the analysis entry integrity is maintained. Just in case... y'know, more surprises turn up with this new data
- the combiner process is edited so that it can combine data using paths in config instead of analysis entries. RD never used the existing analysis-ID option anyway, and this method prevents the need to register this duplicate data in metamist (along with all the contained sample IDs) in order to make use of it. 