### PR TITLE
shebang added

### DIFF
--- a/cpg_workflows/large_cohort/sites_table_job.py
+++ b/cpg_workflows/large_cohort/sites_table_job.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 from lib2to3.pgen2 import driver
 


### PR DESCRIPTION
without shebang, need call with analysis runner to be 'python sites_table_job.py ', but i think this means we then copy the local ENV and we get a `ValueError: No billing project.  Call 'init_batch' with the billing project or run 'hailctl config set batch/billing_project MY_BILLING_PROJECT`