### PR TITLE
Vcf from mt fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.7
+current_version = 1.37.8
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.8
+current_version = 1.37.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.7
+  VERSION: 1.37.8
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.8
+  VERSION: 1.37.9
 
 jobs:
   docker:

--- a/cpg_workflows/stages/rd_combiner.py
+++ b/cpg_workflows/stages/rd_combiner.py
@@ -764,7 +764,7 @@ class AnnotatedDatasetMtToVcfWithHailQuery(DatasetStage):
         if dataset.name not in eligible_datasets:
             return None
 
-        mt_path = inputs.as_path(target=dataset, stage=AnnotateDatasetSmallVariantsWithHailQuery, key='mt')
+        mt_path = inputs.as_path(target=dataset, stage=AnnotateDatasetSmallVariantsWithHailQuery)
 
         job = cohort_to_vcf_job(
             b=get_batch(),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.8',
+    version='1.37.9',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.7',
+    version='1.37.8',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The expected outputs from `AnnotateDatasetSmallVariantsWithHailQuery` are not a dict, whilst in the `seqr_loader` pipeline (which I copied and pasted the mt to VCF stage from) they are. This change removes the dict key from the `inputs.as_path` call to prevent the error seen [here](https://batch.hail.populationgenomics.org.au/batches/618427/jobs/1).

```
File "/production-pipelines/cpg_workflows/workflow.py", line 154, in _get
    raise ValueError(f'{self.stage}: {self.data} is not a dictionary, can\'t get "{key}"')
ValueError: AnnotateDatasetSmallVariantsWithHailQuery <- [AnnotateCohortSmallVariantsWithHailQuery, SubsetMatrixTableToDatasetUsingHailQuery]: gs://cpg-heartkids-main/mt/AnnotateDatasetSmallVariantsWithHailQuery/5fae2753fb994fee344bbfac04aed6e66b3e3a_5804-heartkids.mt is not a dictionary, can't get "mt"
```