### PR TITLE
Compressing output

### DIFF
--- a/scripts/ega_submission_vcf_reheadering.py
+++ b/scripts/ega_submission_vcf_reheadering.py
@@ -117,7 +117,8 @@ EOF
             # Subset -> Filter -> Reheader -> Write
             bcftools view --no-version --threads 1 -S subset_list.txt --force-samples "{input_vcf.vcf}" -Ou \\
             | bcftools view --no-version -c 1 -a -Ou \\
-            | bcftools reheader --threads 3 -s rename_map.txt --output "{j.output_vcf.vcf}"
+            | bcftools reheader -s rename_map.txt \\
+            | bcftools view --no-version --threads 3 -Oz -o "{j.output_vcf.vcf}"
 
             bcftools index {index_flag} "{j.output_vcf.vcf}"
             """,


### PR DESCRIPTION
Streaming reheader output to `bcftools view` so that it can properly be compressed and therefore indexed