### PR TITLE
Prevent running of migrated workflows in this codebase

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ from cpg_workflows.stages.talos import MakePhenopackets, MinimiseOutputForSeqr, 
 from cpg_workflows.stages.talos_prep.talos_prep import SquashMtIntoTarball
 from cpg_workflows.workflow import StageDecorator, run_workflow
 
+MIGRATED_WORKFLOWS = ['talos', 'clinvarbitration']
 WORKFLOWS: dict[str, list[StageDecorator]] = {
     'clinvarbitration': [PackageForRelease],
     'talos': [MakePhenopackets, ValidateMOI, UploadTalosHtml, MinimiseOutputForSeqr],
@@ -156,6 +157,10 @@ def main(
     """
     fmt = '%(asctime)s %(levelname)s (%(pathname)s %(lineno)s): %(message)s'
     coloredlogs.install(level='DEBUG' if verbose else 'INFO', fmt=fmt)
+
+    if workflow in MIGRATED_WORKFLOWS:
+        click.echo(f'Workflow "{workflow}" has been migrated to cpg-flow, please use the migrated version instead.')
+        return
 
     if not workflow and not list_workflows:
         click.echo('You must specify WORKFLOW as a first positional command line argument.')


### PR DESCRIPTION
Purely out of force of habit I just ran the production-pipelines version of a migrated workflow. Not only did this run old code, it also might contain some bugs which were found and patched during migration, without the changes being backported to this codebase (because why).

It makes sense to disable this possibility, without having to delete all the code in this repository. Adding an extensible list of migrated workflows, an informative error message, and leaving the underlying code intact, seems like a quick and easy compromise

... I think the Dragen workflow might also be fully migrated and in use, but that had a different runner script. Feel free to extend this initial list if there are other successful migrations to disable.