### PR TITLE
Coverage reuse

### DIFF
--- a/cpg_workflows/large_cohort/generate_coverage_table.py
+++ b/cpg_workflows/large_cohort/generate_coverage_table.py
@@ -7,6 +7,7 @@ import hailtop.batch as hb
 
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import genome_build
+from cpg_workflows.utils import can_reuse
 from gnomad.utils import reference_genome, sparse_mt
 from gnomad.utils.annotations import generate_freq_group_membership_array
 
@@ -320,6 +321,10 @@ def run(
     from gnomad.utils.reference_genome import add_reference_sequence
 
     init_batch()
+
+    if can_reuse(out_path):
+        return hl.read_table(out_path)
+
     rg: hl.ReferenceGenome = hl.get_reference(genome_build())
     add_reference_sequence(rg)
 

--- a/cpg_workflows/large_cohort/generate_coverage_table.py
+++ b/cpg_workflows/large_cohort/generate_coverage_table.py
@@ -323,7 +323,8 @@ def run(
     init_batch()
 
     if can_reuse(out_path):
-        return hl.read_table(out_path)
+        logging.info(f"Reusing existing coverage table at {out_path}.")
+        return None
 
     rg: hl.ReferenceGenome = hl.get_reference(genome_build())
     add_reference_sequence(rg)


### PR DESCRIPTION
If a stage has a dictionary as its `expected_outputs` (as `GenerateCoverageTable` does) and if, in a previous run, one or several of those outputs failed to be generated (due to batch reasons), then the workflow logic is: when submitting a follow-up run it will detect that at least one expected output doesn't exist and will submit jobs to generate **all** outputs again.

This is not desired behaviour. To avoid having all intermediate split coverage tables be generated if just one fails this PR implements the `can_reuse()` function that checks the individual coverage tables path and returns early if that path already exists