### PR TITLE
Allow writing multiple files into a single analysis record

### DIFF
--- a/cpg_workflows/stages/cram_qc.py
+++ b/cpg_workflows/stages/cram_qc.py
@@ -138,7 +138,7 @@ class CramQC(SequencingGroupStage):
         return self.make_outputs(sequencing_group, data=self.expected_outputs(sequencing_group), jobs=jobs)
 
 
-@stage(required_stages=[CramQC])
+@stage(required_stages=[CramQC], analysis_type='qc', analysis_keys=['html', 'samples', 'pairs', 'expected_ped'])
 class SomalierPedigree(DatasetStage):
     """
     Checks pedigree from CRAM fingerprints.
@@ -212,7 +212,7 @@ class SomalierPedigree(DatasetStage):
             return self.make_outputs(dataset, skipped=True)
 
 
-@stage(required_stages=[CramQC, SomalierPedigree], analysis_type='qc', analysis_keys=['json'])
+@stage(required_stages=[CramQC, SomalierPedigree], analysis_type='qc', analysis_keys=['html', 'json'])
 class CramMultiQC(DatasetStage):
     """
     Run MultiQC to aggregate CRAM QC stats.

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -96,12 +96,12 @@ class GvcfHappy(SequencingGroupStage):
             return self.make_outputs(sequencing_group, self.expected_outputs(sequencing_group), jobs)
 
 
-def _update_meta(output_path: str) -> dict[str, Any]:
+def _update_meta(output_paths: dict[str, str | Path]) -> dict[str, Any]:
     import json
 
     from cloudpathlib import CloudPath
 
-    with CloudPath(output_path).open() as f:
+    with CloudPath(output_paths['json']).open() as f:
         d = json.load(f)
     return {'multiqc': d['report_general_stats_data']}
 

--- a/cpg_workflows/stages/gvcf_qc.py
+++ b/cpg_workflows/stages/gvcf_qc.py
@@ -112,7 +112,7 @@ def _update_meta(output_path: str) -> dict[str, Any]:
         GvcfHappy,
     ],
     analysis_type='qc',
-    analysis_keys=['json'],
+    analysis_keys=['html', 'json'],
     update_analysis_meta=_update_meta,
 )
 class GvcfMultiQC(DatasetStage):

--- a/cpg_workflows/stages/stripy.py
+++ b/cpg_workflows/stages/stripy.py
@@ -50,7 +50,7 @@ def _get_target_loci(dataset: str) -> str:
     return target_loci
 
 
-def _update_meta(output_path: str) -> dict[str, Any]:
+def _update_meta(output_paths: dict[str, str | Path]) -> dict[str, Any]:
     """
     Add the detected outlier loci to the analysis meta
     """
@@ -58,7 +58,7 @@ def _update_meta(output_path: str) -> dict[str, Any]:
 
     # Munge html path into log path (As far as I can know I can not pass to
     # output paths to one analysis object?)
-    log_path = output_path.replace('-web/', '-analysis/').replace('.html', '.log.txt')
+    log_path = output_paths['log']
 
     outlier_loci = {}
     with CloudPath(log_path).open() as f:
@@ -80,7 +80,9 @@ def _update_meta(output_path: str) -> dict[str, Any]:
     required_stages=Align,
     analysis_type='web',
     analysis_keys=[
-        'stripy_html',
+        'html',
+        'json',
+        'log',
     ],
     update_analysis_meta=_update_meta,
 )
