### PR TITLE
Sampleqc config intervals

### DIFF
--- a/configs/defaults/large_cohort.toml
+++ b/configs/defaults/large_cohort.toml
@@ -83,6 +83,10 @@ remove_failed_qc_pca = true
 # `datasets` must be a list paths to matrix tables or VDS, and
 # `pop_field` if defined would specify the column-level field in th datasets
 # to extract the population tag for RF training for ancestry inference.
+
+# section that specifies intervals for sample_qc
+# sampleqc_intervals = None
+
 [large_cohort.pca_background]
 #datasets = ['gs://cpg-common-main/references/ancestry/oceania_eur.mt']
 #pop_field = 'continental_pop'

--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -93,10 +93,20 @@ def impute_sex(
         sex_ht = hl.read_table(str(checkpoint_path))
         return ht.annotate(**sex_ht[ht.s])
 
-    # Load calling intervals
+    # Load calling intervals -> default inferred from seq_type, or user supplied
     seq_type = get_config()['workflow']['sequencing_type']
-    calling_intervals_path = reference_path(f'broad/{seq_type}_calling_interval_lists')
-    calling_intervals_ht = hl.import_locus_intervals(str(calling_intervals_path), reference_genome=genome_build())
+
+    sampleqc_intervals: str | None = config_retrieve(
+        ['large_cohort', 'sampleqc_intervals'],
+        default=None,
+    )  # key to references.py, 'exome_probesets/mackenzie_intersect_exome_probes_interval_list'
+    if sampleqc_intervals:
+        intervals_path = reference_path(sampleqc_intervals)
+    else:
+        intervals_path = reference_path(f'broad/{seq_type}_calling_interval_lists')
+
+    calling_intervals_ht = hl.import_locus_intervals(str(intervals_path), reference_genome=genome_build())
+
     logging.info('Calling intervals table:')
     calling_intervals_ht.describe()
 


### PR DESCRIPTION
we can now pass intervals for sampleqc.

 - we can use the `interval_list` files for exome probesets we already have in `references`
 - testing in notebook shows similar format in resulting table.

And importantly,
 - If not included in the config, defaults to previous behaviour of getting `seq_type` and getting `reference_path(f'broad/{seq_type}_calling_interval_lists')`

To use, `config.toml`:

```
[large_cohort]
sampleqc_intervals = 'exome_probesets/mackenzie_intersect_exome_probes_interval_list'
```