### PR TITLE
Getting intersection of faf populations instead of union

### DIFF
--- a/cpg_workflows/large_cohort/joint_frequencies.py
+++ b/cpg_workflows/large_cohort/joint_frequencies.py
@@ -772,8 +772,11 @@ def run(
     )
 
     # Perform Cochran-Mantel-Haenszel test for joint frequencies.
-    # Note: We can only perform this test for populations in both datasets
-    faf_pops = list({d.get('pop') for d in ht.joint_faf_meta.collect()[0] if d.get('pop')})
+    # Note: We can only perform this test for populations in both datasets (intersection of metadata)
+    faf_pops = list(
+        {d.get('pop') for d in ht.exomes_freq_meta.collect()[0] if d.get('pop') and d.get('pop') != 'NA'}
+        & {d.get('pop') for d in ht.genomes_freq_meta.collect()[0] if d.get('pop') and d.get('pop') != 'NA'},
+    )
 
     ht = ht.filter(hl.is_defined(ht.genomes_freq) & hl.is_defined(ht.exomes_freq))
     ht = ht.annotate(


### PR DESCRIPTION
[Slack thread here](https://centrepopgen.slack.com/archives/C08JL4YHPNE/p1757022919395919?thread_ts=1756936562.919359&cid=C08JL4YHPNE). We need to get the intersection of the faf populations instead of the union as we can only perform the Cochran-Mantel-Haenszel test for populations in both datasets