### PR TITLE
added steps to preserve cols in the datset sample_qc.ht which are abs…

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -70,6 +70,8 @@ def add_background(
                 metadata_tables.append(sample_qc_background)
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             metadata_tables = reorder_columns(metadata_tables, sample_qc_ht)
+            metadata_tables = hl.Table.union(*[metadata_tables, sample_qc_ht], unify=allow_missing_columns)
+
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
             if populations_to_filter:
                 logging.info(f'Filtering background samples by {populations_to_filter}')

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -71,7 +71,6 @@ def add_background(
             metadata_tables = hl.Table.union(*metadata_tables, unify=allow_missing_columns)
             metadata_tables = reorder_columns(metadata_tables, sample_qc_ht)
             metadata_tables = hl.Table.union(*[metadata_tables, sample_qc_ht], unify=allow_missing_columns)
-
             background_mt = background_mt.annotate_cols(**metadata_tables[background_mt.col_key])
             if populations_to_filter:
                 logging.info(f'Filtering background samples by {populations_to_filter}')
@@ -104,6 +103,12 @@ def add_background(
             raise ValueError('Background dataset path must be either .mt or .vds')
 
     if drop_columns:
+        missing = [field for field in drop_columns if field not in sample_qc_ht.row.dtype.fields]
+        if missing:
+            raise ValueError(
+                f"Cannot drop columns: {missing}. These fields do not exist in the table. "
+                f"Available fields: {list(sample_qc_ht.describe())}",
+            )
         sample_qc_ht = sample_qc_ht.drop(*drop_columns)
 
     return dense_mt, sample_qc_ht

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -107,7 +107,7 @@ def add_background(
         if missing:
             raise ValueError(
                 f"Cannot drop columns: {missing}. These fields do not exist in the table. "
-                f"Available fields: {list(sample_qc_ht.describe())}",
+                f"Available fields: {list(sample_qc_ht.row.dtype.fields)}",
             )
         sample_qc_ht = sample_qc_ht.drop(*drop_columns)
 


### PR DESCRIPTION
A better attempt than PR [1260](https://github.com/populationgenomics/production-pipelines/pull/1260) at fixing the issue that `large_cohort ancestry` will drop columns in the cohort/dataset s`ample_qc.ht` that are absent from the background (hgdp and 1kg) `sample_qc.ht`.
This can lead to errors when code expects those columns to exist e.g. `get_config()['large_cohort']['pca_background'].get('drop_columns')`