### PR TITLE
Take the union of background and cohort rows

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -97,7 +97,7 @@ def add_background(
             background_mt = background_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
             background_mt = background_mt.naive_coalesce(5000)
             # combine dense dataset with background population dataset
-            dense_mt = dense_mt.union_cols(background_mt)
+            dense_mt = dense_mt.union_cols(background_mt, row_join_type='outer')
             sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')


### PR DESCRIPTION
Take the union of rows when combining the background data with the cohort for PCA, rather than the intersection. This helps avoid the PCA being skewed based on the variation that is observed in the cohort population (especially relevant if the cohort is small, and from a single population).