### PR TITLE
Add default global age distribution for browser tables

### DIFF
--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -180,11 +180,13 @@ def prepare_gnomad_v4_variants_helper(ds_path: str | None, exome_or_genome: str)
 
         age_hist = hl.struct(
             bin_edges=hl.literal([30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 80.0]),
-            bin_freq=hl.literal([0] * 11),
+            bin_freq=hl.literal([0] * 10),
             n_smaller=hl.int32(0),
             n_larger=hl.int32(0),
         )
-        ds = ds.annotate_globals(age_distribution=age_hist)
+
+        ds_globals = ds.globals.annotate(**{f"{exome_or_genome}_age_distribution": age_hist})
+        ds = ds.annotate_globals(**ds_globals)
 
         ds = ds.rename({'type': exome_or_genome})
         return ds

--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -177,6 +177,15 @@ def prepare_gnomad_v4_variants_helper(ds_path: str | None, exome_or_genome: str)
 
     if ds_path is None:
         ds = hl.Table.parallelize(hl.literal([], "".join(EMPTY_TABLE_CONFIG.split()))).key_by('locus', 'alleles')
+
+        age_hist = hl.struct(
+            bin_edges=hl.literal([30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 80.0]),
+            bin_freq=hl.literal([0] * 11),
+            n_smaller=hl.int32(0),
+            n_larger=hl.int32(0),
+        )
+        ds = ds.annotate_globals(age_distribution=age_hist)
+
         ds = ds.rename({'type': exome_or_genome})
         return ds
 


### PR DESCRIPTION
Now that browser loading pulls the age distribution straight from the…global variable, we need to add a default for empty tables.