### PR TITLE
write_vcf rd_combiner.toml default config option

### DIFF
--- a/configs/defaults/rd_combiner.toml
+++ b/configs/defaults/rd_combiner.toml
@@ -37,6 +37,9 @@ indel_recal_disc_size = 20
 snps_gather_disc_size = 10
 snps_recal_disc_size = 20
 
+# add any datasets to this list to export a VCF from the Annotated Dataset mt
+write_vcf = []
+
 [workflow.es_index]
 # if false, use a non-preemptible instance to run the ES export
 spot_instance = false

--- a/configs/defaults/seqr_loader.toml
+++ b/configs/defaults/seqr_loader.toml
@@ -34,7 +34,7 @@ reblock_gq_bands = [13, 20, 30, 40]
 # Create Seqr ElasticSearch indices for these datasets. Required for the MtToEs stage.
 # create_es_index_for_datasets = []
 
-write_vcf = ["udn-aus"]
+write_vcf = []
 
 # Add in specific multiQC report config options
 # See https://multiqc.info/docs/getting_started/config for more details


### PR DESCRIPTION
Add in the config default for the write_vcf option, without it the rd_combiner workflow won't start

e.g. https://batch.hail.populationgenomics.org.au/batches/618474/jobs/1

```
cpg_utils.config.ConfigError: Key "write_vcf" not found in {...}
```

Also removes the hard-coded dataset name from the seqr_loader config, it's not used anymore but it shouldn't really be there either way.