### PR TITLE
Write unique CNV & SV VCF Path

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.9
+current_version = 1.37.10
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.9
+  VERSION: 1.37.10
 
 jobs:
   docker:

--- a/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
+++ b/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py
@@ -1433,7 +1433,9 @@ class SplitAnnotatedSvVcfByDataset(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return dataset.prefix() / 'annotated_sv.vcf.bgz'
+        return (
+            dataset.prefix() / get_workflow().name / get_workflow().output_version / self.name / 'annotated_sv.vcf.bgz'
+        )
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         output = self.expected_outputs(dataset)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -765,7 +765,7 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return dataset.prefix() / 'annotated_sv.vcf.bgz'
+        return dataset.prefix() / get_workflow().name / get_workflow().output_version / self.name / 'annotated_cnv.vcf.bgz'
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         output = self.expected_outputs(dataset)

--- a/cpg_workflows/stages/gcnv.py
+++ b/cpg_workflows/stages/gcnv.py
@@ -765,7 +765,9 @@ class SplitAnnotatedCnvVcfByDataset(DatasetStage):
     """
 
     def expected_outputs(self, dataset: Dataset) -> Path:
-        return dataset.prefix() / get_workflow().name / get_workflow().output_version / self.name / 'annotated_cnv.vcf.bgz'
+        return (
+            dataset.prefix() / get_workflow().name / get_workflow().output_version / self.name / 'annotated_cnv.vcf.bgz'
+        )
 
     def queue_jobs(self, dataset: Dataset, inputs: StageInput) -> StageOutput:
         output = self.expected_outputs(dataset)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.9',
+    version='1.37.10',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Major oversight from me - the CNV & SV VCFs which are now the starting point for Talos were being written to a really generic path (i.e. `gs://dataset-bucket/annotated_svs.vcf.bgz`). This contained nothing identifying to a specific run/cohort/multicohort, so this stage has only ever been run once.

This change inserts a fully qualified Path (including dataset, multicohort hash, workflow name, stage name), so it's guaranteed to run with each gCNV/GATK-SV pipeline run

I already fixed this in the CPG-Flow migration of GATK-SV, and just added it to the [gCNV migration](https://github.com/populationgenomics/cpg-flow-gcnv/pull/2) 