### PR TITLE
Add the DatasetVCF stage to rd_combiner workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.6
+current_version = 1.37.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.6
+  VERSION: 1.37.7
 
 jobs:
   docker:

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from cpg_workflows.stages.outrider import Outrider
 from cpg_workflows.stages.rd_combiner import (
     AnnotateCohortSmallVariantsWithHailQuery,
     AnnotateDatasetSmallVariantsWithHailQuery,
+    AnnotatedDatasetMtToVcfWithHailQuery,
     AnnotateFragmentedVcfWithVep,
     ConcatenateVcfFragmentsWithGcloud,
     CreateDenseMtFromVdsWithHail,
@@ -77,6 +78,7 @@ WORKFLOWS: dict[str, list[StageDecorator]] = {
         AnnotateCohortSmallVariantsWithHailQuery,
         SubsetMatrixTableToDatasetUsingHailQuery,
         AnnotateDatasetSmallVariantsWithHailQuery,
+        AnnotatedDatasetMtToVcfWithHailQuery,
         ExportMtAsEsIndex,
     ],
     'seqr_loader': [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.6',
+    version='1.37.7',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Quick and dirty move of [the `DatasetVCF` stage](https://github.com/populationgenomics/production-pipelines/blob/86f1c5b30364702a0bc859ef73bde3b357249a8e/cpg_workflows/stages/seqr_loader.py#L122) from the `seqr_loader` workflow into the `rd_combiner` workflow.

Also adds the functionality of subsetting the dataset to specific families.