### PR TITLE
bump version to 1.38.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.38.0
+current_version = 1.38.1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg_workflows',
     # This tag is automatically updated by bumpversion
-    version='1.38.0',
+    version='1.38.1',
     description='CPG workflows for Hail Batch',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
cpg_workflows version 1.38.0 image has hail 0.2.137.
bumping version to 1.38.1 will trigger image rebuild + implicit upgrade to 0.2.138 from AR base image.