@@ -93,13 +95,9 @@ class Stripy(SequencingGroupStage):
         # When testing new loci, its useful to save the report to an alternate path
         output_prefix = config_retrieve(['stripy', 'output_prefix'], default='stripy')
         return {
-            'stripy_html': sequencing_group.dataset.web_prefix() / output_prefix / f'{sequencing_group.id}.stripy.html',
-            'stripy_json': sequencing_group.dataset.analysis_prefix()
-            / output_prefix
-            / f'{sequencing_group.id}.stripy.json',
-            'stripy_log': sequencing_group.dataset.analysis_prefix()
-            / output_prefix
-            / f'{sequencing_group.id}.stripy.log.txt',
+            'html': sequencing_group.dataset.web_prefix() / output_prefix / f'{sequencing_group.id}.stripy.html',
+            'json': sequencing_group.dataset.analysis_prefix() / output_prefix / f'{sequencing_group.id}.stripy.json',
+            'log': sequencing_group.dataset.analysis_prefix() / output_prefix / f'{sequencing_group.id}.stripy.log.txt',
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -152,8 +152,9 @@ class MetamistStatusReporter(StatusReporter):
 
         # find all relevant SG IDs
         sg_ids = target.get_sequencing_group_ids()
+        outputs_str = ', '.join(f'{k}: {str(v)}' for k, v in outputs.items())
         py_job = b.new_python_job(
-            f'Register analysis outputs {outputs}',
+            f'Register analysis outputs: {outputs_str}',
             job_attr or {} | {'tool': 'metamist'},
         )
         py_job.image(get_config()['workflow']['driver_image'])

--- a/cpg_workflows/status.py
+++ b/cpg_workflows/status.py
@@ -8,13 +8,14 @@ from typing import Callable
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
 
+from cpg_utils import Path
 from cpg_utils.config import get_config
 
 from .targets import Target
 
 
 def complete_analysis_job(
-    output: str,
+    outputs: dict[str, str | Path],
     analysis_type: str,
     sg_ids: list[str],
     project_name: str,
@@ -27,7 +28,8 @@ def complete_analysis_job(
     this will register the analysis outputs from a Stage
 
     Args:
-        output (str): path to the output file
+        outputs dict[str, str | path]: dict of output files,
+            where the keys are the output names and the values are the paths.
         analysis_type (str): metamist analysis type
         sg_ids (list[str]): all CPG IDs relevant to this target
         project_name (str): project/dataset name
@@ -39,11 +41,11 @@ def complete_analysis_job(
     from cpg_utils import to_path
     from cpg_workflows.metamist import AnalysisStatus, get_metamist
 
-    assert isinstance(output, str)
-    output_cloudpath = to_path(output)
+    assert isinstance(outputs, dict)
+    output_cloudpaths = {k: to_path(v) for k, v in outputs.items()}
 
     if update_analysis_meta is not None:
-        meta = meta | update_analysis_meta(output)
+        meta = meta | update_analysis_meta(outputs)
 
     # if SG IDs are listed in the meta, remove them
     # these are already captured in the sg_ids list
@@ -63,18 +65,15 @@ def complete_analysis_job(
     # we know that es indexes are registered names, not files/dirs
     # skip all relevant checks for this output type
     if analysis_type != 'es-index':
-        if not output_cloudpath.exists():
-            if tolerate_missing:
-                print(f"Output {output} doesn't exist, allowing silent return")
-                return
-            raise ValueError(f"Output {output} doesn't exist")
-
-        # add file size to meta
-        if not output_cloudpath.is_dir():
-            meta |= {'size': output_cloudpath.stat().st_size}
+        for k, output_cloudpath in output_cloudpaths.items():
+            if not output_cloudpath.exists():
+                if tolerate_missing:
+                    print(f"Output {output_cloudpath} doesn't exist, allowing silent return")
+                    return
+                raise ValueError(f"Output {k}: {output_cloudpath} doesn't exist")
 
     a_id = get_metamist().create_analysis(
-        output=output,
+        outputs=outputs,
         type_=analysis_type,
         status=AnalysisStatus('completed'),
         sequencing_group_ids=sg_ids,
@@ -82,11 +81,11 @@ def complete_analysis_job(
         meta=meta,
     )
     if a_id is None:
-        print(f'Creation of Analysis failed (type={analysis_type}, output={output}) in {project_name}')
+        print(f'Creation of Analysis failed (type={analysis_type}, outputs={outputs}) in {project_name}')
         # What Exception should we raise here?
         raise
     else:
-        print(f'Created Analysis(id={a_id}, type={analysis_type}, output={output}) in {project_name}')
+        print(f'Created Analysis(id={a_id}, type={analysis_type}, outputs={outputs}) in {project_name}')
 
 
 class StatusReporterError(Exception):
@@ -104,7 +103,7 @@ class StatusReporter(ABC):
     def create_analysis(
         self,
         b: Batch,
-        output: str,
+        outputs: dict[str, str | Path],
         analysis_type: str,
         target: Target,
         jobs: list[Job] | None = None,
@@ -130,7 +129,7 @@ class MetamistStatusReporter(StatusReporter):
     def create_analysis(
         self,
         b: Batch,
-        output: str,
+        outputs: dict[str, str | Path],
         analysis_type: str,
         target: Target,
         jobs: list[Job] | None = None,
@@ -154,13 +153,13 @@ class MetamistStatusReporter(StatusReporter):
         # find all relevant SG IDs
         sg_ids = target.get_sequencing_group_ids()
         py_job = b.new_python_job(
-            f'Register analysis output {output}',
+            f'Register analysis outputs {outputs}',
             job_attr or {} | {'tool': 'metamist'},
         )
         py_job.image(get_config()['workflow']['driver_image'])
         py_job.call(
             complete_analysis_job,
-            str(output),
+            outputs,
             analysis_type,
             sg_ids,
             project_name,

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -25,7 +25,7 @@ from cloudpathlib import CloudPath
 from hailtop.batch.job import Job
 
 from cpg_utils import Path
-from cpg_utils.config import get_config
+from cpg_utils.config import config_retrieve, get_config
 from cpg_utils.hail_batch import get_batch, reset_batch
 
 from .inputs import get_multicohort
@@ -400,7 +400,7 @@ class Stage(Generic[TargetT], ABC):
         self.assume_outputs_exist = assume_outputs_exist
 
         # If true, only one analysis output will be created for this stage,
-        self.merge_analyses = merge_analyses
+        self.merge_analyses = merge_analyses or self.name in config_retrieve(['workflow', 'merge_analyses_stages'], [])
 
     @property
     def tmp_prefix(self):

--- a/cpg_workflows/workflow.py
+++ b/cpg_workflows/workflow.py
@@ -361,7 +361,7 @@ class Stage(Generic[TargetT], ABC):
         required_stages: list[StageDecorator] | StageDecorator | None = None,
         analysis_type: str | None = None,
         analysis_keys: list[str] | None = None,
-        update_analysis_meta: Callable[[str], dict] | None = None,
+        update_analysis_meta: Callable[[dict], dict] | None = None,
         tolerate_missing_output: bool = False,
         skipped: bool = False,
         assume_outputs_exist: bool = False,
@@ -512,6 +512,8 @@ class Stage(Generic[TargetT], ABC):
         """
         Create StageOutput for this stage.
         """
+        if isinstance(data, (str, Path)):
+            data = {'output': data}
         return StageOutput(
             target=target,
             data=data,
@@ -770,7 +772,7 @@ def stage(
     *,
     analysis_type: str | None = None,
     analysis_keys: list[str | Path] | None = None,
-    update_analysis_meta: Callable[[str], dict] | None = None,
+    update_analysis_meta: Callable[[dict], dict] | None = None,
     tolerate_missing_output: bool = False,
     required_stages: list[StageDecorator] | StageDecorator | None = None,
     skipped: bool = False,

--- a/test/test_metamist.py
+++ b/test/test_metamist.py
@@ -226,7 +226,7 @@ class TestMetamist:
             mock_aapi_create_analysis_err,
         )
         analysis = metamist.create_analysis(
-            output=to_path('test_output'),
+            outputs=to_path('test_output'),
             type_='test',
             status='completed',
             sequencing_group_ids=['test'],
@@ -240,7 +240,7 @@ class TestMetamist:
             mock_aapi_create_analysis_timeout,
         )
         analysis = metamist.create_analysis(
-            output=to_path('test_output'),
+            outputs=to_path('test_output'),
             type_=AnalysisType.parse('custom'),
             status=AnalysisStatus.parse('completed'),
             sequencing_group_ids=['test'],
@@ -253,7 +253,7 @@ class TestMetamist:
             mock_aapi_create_analysis_ok,
         )
         analysis = metamist.create_analysis(
-            output=to_path('test_output'),
+            outputs=to_path('test_output'),
             type_=AnalysisType.parse('custom'),
             status=AnalysisStatus.parse('completed'),
             sequencing_group_ids=['test'],

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -146,10 +146,10 @@ def test_status_reporter(mocker: MockFixture, tmp_path):
     assert get_batch().job_by_tool['metamist']['job_n'] == len(get_multicohort().get_sequencing_groups()) * 2
 
 
-def _update_meta(output_path: str) -> dict[str, Any]:
+def _update_meta(output_paths: dict[str, str | Path]) -> dict[str, Any]:
     from cpg_utils import to_path
 
-    with to_path(output_path).open() as f:
+    with to_path(output_paths['output']).open() as f:
         return {'result': f.read().strip()}
 
 


### PR DESCRIPTION
- Switch to using `outputs` in the calls to `create_analysis` to allow for multiple output files per analysis record in Metamist (see the expected syntax discussed below)
- Treat a `Stage` class outputs like a dictionary most of the time for better compatibility with this 
- Write multiple of a stage's `expected_outputs` to a single analysis record, for stages specified through the config option `workflow.merge_analyses_stages = [ 'Stage1', 'Stage2', ... ]` 

I have tested this update with a few stages (`SomalierPedigree`, `CramMultiQC`, `GvcfMultiQC`) and it seems to work fairly well. 

https://batch.hail.populationgenomics.org.au/batches/618931/jobs/1
https://batch.hail.populationgenomics.org.au/batches/618932

In this run, I used the config option `workflow.merge_analyses_stages = [ "CramMultiQC", "GvcfMultiQC",]` to write multiple files to a single record for the two MultiQC stages, but not for `SomalierPedigree`. 

This makes the MultiQC stage write a single analysis record with both outputs `html` and `json`. While the Somalier stage creates four separate analysis records, one for each of it's analysis keys.

--- 

### TODO

There's still a need to refactor some other uses of `update_analysis_meta` across a few different stages to make it work with dict outputs. 
More testing is needed
Future expansion of this might be to also use the meta dict for each output, as well as the secondary files. 


---

### Syntax for writing analysis outputs

For stages who's expected outputs are just a string, they get coaxed into a dictionary like `{ 'output' : 'gs://bucket/file.html' }` as they are passed through the pipelines, but they are given to the Metamist API as the string alone.
```
outputs = 'gs://bucket/file.html'

analysis_api.create_analysis(
  Analysis(outputs=outputs)
)

# Writes analysis records like
Analysis {
  "id": 315006,
  "output": "gs://bucket/file.html"
  "outputs": {
      "path": "gs://bucket/file.html",
      "file_checksum": "QWy1CQ==",
      "size": 7386642,
      "secondary_files": {}
    }
  }
}
```

For stages with multiple output files that we want to write to the same analysis, we can use the `outputs` like so:
```
outputs = {
  'html': { 'basename': 'gs://bucket/file.html' },  # 
  'json': { 'basename': 'gs://bucket/file.json' }   # specific syntax using 'basename'
}

analysis_api.create_analysis(
  Analysis(outputs=outputs)
)

# Writes analysis records like
Analysis {
  "id": 315007,
  "outputs": {
    "html": {
      "path": "gs://bucket/file.html",
      "file_checksum": "QWy1CQ==",
      "size": 7386642,
      "secondary_files": {}
    },
    "json": {
      "path": "gs://bucket/file.json",
      "file_checksum": "Ax4nCN==",
      "size": 86253421,
      "secondary_files": {}
    }
  }
}
```
Output names as the keys to a second dict containing the path as the dict value for the key `'basename'`. This specific syntax will trigger the db to query GCS for each blobs metadata, and it will fill in each analysis file output record with this additional information. 
