### PR TITLE
Prep gvcf for happy

### DIFF
--- a/cpg_workflows/scripts/NA12878_validation.py
+++ b/cpg_workflows/scripts/NA12878_validation.py
@@ -41,9 +41,9 @@ def run_happy_on_gvcf(
             --convert-gvcf-to-vcf \\
             --filter-nonref \\
             --pass-only \\
+            --reference {reference["base"]} \\
             {gvcf_input["gvcf"]} \\
             {prepy_j.vcf_output["vcf"]}
-            --reference {reference["base"]}
             """,
         ),
     )


### PR DESCRIPTION
Replace the bcftools rinse with pre.py conversion of the gVCF to a VCF before inputting to hap.py, enabling more thorough handling of <NON_REF> genotypes. 

Test run here: https://batch.hail.populationgenomics.org.au/batches/627499