### PR TITLE
allow passing in a VDS via config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.37.10
+current_version = 1.37.11
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 1.37.10
+  VERSION: 1.37.11
 
 jobs:
   docker:

--- a/cpg_workflows/large_cohort/combiner.py
+++ b/cpg_workflows/large_cohort/combiner.py
@@ -89,6 +89,11 @@ def combiner(cohort: Cohort, output_vds_path: str, save_path: str) -> PythonJob:
 
     sgs_for_withdrawal: list[str] = [sg for sg in sg_ids_in_vds if sg not in cohort_sg_ids]
 
+    # Allow passing in VDS paths via config, workaround for Hail 134 combining woes
+    # We still gather info from Metamist in order to check for withdrawals
+    if specified_vds := config_retrieve(['combiner', 'vds_paths'], None):
+        vds_paths = specified_vds
+
     if not config_retrieve(['combiner', 'merge_only_vds'], False):
         # Get SG IDs from the cohort object itself, rather than call Metamist.
         # Get VDS IDs first and filter out from this list

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.37.10',
+    version='1.37.11',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Pass in a VDS via config, in order to escape from the Hail 134 combiner woes (i.e. we have converted the 133 VDS to 134, but not registered it in Metamist since it'll be transient).