### PR TITLE
Shard coverage calculation per sample

### DIFF
--- a/cpg_workflows/large_cohort/generate_coverage_table.py
+++ b/cpg_workflows/large_cohort/generate_coverage_table.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 from math import ceil
-from random import sample
 from typing import Optional
 
 import hail as hl


### PR DESCRIPTION
Costs have blown out with larger number of samples when calculating coverage. Adding the ability to shard coverage calculation per config-specified sample number. 