### PR TITLE
Revert "Take the union of background and cohort rows"

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -97,7 +97,7 @@ def add_background(
             background_mt = background_mt.select_cols().select_rows().select_entries('GT', 'GQ', 'DP', 'AD')
             background_mt = background_mt.naive_coalesce(5000)
             # combine dense dataset with background population dataset
-            dense_mt = dense_mt.union_cols(background_mt, row_join_type='outer')
+            dense_mt = dense_mt.union_cols(background_mt)
             sample_qc_ht = sample_qc_ht.union(ht, unify=allow_missing_columns)
         else:
             raise ValueError('Background dataset path must be either .mt or .vds')


### PR DESCRIPTION
Reverts populationgenomics/production-pipelines#1284

Taking the union at this point results in a drastic increase in the number of PCs required before cohort-relevant separation can be observed. Provided the input cohort is sufficiently large and diverse, the intersection provides a better base for analysis.  