### PR TITLE
Rename incompatible sampleqc fields

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -24,6 +24,32 @@ def reorder_columns(ht: hl.Table, reference_table: hl.Table) -> hl.Table:
     return ht.annotate(sample_qc=hl.struct(**ordered_sample_qc))
 
 
+def sync_sampleqc_hts(dataset_ht: hl.Table, reference_ht: hl.Table) -> tuple[hl.Table, hl.Table]:
+    """
+    Drop columns that are not shared between dataset and reference
+    sample_qc.ht
+    """
+    if dataset_ht.row.dtype.fields == reference_ht.row.dtype.fields:
+        return dataset_ht, reference_ht
+
+    dataset_rows = [i[0] for i in dataset_ht.row.items()]
+    reference_rows = [i[0] for i in reference_ht.row.items()]
+
+    extra_dataset_rows = [i for i in dataset_rows if i not in reference_rows]
+    dataset_ht = dataset_ht.drop(*extra_dataset_rows)
+
+    extra_reference_rows = [i for i in reference_rows if i not in dataset_rows]
+    reference_ht = reference_ht.drop(*extra_reference_rows)
+
+    dataset_ht = reorder_columns(dataset_ht, reference_ht)
+    if dataset_ht.row.dtype.fields == reference_ht.row.dtype.fields:
+        return dataset_ht, reference_ht
+    raise Exception(
+        """Sorry, could not synchronise the dataset and reference
+                    sample_qc hail tables""",
+    )
+
+
 def add_background(
     dense_mt: hl.MatrixTable,
     sample_qc_ht: hl.Table,
@@ -97,11 +123,13 @@ def add_background(
             background_mt = background_mt.naive_coalesce(5000)
             # combine dense dataset with background population dataset
             dense_mt = dense_mt.union_cols(background_mt)
-            sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
+            sample_qc_ht, ht = sync_sampleqc_hts(sample_qc_ht, ht)
+            sample_qc_ht = sample_qc_ht.union(ht)
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')
 
     if drop_columns:
+
         sample_qc_ht = sample_qc_ht.drop(*drop_columns)
 
     return dense_mt, sample_qc_ht


### PR DESCRIPTION
We got an error running the `ancestry` stage [related](https://batch.hail.populationgenomics.org.au/batches/617448/jobs/2)  to dropping columns that were not in one of the `sample_qc.ht`, due to changes in the `sample_qc.ht` schema in different cohorts.

These changes could be:

- Same data source, different row.field name
- Presence absence of row.field
- Asking to drop a row when it is not present

This PR makes two substantive changes as a catch all for all 3:

1. Adding a function, `sync_sampleqc_hts`, and logic, to explicitly drop ow fields missing from the join intersect set of row fields.

I tested this in a notebook:
```
import hail as hl
hgdp_qc   = hl.read_table("gs://cpg-hgdp-main-analysis/large_cohort/v1-0/sample_qc.ht")
ourdna_qc = hl.read_table("gs://cpg-ourdna-main-analysis/large_cohort/c837a1558f7f0c4540f9c68f99e3fa5b2d89ad_101/sample_qc.ht")

ourdna_qc.row.dtype.fields == hgdp_qc.row.dtype.fields
# False
ourdna_qc, hgdp_qc = sync_sampleqc_hts(ourdna_qc, hgdp_qc)
ourdna_qc.row.dtype.fields == hgdp_qc.row.dtype.fields
# True
```

2. When passing `drop_columns`, we first iterate of the row.fields to see if the request columns are still present in the merged `sample_qc.ht`.