### PR TITLE
Filter the sample QC table prior to calculating the group membership

### DIFF
--- a/cpg_workflows/large_cohort/compute_stats_for_all_sites.py
+++ b/cpg_workflows/large_cohort/compute_stats_for_all_sites.py
@@ -786,6 +786,9 @@ def run_coverage(
     )
     vds = hl.vds.filter_samples(vds, samples_to_remove, keep=False)
 
+    # Subset the QC table to QC-pass samples only prior to calculating group membership.
+    sample_qc_ht = sample_qc_ht.filter(~hl.is_defined(samples_to_remove[sample_qc_ht.s]))
+
     # Prepare the group membership hail table.
     if can_reuse(group_membership_out_path):
         logger.info('Reusing group membership table')
@@ -867,6 +870,9 @@ def run_an_calculation(
         sample_qc_ht.filter(hl.len(sample_qc_ht.filters) > 0).select().union(relateds_to_drop_ht.select()).distinct()
     )
     vds = hl.vds.filter_samples(vds, samples_to_remove, keep=False)
+
+    # Subset the QC table to QC-pass samples only prior to calculating group membership.
+    sample_qc_ht = sample_qc_ht.filter(~hl.is_defined(samples_to_remove[sample_qc_ht.s]))
 
     # Prepare the group membership hail table.
     if can_reuse(group_membership_out_path):


### PR DESCRIPTION
So we don't include unnecessary annotations and generate the correct sample counts for the final global metadata annotations.