### PR TITLE
Remove init_batch within coverage script

### DIFF
--- a/cpg_workflows/large_cohort/generate_coverage_table.py
+++ b/cpg_workflows/large_cohort/generate_coverage_table.py
@@ -320,8 +320,6 @@ def run(
     from cpg_utils.hail_batch import init_batch
     from gnomad.utils.reference_genome import add_reference_sequence
 
-    init_batch()
-
     if can_reuse(out_path):
         logging.info(f"Reusing existing coverage table at {out_path}.")
         return None


### PR DESCRIPTION
Remove init_batch() from within the script as it is overriding the init_batch being called by query_command() that contains the init_batch resource overrides