### PR TITLE
Allowing Coverage table generation for scatter_count=1

### DIFF
--- a/cpg_workflows/stages/large_cohort.py
+++ b/cpg_workflows/stages/large_cohort.py
@@ -1,8 +1,6 @@
 import json
 from typing import TYPE_CHECKING, Any, Final, Tuple
 
-from matplotlib.pyplot import scatter
-
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config, image_path
 from cpg_utils.hail_batch import get_batch, query_command


### PR DESCRIPTION
`get_intervals()` function has a special case where if scatter_count = 1 it just reads in the interval_list as a resource file instead of saving to a path. This unfortunately means the path the stage expects will not exist.