### PR TITLE
Merge ten coverage tables at a time

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -612,6 +612,7 @@ class MergeCoverageTables(CohortStage):
             (self.get_job_attrs() or {}) | {'tool': HAIL_QUERY},
         )
         j.image(image_path('cpg_workflows'))
+        j.storage('50Gi')
 
         coverage_version: str = coverage_version or get_workflow().output_version
         tmp_path = (

--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -1,8 +1,6 @@
 import json
 from typing import TYPE_CHECKING, Any, Final, Tuple
 
-from matplotlib import category
-
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command
@@ -615,6 +613,10 @@ class MergeCoverageTables(CohortStage):
         )
         j.image(image_path('cpg_workflows'))
 
+        coverage_version: str = coverage_version or get_workflow().output_version
+        tmp_path = (
+            cohort.analysis_dataset.prefix(category='tmp') / get_workflow().name / coverage_version / 'merged_coverage'
+        )
         init_batch_args: dict[str, str | int] = {}
         workflow_config = config_retrieve('workflow')
 
@@ -633,6 +635,7 @@ class MergeCoverageTables(CohortStage):
                 generate_coverage_table.merge_coverage_tables.__name__,
                 [str(v) for v in inputs.as_dict(cohort, GenerateCoverageTable).values()],
                 str(self.expected_outputs(cohort)),
+                str(tmp_path),
                 setup_gcp=True,
                 init_batch_args=init_batch_args,
             ),


### PR DESCRIPTION
[Currently hitting](https://batch.hail.populationgenomics.org.au/batches/627801/jobs/501) a possible limit of operations when attempting to merge 250 coverage tables at one time.
```
Hail version: 0.2.134-f8c842aa0f46
Error summary: MethodTooLargeException: Method too large: __C5776collect_distributed_array_table_native_writer.apply_region107_4405 (L__C11764applySpills;)V
```

This PR  breaks up merging of coverage tables into groups of ten, checkpoints them, and then does a final merge at the end.