### PR TITLE
Reduce burden of filtering lcr and seg_dups in sampleqc

### DIFF
--- a/cpg_workflows/large_cohort/sample_qc.py
+++ b/cpg_workflows/large_cohort/sample_qc.py
@@ -122,7 +122,7 @@ def impute_sex(
         if interval_table.count() > 0:
             interval_tables.append(interval_table)
 
-    interval_table = hl.Table.union(*interval_tables)
+    interval_table = interval_tables[0].union(*interval_tables[1:])
     vds_tmp_path = tmp_prefix / f'{"-".join(names)}_checkpoint.vds'
     if can_reuse(vds_tmp_path):
         logging.info(f'Loading {"-".join(names)} filtered tmp vds')


### PR DESCRIPTION
 previously would loop over each filter and: 
 - read ht
 -  filter + checkpoint **each loop**
 - vds.variant_data.count()


This changes so that:
-  loop over filter hts, and union them.
- filter and checkpoint **once**
- just log that we are done filtering, and not count remaining variants (removed vds.variant_data.count())


Still unknown to me if this step could be improved (re-partitioning):
```
       tmp_variant_data = vds.variant_data.filter_rows(
            hl.is_defined(interval_table[vds.variant_data.locus]),
            keep=False,
        )
        vds = VariantDataset(reference_data=vds.reference_data, variant_data=tmp_variant_data).checkpoint(
            str(vds_tmp_path),
            overwrite=True,
```