### PR TITLE
Handle multiallelics correctly when creating a dense subset

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -54,6 +54,7 @@ num_pcs = 4
 # demanding higher resources for all operations as standard. Examples below
 
 [large_cohort]
+dense_subset_partitions = 10
 # Kinship threshold to consider two samples as related.
 # the default threshold for second degree relatives in gnomAD is 0.1:
 # https://github.com/broadinstitute/gnomad_methods/blob/382fc2c7976d58cc8983cc4c9f0df5d8d5f9fae3/gnomad/sample_qc/relatedness.py#L195

--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -29,6 +29,18 @@ def run(vds_path: str, out_dense_mt_path: str) -> hl.MatrixTable:
             GT=hl.vds.lgt_to_gt(vds.variant_data.LGT, vds.variant_data.LA),
         )
 
+    if 'AD' not in vds.variant_data.entry:
+        logging.info('Converting LAD to AD annotations...')
+        vds.variant_data = vds.variant_data.annotate_entries(
+            AD=hl.vds.local_to_global(
+                vds.variant_data.LAD,
+                vds.variant_data.LA,
+                n_alleles=hl.len(vds.variant_data.alleles),
+                fill_value=0,
+                number='R',
+            ),
+        )
+
     logging.info('Densifying data...')
     mt = hl.vds.to_dense_mt(vds)
     mt = mt.select_entries('GT', 'GQ', 'DP', 'AD')

--- a/cpg_workflows/large_cohort/dense_subset.py
+++ b/cpg_workflows/large_cohort/dense_subset.py
@@ -26,7 +26,7 @@ def run(vds_path: str, out_dense_mt_path: str) -> hl.MatrixTable:
     mt = hl.vds.to_dense_mt(vds)
     mt = mt.select_entries('GT', 'GQ', 'DP', 'AD')
 
-    n_partitions = get_config()['large_cohort']['dense_subset']['n_partitions']
+    n_partitions = get_config()['large_cohort']['dense_subset_partitions']
     mt = mt.repartition(n_partitions)
     mt = mt.checkpoint(out_dense_mt_path, overwrite=True)
     logging.info(f'Number of predetermined QC variants found in the VDS: {mt.count_rows()}')


### PR DESCRIPTION
Avoid splitting multiallelics before filtering to the pre-determined QC sites, which include only biallelic SNPs. Splitting will enable us to match cleanly against the reference sites, but causes us to retain sites that are truly multiallelic in our cohort but using only the reference allele, giving the false appearance that they were biallelic.

Having filtered, repartition the matrix table using a configurable number of partitions (default of 10, as our default sites are exome-only).