### PR TITLE
Remove low quality samples from PC calculations

### DIFF
--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -15,7 +15,7 @@ from cpg_workflows.utils import can_reuse
 from gnomad.sample_qc.ancestry import assign_population_pcs, run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
-MIN_N_SAMPLES = 10
+MIN_N_SAMPLES = 5 # increase to 10 once a larger test dataset is available
 
 
 def reorder_columns(ht: hl.Table, reference_table: hl.Table) -> hl.Table:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -158,7 +158,7 @@ def run(
     # Annotate the related samples that are being dropped in the sample QC filters field.
     sample_qc_ht = sample_qc_ht.annotate(
         filters=hl.if_else(
-            hl.array(relateds_to_drop_ht.s.collect()).contains(sample_qc_ht.s),
+            hl.is_defined(relateds_to_drop_ht[sample_qc_ht.s]),
             sample_qc_ht.filters.add("relatedness"),
             sample_qc_ht.filters,
         ),

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -15,7 +15,7 @@ from cpg_workflows.utils import can_reuse
 from gnomad.sample_qc.ancestry import assign_population_pcs, run_pca_with_relateds
 
 MIN_N_PCS = 3  # for one PC1 vs PC2 plot
-MIN_N_SAMPLES = 5 # increase to 10 once a larger test dataset is available
+MIN_N_SAMPLES = 5  # increase to 10 once a larger test dataset is available
 
 
 def reorder_columns(ht: hl.Table, reference_table: hl.Table) -> hl.Table:

--- a/cpg_workflows/large_cohort/ancestry_pca.py
+++ b/cpg_workflows/large_cohort/ancestry_pca.py
@@ -155,6 +155,19 @@ def run(
         dense_mt = dense_mt.filter_cols(~hl.literal(sgids_remove).contains(dense_mt.s))
         sample_qc_ht = sample_qc_ht.filter(~hl.literal(sgids_remove).contains(sample_qc_ht.s))
 
+    # Annotate the related samples that are being dropped in the sample QC filters field.
+    sample_qc_ht = sample_qc_ht.annotate(
+        filters=hl.if_else(
+            hl.array(relateds_to_drop_ht.s.collect()).contains(sample_qc_ht.s),
+            sample_qc_ht.filters.add("relatedness"),
+            sample_qc_ht.filters,
+        ),
+    )
+
+    # Drop the related samples and any low-quality samples from the PCA computation,
+    # but still project them into the results.
+    samples_to_drop = sample_qc_ht.filter(hl.len(sample_qc_ht.filters) > 0)
+
     pca_background = get_config()['large_cohort'].get('pca_background', {})
     if 'datasets' in pca_background:
         dense_mt_checkpoint_path = tmp_prefix / 'modified_dense_mt.mt'
@@ -175,7 +188,7 @@ def run(
     )
     scores_ht, eigenvalues_ht, loadings_ht = _run_pca_ancestry_analysis(
         mt=dense_mt,
-        sample_to_drop_ht=relateds_to_drop_ht,
+        sample_to_drop_ht=samples_to_drop,
         n_pcs=n_pcs,
         out_scores_ht_path=out_scores_ht_path,
         out_eigenvalues_ht_path=out_eigenvalues_ht_path,
@@ -209,7 +222,7 @@ def _run_pca_ancestry_analysis(
     @param mt: variants usable for PCA analysis, combined with samples
         with known populations (HGDP, 1KG, etc)
     @param sample_to_drop_ht: table with samples to drop based on
-        previous relatedness analysis. With a `rank` row field
+        previous relatedness analysis.
     @param out_eigenvalues_ht_path: path to a txt file to write PCA eigenvalues
     @param out_scores_ht_path: path to write PCA scores
     @param out_loadings_ht_path: path to write PCA loadings


### PR DESCRIPTION
Rather than needing to manually add the low quality samples to the relateds_to_drop hail table in order to exclude them from PCA, we automatically pull this from the sample QC hail table.

These samples will still get projected into PCA space and be present in the final sample_qc.ht output, but will not be used for PCA generation.