### PR TITLE
Correctly format joint frequency field to stratify by ancestry

### DIFF
--- a/cpg_workflows/large_cohort/browser_prepare.py
+++ b/cpg_workflows/large_cohort/browser_prepare.py
@@ -1130,7 +1130,7 @@ def prepare_gnomad_v4_variants_joint_frequency_helper(ds):
         hl.or_missing(ds.region_flags.not_called_in_genomes, "not_called_in_genomes"),
     ]
 
-    ancestry_groups = set(m.get("gen_anc", None) for m in globals.joint_globals.freq_meta)
+    ancestry_groups = set(m.get("pop", None) for m in globals.joint_globals.freq_meta)
 
     ds = ds.annotate(
         joint=hl.struct(


### PR DESCRIPTION
[Slack thread](https://centrepopgen.slack.com/archives/C08JL4YHPNE/p1758152447904169?thread_ts=1756936562.919359&cid=C08JL4YHPNE) for context.

When preparing the browser table we lost ancestry-group stratifications in the joint frequency metadata. The browser code expects a `'gen_anc'` key in `joint_globals.freq_meta`, but the data we had only included `'pop'`, so extracting ancestry groups returned None.

`browser_ht.joint.freq.all.ancestry_groups` currently returns entries that do not contain ancestry stratifications:

Our browser table:
```
>>> browser_ht.joint.freq.all.ancestry_groups.take(1)
[[Struct(id='', ac=40, an=3492, ...),
  Struct(id='XX', ac=17, an=1698, ...),
  Struct(id='XY', ac=23, an=1794, ...),
  ...]]
```

gnomAD browser table:
```
>>> gnomad_browser_ht.joint.freq.all.ancestry_groups.take(1)
[[Struct(id='remaining', ac=0, an=782, ...),
  Struct(id='amr', ac=0, an=6420, ...),
  Struct(id='afr', ac=0, an=14642, ...),
  ...
  Struct(id='XX', ...),
  Struct(id='XY', ...)]]
```

Investigating globals showed:
```
>>> ancestry_groups = set(m.get("gen_anc", None) for m in globals.joint_globals.freq_meta)
>>> ancestry_groups
None
vs.
>>> ancestry_groups = set(m.get("pop", None) for m in globals.joint_globals.freq_meta)
>>> ancestry_groups
{'AFR','AMR','CSA','EAS','EUR','FIL','MID','NA', None}
```


Root cause: downstream code looks for "gen_anc" while the joint freq metadata only contains "pop". 

One line change on query of globals table.

