### PR TITLE
remove call to _count_rows after sub-sampling

### DIFF
--- a/cpg_workflows/large_cohort/sites_table_job.py
+++ b/cpg_workflows/large_cohort/sites_table_job.py
@@ -157,8 +157,6 @@ def main(
             subsample_n / nrows,
             seed=12345,
         )
-        nrows = cohort_dense_mt.count_rows()
-        print(f'post sub-sample rows = {nrows}')
 
     print('Writing sites table pre-LD pruning')
     checkpoint_path = output_path(f'cohort_dense_mt_{"exome_" if exomes else ""}pre_pruning.mt', 'default')


### PR DESCRIPTION
calls to `ht.count_rows` can be expensive. 
while we need to count n rows before subsampling, calling it afterwards to show for logging that we indeed end up with the n rows we required is unnecessary. 